### PR TITLE
Bencher up cli : add --env and --volume options

### DIFF
--- a/services/cli/src/parser/docker.rs
+++ b/services/cli/src/parser/docker.rs
@@ -11,9 +11,13 @@ pub struct CliUp {
     #[clap(long)]
     pub pull: Option<CliUpPull>,
 
-    /// Pass environment variables to containers. Same semantic than docker run --env option.
-    #[clap(short, long, value_parser = check_key_value)]
+    /// Pass environment variables to containers. Same semantic than docker run "--env" option.
+    #[clap(short, long, value_parser = check_key_value::<'='>)]
     pub env: Vec<String>,
+
+    /// Pass volume information to containers. Same semantic than docker run "--volume" option.
+    #[clap(short, long = "volume", value_parser = check_key_value::<':'>)]
+    pub volumes: Vec<String>,
 }
 
 #[derive(ValueEnum, Debug, Clone, Copy, Default)]
@@ -34,10 +38,12 @@ pub struct CliLogs {
     pub container: Option<String>,
 }
 
-/// check that input argument is in the form 'key=value'
-fn check_key_value(s: &str) -> Result<String, Box<dyn Error + Send + Sync + 'static>> {
-    s.find('=')
-        .ok_or_else(|| format!("invalid KEY=value: no `=` found in `{s}`"))?;
+/// check that input argument is in the form 'key<separator>value'
+fn check_key_value<const SEPARATOR: char>(
+    s: &str,
+) -> Result<String, Box<dyn Error + Send + Sync + 'static>> {
+    s.find(SEPARATOR)
+        .ok_or_else(|| format!("invalid KEY{SEPARATOR}value: no `{SEPARATOR}` found in `{s}`"))?;
 
     Ok(String::from(s))
 }

--- a/services/cli/src/parser/docker.rs
+++ b/services/cli/src/parser/docker.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, ValueEnum};
+use std::error::Error;
 
 #[derive(Parser, Debug)]
 pub struct CliUp {
@@ -9,6 +10,10 @@ pub struct CliUp {
     /// Pull image before running ("always"|"missing"|"never")
     #[clap(long)]
     pub pull: Option<CliUpPull>,
+
+    /// Pass environment variables to containers. Same semantic than docker run --env option.
+    #[clap(short, long, value_parser = check_key_value)]
+    pub env: Vec<String>,
 }
 
 #[derive(ValueEnum, Debug, Clone, Copy, Default)]
@@ -27,4 +32,12 @@ pub struct CliDown {}
 pub struct CliLogs {
     /// Docker container name
     pub container: Option<String>,
+}
+
+/// check that input argument is in the form 'key=value'
+fn check_key_value(s: &str) -> Result<String, Box<dyn Error + Send + Sync + 'static>> {
+    s.find('=')
+        .ok_or_else(|| format!("invalid KEY=value: no `=` found in `{s}`"))?;
+
+    Ok(String::from(s))
 }


### PR DESCRIPTION
Solve #416 #417

I also added --volume, so that we can pass config file to the container. The idiomatic usages would be : 

```
>> bencher up --env BENCHER_CONFIG="$(cat config.json)"
>> bencher up --volume "$(pwd):/bencher" --env BENCHER_CONFIG_PATH=/bencher/config.json
```

