### PR TITLE
feat: charts use pow scaling to allow users to more easily reason on

### DIFF
--- a/services/console/src/components/console/perf/plot/line/LinePlot.tsx
+++ b/services/console/src/components/console/perf/plot/line/LinePlot.tsx
@@ -439,7 +439,7 @@ type Scale = {
 	measure: JsonMeasure;
 	factor: number;
 	units: string;
-	yScale: d3.ScaleLinear<number, number, never>;
+	yScale: d3.ScalePower<number, number, never>;
 };
 
 const scale_data = (
@@ -491,7 +491,9 @@ const get_scale = (
 	const units = scale_units(min, raw_units);
 
 	const domain = [min / factor, max / factor];
-	const yScale = d3.scaleLinear().domain(domain).nice();
+	// Use pow scaling to allow users to more easily reason on graphs with highly differentiated values
+	// See: https://observablehq.com/plot/features/scales#continuous-scales
+	const yScale = d3.scalePow().exponent(0.5).domain(domain).nice();
 
 	return {
 		measure,

--- a/services/console/src/components/console/perf/plot/line/LinePlot.tsx
+++ b/services/console/src/components/console/perf/plot/line/LinePlot.tsx
@@ -490,10 +490,15 @@ const get_scale = (
 	const factor = scale_factor(min, raw_units);
 	const units = scale_units(min, raw_units);
 
-	const domain = [min / factor, max / factor];
-	// Use pow scaling to allow users to more easily reason on graphs with highly differentiated values
+	// Use pow scaling to allow users to more easily reason on graphs with
+	// highly differentiated values. If the min is less than 1,000 times
+	// smaller than max use a linear scale pow(1), or else use a square root
+	// scale pow(.5).
+	//
 	// See: https://observablehq.com/plot/features/scales#continuous-scales
-	const yScale = d3.scalePow().exponent(0.5).domain(domain).nice();
+	const exponent = (max / min) < 1000 ? 1 : 0.5;
+	const domain = [min / factor, max / factor];
+	const yScale = d3.scalePow().exponent(exponent).domain(domain).nice();
 
 	return {
 		measure,

--- a/services/console/src/components/console/perf/plot/line/LinePlot.tsx
+++ b/services/console/src/components/console/perf/plot/line/LinePlot.tsx
@@ -492,7 +492,7 @@ const get_scale = (
 
 	// Use pow scaling to allow users to more easily reason on graphs with
 	// highly differentiated values. If the min is less than 10 times smaller
-	// than max use a linear scale.
+	// than the max, use a linear scale.
 	//
 	// See: https://observablehq.com/plot/features/scales#continuous-scales
 	const relativeDifference = max / min;

--- a/services/console/src/components/console/perf/plot/line/LinePlot.tsx
+++ b/services/console/src/components/console/perf/plot/line/LinePlot.tsx
@@ -491,12 +491,15 @@ const get_scale = (
 	const units = scale_units(min, raw_units);
 
 	// Use pow scaling to allow users to more easily reason on graphs with
-	// highly differentiated values. If the min is less than 1,000 times
-	// smaller than max use a linear scale pow(1), or else use a square root
-	// scale pow(.5).
+	// highly differentiated values. If the min is less than 10 times smaller
+	// than max use a linear scale.
 	//
 	// See: https://observablehq.com/plot/features/scales#continuous-scales
-	const exponent = (max / min) < 1000 ? 1 : 0.5;
+	const relativeDifference = max / min;
+	const exponent =
+		relativeDifference < 10
+			? 1
+			: Math.max(1 / Math.log10(relativeDifference), 1 / 3);
 	const domain = [min / factor, max / factor];
 	const yScale = d3.scalePow().exponent(exponent).domain(domain).nice();
 


### PR DESCRIPTION
Update charts use pow scaling to allow users to more easily reason on graphs with highly differentiated values.  Previously, charts were displaying values using a linear scale; e.g.:

![image](https://github.com/user-attachments/assets/a8f70677-c318-418a-9345-7153f161875a)

**Before: linear**
<img width="1340" alt="image" src="https://github.com/user-attachments/assets/0228c762-df20-4c3e-be31-5c72d5e39383" />

**After: pow (.5) if max > 1000x min**
<img width="1331" alt="image" src="https://github.com/user-attachments/assets/800e9dac-8611-4e6a-8564-0763e0c6c101" />

**After: pow (1) if min < 1000x**
<img width="1332" alt="image" src="https://github.com/user-attachments/assets/9808c664-5cfc-496b-8131-7a93bc625305" />

**After: pow (1) if min < 1000x (large value not selected)**
<img width="1338" alt="image" src="https://github.com/user-attachments/assets/f1098211-b40d-4ad1-bc77-3683c9728974" />


Addresses: #564 