### PR TITLE
fix: added missing ":" to BMF JSON example

### DIFF
--- a/services/console/src/chunks/docs-reference/bencher-metric-format/bmf-example.mdx
+++ b/services/console/src/chunks/docs-reference/bencher-metric-format/bmf-example.mdx
@@ -6,7 +6,7 @@
       "lower_value": 87.42,
       "upper_value": 88.88
     },
-    "throughput" {
+    "throughput": {
       "value": 5.55,
       "lower_value": 3.14,
       "upper_value": 6.30


### PR DESCRIPTION
https://bencher.dev/docs/reference/bencher-metric-format/