### PR TITLE
Remove forced `mold` linker on linux

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,10 +1,2 @@
 [alias]
 xtask = "run --manifest-path ./xtask/Cargo.toml --"
-
-[target.x86_64-unknown-linux-gnu]
-linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]
-
-[target.aarch64-unknown-linux-gnu]
-linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]


### PR DESCRIPTION
This blocked me from building, as it expects `mold` to be present *and* for it to be installed at `/usr/local/bin/mold`.