### PR TITLE
docs(development): add missing dependencies to development guide

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,6 +18,9 @@ prerequisites installed on your machine.
    ```shell
    curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
    ```
+- [mold](https://github.com/rui314/mold)
+- [fontconfig](https://gitlab.freedesktop.org/fontconfig/fontconfig)
+- [freetype2](https://freetype.org)
 
 ### Installation
 


### PR DESCRIPTION
During setup I needed to install additional dependencies that were not listed in the development guide.
This commit updates the guide to include these dependencies to help future developers set up their environment.