### PR TITLE
chore: add JetBrains and arch support to devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
             "MOLD_DEFAULT": "true",
             "RUST_VERSION": "1.82.0",
             "LITESTREAM_VERSION": "0.3.13",
-            "LITESTREAM_ARCH": "amd64"
+            "LITESTREAM_ARCH": "${localEnv:ARCH:amd64}"
         }
     },
     "postCreateCommand": "./.devcontainer/scripts/setup.sh",
@@ -22,6 +22,13 @@
         61016
     ],
     "customizations": {
+        "jetbrains": {
+            "settings": {
+                "com.intellij:app:HttpConfigurable.use_proxy_pac": true,
+                "com.intellij:app:BaseRefactoringSettings.safe_delete_when_delete": false,
+                "com.intellij:app:BaseRefactoringSettings.move_search_for_references_for_file": false
+            }
+        },
         "vscode": {
             "extensions": [
                 "astro-build.astro-vscode",


### PR DESCRIPTION
Adds support for JetBrains IDEs (tested w/RustRover) and `arm64` architectures through the `ARCH` environment variable.

<img width="866" alt="image" src="https://github.com/user-attachments/assets/9740becd-4192-453d-8b56-896d9bd791fd" />
