### PR TITLE
pull_request_target enabled in CI run

### DIFF
--- a/services/cli/src/bencher/sub/project/run/ci.rs
+++ b/services/cli/src/bencher/sub/project/run/ci.rs
@@ -101,7 +101,7 @@ impl GitHubActions {
 
         // The name of the event that triggered the workflow. For example, `workflow_dispatch`.
         match std::env::var("GITHUB_EVENT_NAME").ok() {
-            Some(event_name) if event_name == "pull_request" => {},
+            Some(event_name) if event_name == "pull_request" || event_name == "pull_request_target" => {},
             _ => {
                 cli_println!(
                     "Not running as a GitHub Action pull request. Skipping CI integration."


### PR DESCRIPTION
Right now CI integration (results automatically added to the pull request as a comment) works perfectly with the pull_request trigger.
By the way I experienced the following issue: if the trigger of the bencher github action is a PR opened from a fork of a public repository, the BENCHER_API_TOKEN (which is stored as a repository secret) is not accessible for security reason.
The official workaround proposed by github is about using the [pull_request_target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) to let the PR opened from a fork of a public repo getting access to the repo secrets used in a workflow.
For this reason, I simply added a condition in the ci.rs file in order to achieve this.

Hope everything is clear and the addition is correct for this important feature!