### PR TITLE
deduplicate workspace package names

### DIFF
--- a/examples/ebpf/perf_event/xtask/Cargo.toml
+++ b/examples/ebpf/perf_event/xtask/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-name = "perf-event-xtask"
+name = "xtask"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 anyhow = "1"

--- a/examples/ebpf/perf_event/xtask/Cargo.toml
+++ b/examples/ebpf/perf_event/xtask/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "xtask"
+name = "perf-event-xtask"
 version = "0.1.0"
 edition = "2021"
 

--- a/examples/ebpf/xdp/xtask/Cargo.toml
+++ b/examples/ebpf/xdp/xtask/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "xtask"
+name = "xdp-xtask"
 version = "0.1.0"
 edition = "2021"
 

--- a/examples/ebpf/xdp/xtask/Cargo.toml
+++ b/examples/ebpf/xdp/xtask/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-name = "xdp-xtask"
+name = "xtask"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 anyhow = "1"

--- a/examples/rust/bench/Cargo.toml
+++ b/examples/rust/bench/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 
 [package]
-name = "game"
+name = "bench-game"
 version = "0.1.0"
 edition = "2021"
 

--- a/examples/rust/bench/Cargo.toml
+++ b/examples/rust/bench/Cargo.toml
@@ -1,8 +1,9 @@
 [workspace]
 
 [package]
-name = "bench-game"
+name = "game"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]

--- a/examples/rust/criterion/Cargo.toml
+++ b/examples/rust/criterion/Cargo.toml
@@ -1,9 +1,10 @@
 [workspace]
 
 [package]
-name = "criterion-game"
+name = "game"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 

--- a/examples/rust/criterion/Cargo.toml
+++ b/examples/rust/criterion/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 
 [package]
-name = "game"
+name = "criterion-game"
 version = "0.1.0"
 edition = "2021"
 

--- a/examples/rust/iai/Cargo.toml
+++ b/examples/rust/iai/Cargo.toml
@@ -1,9 +1,10 @@
 [workspace]
 
 [package]
-name = "iai-game"
+name = "game"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 

--- a/examples/rust/iai/Cargo.toml
+++ b/examples/rust/iai/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 
 [package]
-name = "game"
+name = "iai-game"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
Currently the recommended way to install `bencher_cli` from source produces the following warnings:

```bash
$ cargo install bencher_cli --git https://github.com/bencherdev/bencher --branch main

    Updating git repository `https://github.com/bencherdev/bencher`
warning: skipping duplicate package `game` found at `/.../rust/git/checkouts/bencher-c9d027409129568d/6b48e62/examples/rust/iai`
warning: skipping duplicate package `game` found at `/.../rust/git/checkouts/bencher-c9d027409129568d/6b48e62/examples/rust/criterion`
warning: skipping duplicate package `xtask` found at `/.../rust/git/checkouts/bencher-c9d027409129568d/6b48e62/examples/ebpf/xdp/xtask`
```

This deduplicates the different package names in the workspace by adding parent-specific prefixes.