### PR TITLE
fix: benchmark names with multiple lines

### DIFF
--- a/lib/bencher_adapter/tool_output/rust/iai_callgrind/name_on_multiple_lines.txt
+++ b/lib/bencher_adapter/tool_output/rust/iai_callgrind/name_on_multiple_lines.txt
@@ -1,0 +1,34 @@
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+rust_iai_callgrind::bench::multiple_lines id:string with two
+lines
+  Instructions:                   1|N/A             (*********)
+  L1 Hits:                        2|N/A             (*********)
+  L2 Hits:                        3|N/A             (*********)
+  RAM Hits:                       4|N/A             (*********)
+  Total read+write:               5|N/A             (*********)
+  Estimated Cycles:               6|N/A             (*********)
+rust_iai_callgrind::bench::multiple_lines id:string with multiple
+lines
+and one more
+  Instructions:                   7|N/A             (*********)
+  L1 Hits:                        8|N/A             (*********)
+  L2 Hits:                        9|N/A             (*********)
+  RAM Hits:                      10|N/A             (*********)
+  Total read+write:              11|N/A             (*********)
+  Estimated Cycles:              12|N/A             (*********)
+
+
+
+
+
+
+
+
+
+.... Some trailing text that should be ignored ...
+.... Some trailing text that should be ignored ...
+.... Some trailing text that should be ignored ...

--- a/lib/bencher_adapter/tool_output/rust/iai_callgrind/name_on_multiple_lines_mixed.txt
+++ b/lib/bencher_adapter/tool_output/rust/iai_callgrind/name_on_multiple_lines_mixed.txt
@@ -1,0 +1,39 @@
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+rust_iai_callgrind::bench::multiple_lines id:first with one line
+  Instructions:                   1|N/A             (*********)
+  L1 Hits:                        2|N/A             (*********)
+  L2 Hits:                        3|N/A             (*********)
+  RAM Hits:                       4|N/A             (*********)
+  Total read+write:               5|N/A             (*********)
+  Estimated Cycles:               6|N/A             (*********)
+rust_iai_callgrind::bench::multiple_lines id:two
+lines
+  Instructions:                   7|N/A             (*********)
+  L1 Hits:                        8|N/A             (*********)
+  L2 Hits:                        9|N/A             (*********)
+  RAM Hits:                      10|N/A             (*********)
+  Total read+write:              11|N/A             (*********)
+  Estimated Cycles:              12|N/A             (*********)
+rust_iai_callgrind::bench::multiple_lines id:last with one line
+  Instructions:                  13|N/A             (*********)
+  L1 Hits:                       14|N/A             (*********)
+  L2 Hits:                       15|N/A             (*********)
+  RAM Hits:                      16|N/A             (*********)
+  Total read+write:              17|N/A             (*********)
+  Estimated Cycles:              18|N/A             (*********)
+
+
+
+
+
+
+
+
+
+.... Some trailing text that should be ignored ...
+.... Some trailing text that should be ignored ...
+.... Some trailing text that should be ignored ...


### PR DESCRIPTION
Here's the fix for the problem on discord https://discord.com/channels/1074890101362004088/1412794833072033903/1413138826645209198 and as discussed in #619. Because there's no github issue: Here's a quick summary of the problem and the solution:

In the output of the slang benchmark there are benchmarks which have a multiline benchmark name. These benchmarks are not parsed correctly and are skipped by the current parser which causes the discrepancy between the expected amount of `12` benchmarks and the actual amount of `7` in this benchmark run https://github.com/NomicFoundation/slang/actions/runs/17408413743/job/49418989630. This issue arises in gungraun due to the use of syn's `to_string` function, which occasionally splits strings across multiple lines. While this behavior may not be considered a bug within gungraun, it deviates from the original intention of keeping both the benchmark name and description on a single line.

This pr contains a fix for the parser to accept benchmark names on multiple lines. Multiline benchmark names and descriptions will be removed in future versions of gungraun but this fix should work for all versions of gungraun/iai-callgrind.