### PR TITLE
tests: Add gungraun summary line test

### DIFF
--- a/lib/bencher_adapter/src/adapters/rust/iai_callgrind.rs
+++ b/lib/bencher_adapter/src/adapters/rust/iai_callgrind.rs
@@ -629,6 +629,15 @@ pub(crate) mod test_rust_iai_callgrind {
     }
 
     #[test]
+    fn test_with_gungraun_summary() {
+        let results = convert_file_path::<AdapterRustIaiCallgrind>(
+            "./tool_output/rust/iai_callgrind/with-gungraun-summary.txt",
+        );
+
+        validate_adapter_rust_iai_callgrind(&results, &OptionalMetrics::default());
+    }
+
+    #[test]
     fn test_ansi_escapes_issue_345() {
         let results = convert_file_path::<AdapterRustIaiCallgrind>(
             "./tool_output/rust/iai_callgrind/ansi-escapes.txt",

--- a/lib/bencher_adapter/tool_output/rust/iai_callgrind/with-gungraun-summary.txt
+++ b/lib/bencher_adapter/tool_output/rust/iai_callgrind/with-gungraun-summary.txt
@@ -1,0 +1,21 @@
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+rust_iai_callgrind::bench_fibonacci_group::bench_fibonacci short:10
+  Instructions:                1734|1650            (+5.09090%) [+1.04844x]
+  L1 Hits:                     2359|2275            (+3.69230%) [+1.03560x]
+  L2 Hits:                        0|0               (No change)
+  RAM Hits:                       3|3               (No change)
+  Total read+write:            2362|2278            (+3.68744%) [+1.03556x]
+  Estimated Cycles:            2464|2380            (+3.52941%) [+1.03409x]
+rust_iai_callgrind::bench_fibonacci_group::bench_fibonacci long:30
+  Instructions:            26214734|24943490        (+5.09649%) [+1.04849x]
+  L1 Hits:                 35638619|34367375        (+3.69898%) [+1.03567x]
+  L2 Hits:                        0|0               (No change)
+  RAM Hits:                       3|3               (No change)
+  Total read+write:        35638622|34367378        (+3.69898%) [+1.03567x]
+  Estimated Cycles:        35638724|34367480        (+3.69897%) [+1.03567x]
+
+Gungraun result: Regressed. 2 without regressions; 0 regressed; 2 benchmarks finished in 1.002s


### PR DESCRIPTION
This pr adds a test for the new gungraun summary line. No changes to the parser required.

Related #619