### PR TITLE
Bump the actions/checkout version to v6

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: rui314/setup-mold@v1
         with:
           mold-version: ${{ env.MOLD_VERSION }}

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -46,7 +46,7 @@ jobs:
     name: Build GitHub Action
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Bencher CLI GitHub Action Dependencies
         working-directory: ./services/action
         run: npm install --include=dev
@@ -122,7 +122,7 @@ jobs:
       - name: Windows CLI Download Install Script
         if: matrix.source == 'script-cloud' && matrix.os == 'windows-2022'
         run: powershell -c "irm https://bencher.dev/download/install-cli.ps1 | iex"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: matrix.source == 'script-gen' || matrix.source == 'script-gen-version'
       - name: Unix CLI Install Script
         if: matrix.source == 'script-gen' && matrix.os != 'windows-2022'
@@ -150,7 +150,7 @@ jobs:
     name: Cargo Format
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Add fmt
         run: rustup component add rustfmt
       - name: Run fmt
@@ -160,7 +160,7 @@ jobs:
     name: Cargo Clippy
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/cache@v4
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/cloud' || github.ref == 'refs/heads/devel' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
         with:
@@ -183,7 +183,7 @@ jobs:
     name: Check Generated
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: rui314/setup-mold@v1
         with:
           mold-version: ${{ env.MOLD_VERSION }}
@@ -214,7 +214,7 @@ jobs:
     env:
       TEST_BILLING_KEY: ${{ secrets.TEST_BILLING_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/cache@v4
         with:
           path: |
@@ -241,7 +241,7 @@ jobs:
     name: Cargo Test PR
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: rui314/setup-mold@v1
         with:
           mold-version: ${{ env.MOLD_VERSION }}
@@ -262,7 +262,7 @@ jobs:
       - uses: jlumbroso/free-disk-space@main
         with:
           large-packages: false
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/cache@v4
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/cloud' || github.ref == 'refs/heads/devel' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
         with:
@@ -292,7 +292,7 @@ jobs:
           - os: windows-2022
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: rui314/setup-mold@v1
         if: matrix.os == 'ubuntu-22.04'
         with:
@@ -318,7 +318,7 @@ jobs:
       - uses: jlumbroso/free-disk-space@main
         with:
           large-packages: false
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: rui314/setup-mold@v1
         if: matrix.os == 'ubuntu-22.04'
         with:
@@ -333,7 +333,7 @@ jobs:
     name: Cargo Check Workspace (not(plus))
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: rui314/setup-mold@v1
         with:
           mold-version: ${{ env.MOLD_VERSION }}
@@ -344,7 +344,7 @@ jobs:
     name: Bencher Console (not(plus))
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install `wasm-pack`
         run: cargo install wasm-pack --version ${{ env.WASM_PACK_VERSION }} --locked --force
       - name: Build WASM
@@ -363,7 +363,7 @@ jobs:
     # or there are any breaking changes to the report format
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/cache@v4
         with:
           path: |
@@ -399,7 +399,7 @@ jobs:
     runs-on: ubuntu-22.04
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/cache@v4
         with:
           path: |
@@ -420,7 +420,7 @@ jobs:
     runs-on: ubuntu-22.04
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           log-level: warn
@@ -433,7 +433,7 @@ jobs:
     runs-on: ubuntu-22.04
     continue-on-error: ${{ !startsWith(github.ref, 'refs/tags/') }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/cache@v4
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/cloud' || github.ref == 'refs/heads/devel' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
         with:
@@ -465,7 +465,7 @@ jobs:
     name: Biome Format
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Biome format Action
         working-directory: ./services/action
         run: |
@@ -481,7 +481,7 @@ jobs:
     name: Biome Lint
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Biome check Action
         working-directory: ./services/action
         run: |
@@ -500,7 +500,7 @@ jobs:
     env:
       WASM_PACK_BUILD: "wasm-pack build --target web --no-default-features --features wasm,plus"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/cache@v4
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/cloud' || github.ref == 'refs/heads/devel' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
         with:
@@ -533,7 +533,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: build_bencher_valid_wasm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/cache@v4
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/cloud' || github.ref == 'refs/heads/devel' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
         with:
@@ -557,7 +557,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: build_bencher_valid_wasm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download `bencher_valid` Artifact
         uses: actions/download-artifact@v4
         with:
@@ -576,7 +576,7 @@ jobs:
     name: Build API Docker
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Setup Docker buildx
@@ -642,7 +642,7 @@ jobs:
             target: aarch64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # Install
       - name: Install Rust target
         run: rustup target add ${{ matrix.target }}
@@ -709,7 +709,7 @@ jobs:
     env:
       CLI_DEB_DIR: deb
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download CLI Artifact
         if: (!startsWith(matrix.build, 'windows'))
         uses: actions/download-artifact@v4
@@ -744,7 +744,7 @@ jobs:
     name: Build Console Docker
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Setup Docker buildx
@@ -782,7 +782,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: build_bencher_valid_wasm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download `bencher_valid` Artifact
         uses: actions/download-artifact@v4
         with:
@@ -811,7 +811,7 @@ jobs:
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download Local Artifact
         uses: actions/download-artifact@v4
         with:
@@ -849,7 +849,7 @@ jobs:
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download Litestream Artifact
         uses: actions/download-artifact@v4
         with:
@@ -896,7 +896,7 @@ jobs:
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Download Litestream Artifact
@@ -930,7 +930,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: deploy_api_fly_dev
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download `bencher_valid` Artifact
         uses: actions/download-artifact@v4
         with:
@@ -969,7 +969,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: deploy_api_fly
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download `bencher_valid` Artifact
         uses: actions/download-artifact@v4
         with:
@@ -1042,7 +1042,7 @@ jobs:
       BUILD_WINDOWS_X86_64: windows-x86-64
       BUILD_WINDOWS_ARM_64: windows-arm-64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # Download Docker
       - name: Download API Docker Artifact
         uses: actions/download-artifact@v4
@@ -1161,7 +1161,7 @@ jobs:
     name: Build dev container
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Setup Docker buildx

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ jobs:
       BENCHER_PROJECT: my-project-slug
       BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: bencherdev/bencher@main
       - run: bencher run "bencher mock"
 ```

--- a/services/console/src/chunks/docs-how-to/github-actions/base-branch-code.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/base-branch-code.mdx
@@ -10,7 +10,7 @@ jobs:
       checks: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: bencherdev/bencher@main
       - name: Track base branch benchmarks with Bencher
         run: |

--- a/services/console/src/chunks/docs-how-to/github-actions/de/base-branch.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/de/base-branch.mdx
@@ -24,7 +24,7 @@ Diese historische Basislinie kann dann verwendet werden, um Leistungsregressione
    für einen vollständigen Überblick.
    (z.B.: `runs-on: ubuntu-latest`)
 6. Checken Sie Ihren Basis-Branch Quellcode aus.
-   (z.B.: `uses: actions/checkout@v4`)
+   (z.B.: `uses: actions/checkout@v6`)
 7. Installieren Sie die Bencher CLI mithilfe der [GitHub Action][bencher cli github action].
    (z.B.: `uses: bencherdev/bencher@main`)
 8. Verwenden Sie das <code><a href="/de/docs/explanation/bencher-run/">bencher run</a></code> CLI-Unterkommando,

--- a/services/console/src/chunks/docs-how-to/github-actions/de/pull-requests-closed.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/de/pull-requests-closed.mdx
@@ -25,7 +25,7 @@ Dieser Workflow archiviert den PR-Branch mit dem Befehl `bencher archive`.
    für einen vollständigen Überblick.
    (z.B.: `runs-on: ubuntu-latest`)
 6. Checken Sie den PR-Branch-Quellcode aus.
-   (z.B.: `uses: actions/checkout@v4`)
+   (z.B.: `uses: actions/checkout@v6`)
 7. Installieren Sie das Bencher CLI mit [dem GitHub Action][bencher cli github action].
    (z.B.: `uses: bencherdev/bencher@main`)
 8. Verwenden Sie den `bencher archive` CLI-Unterbefehl, um den PR-Branch zu archivieren.

--- a/services/console/src/chunks/docs-how-to/github-actions/de/pull-requests-fork-closed.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/de/pull-requests-fork-closed.mdx
@@ -21,7 +21,7 @@ Dieser Workflow archiviert den Fork-PR-Branch mit dem Befehl `bencher archive`.
    für einen vollständigen Überblick.
    (z.B.: `runs-on: ubuntu-latest`)
 5. Checken Sie den Quellcode des PR-Branches aus.
-   (z.B.: `uses: actions/checkout@v4`)
+   (z.B.: `uses: actions/checkout@v6`)
 6. Installieren Sie die Bencher CLI mit [der GitHub Action][bencher cli github action].
    (z.B.: `uses: bencherdev/bencher@main`)
 7. Verwenden Sie den `bencher archive` CLI-Unterbefehl, um den PR-Branch zu archivieren.

--- a/services/console/src/chunks/docs-how-to/github-actions/de/pull-requests-fork-run.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/de/pull-requests-fork-run.mdx
@@ -23,7 +23,7 @@ import PullRequestsForkRunCode from "../pull-requests-fork-run-code.mdx";
    für einen vollständigen Überblick.
    (z.B.: `runs-on: ubuntu-latest`)
 6. Überprüfen Sie den Quellcode des Fork PR Branch.
-   (z.B.: `uses: actions/checkout@v4`)
+   (z.B.: `uses: actions/checkout@v6`)
 7. Führen Sie Ihre Benchmarks durch und speichern Sie die Ergebnisse in einer Datei.
    (z.B.: `/bin/echo '{ ... }' > benchmark_results.json`)
 8. Laden Sie die Benchmark-Ergebnisdatei als Artefakt hoch.

--- a/services/console/src/chunks/docs-how-to/github-actions/de/pull-requests.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/de/pull-requests.mdx
@@ -34,7 +34,7 @@ Um Performance-Regressionen in Pull Requests zu erfassen, müssen Sie Ihre Bench
    Siehe die [GitHub Actions `runs-on` Dokumentation][github actions runs-on] für einen vollständigen Überblick.
    (z.B.: `runs-on: ubuntu-latest`)
 7. Checken Sie den Quellcode des PR-Branches aus.
-   (z.B.: `uses: actions/checkout@v4`)
+   (z.B.: `uses: actions/checkout@v6`)
 8. Installieren Sie die Bencher CLI mithilfe [der GitHub Action][bencher cli github action].
    (z.B.: `uses: bencherdev/bencher@main`)
 9. Verwenden Sie den <code><a href="/de/docs/explanation/bencher-run/">bencher run</a></code> CLI-Unterbefehl, um Ihre Pull Request-Branch-Benchmarks auszuführen.

--- a/services/console/src/chunks/docs-how-to/github-actions/en/base-branch.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/en/base-branch.mdx
@@ -24,7 +24,7 @@ This historical baseline can then be used to detect performance regressions in P
    for a full overview.
    (ex: `runs-on: ubuntu-latest`)
 6. Checkout your base branch source code.
-   (ex: `uses: actions/checkout@v4`)
+   (ex: `uses: actions/checkout@v6`)
 7. Install the Bencher CLI using [the GitHub Action][bencher cli github action].
    (ex: `uses: bencherdev/bencher@main`)
 8. Use the <code><a href="/docs/explanation/bencher-run/">bencher run</a></code> CLI subcommand

--- a/services/console/src/chunks/docs-how-to/github-actions/en/pull-requests-closed.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/en/pull-requests-closed.mdx
@@ -25,7 +25,7 @@ This workflow will archive the PR branch using the `bencher archive` command.
    for a full overview.
    (ex: `runs-on: ubuntu-latest`)
 6. Checkout the PR branch source code.
-   (ex: `uses: actions/checkout@v4`)
+   (ex: `uses: actions/checkout@v6`)
 7. Install the Bencher CLI using [the GitHub Action][bencher cli github action].
    (ex: `uses: bencherdev/bencher@main`)
 8.  Use the `bencher archive` CLI subcommand to archive the PR branch.

--- a/services/console/src/chunks/docs-how-to/github-actions/en/pull-requests-fork-closed.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/en/pull-requests-fork-closed.mdx
@@ -21,7 +21,7 @@ This workflow will archive the fork PR branch using the `bencher archive` comman
    for a full overview.
    (ex: `runs-on: ubuntu-latest`)
 5. Checkout the PR branch source code.
-   (ex: `uses: actions/checkout@v4`)
+   (ex: `uses: actions/checkout@v6`)
 6. Install the Bencher CLI using [the GitHub Action][bencher cli github action].
    (ex: `uses: bencherdev/bencher@main`)
 7. Use the `bencher archive` CLI subcommand to archive the PR branch.

--- a/services/console/src/chunks/docs-how-to/github-actions/en/pull-requests-fork-run.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/en/pull-requests-fork-run.mdx
@@ -23,7 +23,7 @@ import PullRequestsForkRunCode from "../pull-requests-fork-run-code.mdx";
    for a full overview.
    (ex: `runs-on: ubuntu-latest`)
 6. Checkout the fork PR branch source code.
-   (ex: `uses: actions/checkout@v4`)
+   (ex: `uses: actions/checkout@v6`)
 7. Run your benchmarks and save the results to a file.
    (ex: `/bin/echo '{ ... }' > benchmark_results.json`)
 8. Upload the benchmark results file as an artifact.

--- a/services/console/src/chunks/docs-how-to/github-actions/en/pull-requests.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/en/pull-requests.mdx
@@ -44,7 +44,7 @@ then you can simply create another workflow to run `on` `pull_request` events fr
    for a full overview.
    (ex: `runs-on: ubuntu-latest`)
 7. Checkout the PR branch source code.
-   (ex: `uses: actions/checkout@v4`)
+   (ex: `uses: actions/checkout@v6`)
 8. Install the Bencher CLI using [the GitHub Action][bencher cli github action].
    (ex: `uses: bencherdev/bencher@main`)
 9. Use the <code><a href="/docs/explanation/bencher-run/">bencher run</a></code> CLI subcommand

--- a/services/console/src/chunks/docs-how-to/github-actions/es/base-branch.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/es/base-branch.mdx
@@ -18,7 +18,7 @@ Una piedra angular de [Benchmarking Continuo Estadístico][statistical continuou
    Consulta la [documentación `runs-on` de GitHub Actions][github actions runs-on] para una visión completa.
    (ej: `runs-on: ubuntu-latest`)
 6. Revisa tu código fuente de la rama base.
-   (ej: `uses: actions/checkout@v4`)
+   (ej: `uses: actions/checkout@v6`)
 7. Instala la CLI de Bencher usando [la Acción de GitHub][bencher cli github action].
    (ej: `uses: bencherdev/bencher@main`)
 8. Usa el subcomando <code><a href="/es/docs/explanation/bencher-run/">bencher run</a></code> de la CLI para ejecutar tus benchmarks de la rama `main`. Consulta [el subcomando `bencher run` de la CLI][bencher run] para una visión completa.

--- a/services/console/src/chunks/docs-how-to/github-actions/es/pull-requests-closed.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/es/pull-requests-closed.mdx
@@ -23,7 +23,7 @@ Para limpiar la rama de PR después de que su PR esté cerrado, puedes crear un 
    para una visión completa.
    (ej: `runs-on: ubuntu-latest`)
 6. Checkout del código fuente de la rama PR.
-   (ej: `uses: actions/checkout@v4`)
+   (ej: `uses: actions/checkout@v6`)
 7. Instala el CLI de Bencher usando [la Acción de GitHub][bencher cli github action].
    (ej: `uses: bencherdev/bencher@main`)
 8.  Utiliza el subcomando `bencher archive` del CLI para archivar la rama PR.

--- a/services/console/src/chunks/docs-how-to/github-actions/es/pull-requests-fork-closed.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/es/pull-requests-fork-closed.mdx
@@ -21,7 +21,7 @@ Este flujo de trabajo archivará la rama del PR del fork utilizando el comando `
    para una visión general completa.
    (ej: `runs-on: ubuntu-latest`)
 5. Revisa el código fuente de la rama del PR.
-   (ej: `uses: actions/checkout@v4`)
+   (ej: `uses: actions/checkout@v6`)
 6. Instala el Bencher CLI usando [la acción de GitHub][bencher cli github action].
    (ej: `uses: bencherdev/bencher@main`)
 7. Usa el subcomando CLI `bencher archive` para archivar la rama del PR.

--- a/services/console/src/chunks/docs-how-to/github-actions/es/pull-requests-fork-run.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/es/pull-requests-fork-run.mdx
@@ -23,7 +23,7 @@ import PullRequestsForkRunCode from "../pull-requests-fork-run-code.mdx";
    para una vista completa.
    (ej: `runs-on: ubuntu-latest`)
 6. Verifica el código fuente de la rama PR del fork.
-   (ej: `uses: actions/checkout@v4`)
+   (ej: `uses: actions/checkout@v6`)
 7. Ejecuta tus pruebas de rendimiento y guarda los resultados en un archivo.
    (ej: `/bin/echo '{ ... }' > benchmark_results.json`)
 8. Sube el archivo de resultados de pruebas de rendimiento como artefacto.

--- a/services/console/src/chunks/docs-how-to/github-actions/es/pull-requests.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/es/pull-requests.mdx
@@ -44,7 +44,7 @@ entonces simplemente puedes crear otro flujo de trabajo para ejecutar `on` event
    para una visión completa.
    (ej: `runs-on: ubuntu-latest`)
 7. Clona el código fuente de la rama PR.
-   (ej: `uses: actions/checkout@v4`)
+   (ej: `uses: actions/checkout@v6`)
 8. Instala el Bencher CLI usando [la GitHub Action][bencher cli github action].
    (ej: `uses: bencherdev/bencher@main`)
 9. Usa la subcomando CLI <code><a href="/es/docs/explanation/bencher-run/">bencher run</a></code>

--- a/services/console/src/chunks/docs-how-to/github-actions/fr/base-branch.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/fr/base-branch.mdx
@@ -24,7 +24,7 @@ Cette base de référence historique peut alors être utilisée pour détecter l
    pour un aperçu complet.
    (ex: `runs-on: ubuntu-latest`)
 6. Récupérez le code source de votre branche de base.
-   (ex: `uses: actions/checkout@v4`)
+   (ex: `uses: actions/checkout@v6`)
 7. Installez le Bencher CLI en utilisant [l'Action GitHub][bencher cli github action].
    (ex: `uses: bencherdev/bencher@main`)
 8. Utilisez la sous-commande CLI <code><a href="/fr/docs/explanation/bencher-run/">bencher run</a></code>

--- a/services/console/src/chunks/docs-how-to/github-actions/fr/pull-requests-closed.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/fr/pull-requests-closed.mdx
@@ -25,7 +25,7 @@ Ce flux de travail archivera la branche PR en utilisant la commande `bencher arc
    pour un aperçu complet.
    (ex: `runs-on: ubuntu-latest`)
 6. Validez le code source de la branche PR.
-   (ex: `uses: actions/checkout@v4`)
+   (ex: `uses: actions/checkout@v6`)
 7. Installez le Bencher CLI en utilisant [l'Action GitHub][bencher cli github action].
    (ex: `uses: bencherdev/bencher@main`)
 8. Utilisez la sous-commande CLI `bencher archive` pour archiver la branche PR.

--- a/services/console/src/chunks/docs-how-to/github-actions/fr/pull-requests-fork-closed.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/fr/pull-requests-fork-closed.mdx
@@ -21,7 +21,7 @@ Ce flux de travail archivera la branche de PR fork en utilisant la commande `ben
    pour un aperçu complet.
    (ex : `runs-on: ubuntu-latest`)
 5. Récupérez le code source de la branche PR.
-   (ex : `uses: actions/checkout@v4`)
+   (ex : `uses: actions/checkout@v6`)
 6. Installez le Bencher CLI en utilisant [l'action GitHub][bencher cli github action].
    (ex : `uses: bencherdev/bencher@main`)
 7. Utilisez la sous-commande CLI `bencher archive` pour archiver la branche PR.

--- a/services/console/src/chunks/docs-how-to/github-actions/fr/pull-requests-fork-run.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/fr/pull-requests-fork-run.mdx
@@ -23,7 +23,7 @@ import PullRequestsForkRunCode from "../pull-requests-fork-run-code.mdx";
    pour un aperçu complet.
    (ex : `runs-on: ubuntu-latest`)
 6. Récupérez le code source de la branche fork PR.
-   (ex : `uses: actions/checkout@v4`)
+   (ex : `uses: actions/checkout@v6`)
 7. Exécutez vos benchmarks et enregistrez les résultats dans un fichier.
    (ex : `/bin/echo '{ ... }' > benchmark_results.json`)
 8. Téléchargez le fichier de résultats des benchmarks en tant qu'artifact.

--- a/services/console/src/chunks/docs-how-to/github-actions/fr/pull-requests.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/fr/pull-requests.mdx
@@ -44,7 +44,7 @@ alors vous pouvez simplement créer un autre workflow pour fonctionner avec des 
    pour un aperçu complet.
    (ex : `runs-on: ubuntu-latest`)
 7. Validez le code source de la branche PR.
-   (ex : `uses: actions/checkout@v4`)
+   (ex : `uses: actions/checkout@v6`)
 8. Installez le Bencher CLI en utilisant [l'Action GitHub][bencher cli github action].
    (ex : `uses: bencherdev/bencher@main`)
 9. Utilisez la sous-commande CLI <code><a href="/fr/docs/explanation/bencher-run/">bencher run</a></code>

--- a/services/console/src/chunks/docs-how-to/github-actions/ja/base-branch.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/ja/base-branch.mdx
@@ -21,7 +21,7 @@ import BaseBranchCode from "../base-branch-code.mdx";
    詳細については、[GitHub Actionsの`runs-on`ドキュメント][github actions runs-on]を参照してください。
    （例: `runs-on: ubuntu-latest`）
 6. ベースブランチのソースコードをチェックアウトします。
-   （例: `uses: actions/checkout@v4`）
+   （例: `uses: actions/checkout@v6`）
 7. [GitHub Action][bencher cli github action]を使用してBencher CLIをインストールします。
    （例: `uses: bencherdev/bencher@main`）
 8. <code><a href="/ja/docs/explanation/bencher-run/">bencher run</a></code> CLIサブコマンドを使用して`main`ブランチのベンチマークを実行します。

--- a/services/console/src/chunks/docs-how-to/github-actions/ja/pull-requests-closed.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/ja/pull-requests-closed.mdx
@@ -21,7 +21,7 @@ PRがクローズされた後にPRブランチをクリーンアップするた�
    完全な概要については[GitHub Actionsの`runs-on`ドキュメント][github actions runs-on]をご覧ください。
    (例: `runs-on: ubuntu-latest`)
 6. PRブランチのソースコードをチェックアウトします。
-   (例: `uses: actions/checkout@v4`)
+   (例: `uses: actions/checkout@v6`)
 7. [GitHub Action][bencher cli github action]を使用してBencher CLIをインストールします。
    (例: `uses: bencherdev/bencher@main`)
 8. `bencher archive` CLIサブコマンドを使用してPRブランチをアーカイブします。

--- a/services/console/src/chunks/docs-how-to/github-actions/ja/pull-requests-fork-closed.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/ja/pull-requests-fork-closed.mdx
@@ -20,7 +20,7 @@ import PullRequestsForkClosedCode from "../pull-requests-fork-closed-code.mdx";
    詳細は[GitHub Actions `runs-on`ドキュメント][github actions runs-on]を参照してください。
    (例: `runs-on: ubuntu-latest`)
 5. PRブランチのソースコードをチェックアウトします。
-   (例: `uses: actions/checkout@v4`)
+   (例: `uses: actions/checkout@v6`)
 6. [GitHub Action][bencher cli github action]を使用してBencher CLIをインストールします。
    (例: `uses: bencherdev/bencher@main`)
 7. `bencher archive` CLIサブコマンドを使用してPRブランチをアーカイブします。

--- a/services/console/src/chunks/docs-how-to/github-actions/ja/pull-requests-fork-run.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/ja/pull-requests-fork-run.mdx
@@ -24,7 +24,7 @@ import PullRequestsForkRunCode from "../pull-requests-fork-run-code.mdx";
    詳細を確認してください。
    (例: `runs-on: ubuntu-latest`)
 6. フォークされたPRブランチのソースコードをチェックアウトします。
-   (例: `uses: actions/checkout@v4`)
+   (例: `uses: actions/checkout@v6`)
 7. ベンチマークを実行し、結果をファイルに保存します。
    (例: `/bin/echo '{ ... }' > benchmark_results.json`)
 8. ベンチマークの結果ファイルをアーティファクトとしてアップロードします。

--- a/services/console/src/chunks/docs-how-to/github-actions/ja/pull-requests.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/ja/pull-requests.mdx
@@ -40,7 +40,7 @@ import PullRequestsClosed from "./pull-requests-closed.mdx";
    [GitHub Actionsの`runs-on`ドキュメント][github actions runs-on]を参照し、全体を把握してください。
    (例: `runs-on: ubuntu-latest`)
 7. PRブランチのソースコードをチェックアウトします。
-   (例: `uses: actions/checkout@v4`)
+   (例: `uses: actions/checkout@v6`)
 8. [GitHub Actionから][bencher cli github action]Bencher CLIをインストールします。
    (例: `uses: bencherdev/bencher@main`)
 9. プルリクエストブランチのベンチマークを実行するために、<code><a href="/ja/docs/explanation/bencher-run/">bencher run</a></code> CLIサブコマンドを使用します。

--- a/services/console/src/chunks/docs-how-to/github-actions/ko/base-branch.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/ko/base-branch.mdx
@@ -21,7 +21,7 @@ import BaseBranchCode from "../base-branch-code.mdx";
    전체 개요는 [GitHub Actions `runs-on` 문서][github actions runs-on]를 참조하세요.
    (예: `runs-on: ubuntu-latest`)
 6. 기본 브랜치 소스 코드를 체크아웃하세요.
-   (예: `uses: actions/checkout@v4`)
+   (예: `uses: actions/checkout@v6`)
 7. [GitHub Action][bencher cli github action]을 사용하여 Bencher CLI를 설치하세요.
    (예: `uses: bencherdev/bencher@main`)
 8. <code><a href="/ko/docs/explanation/bencher-run/">bencher run</a></code> CLI 서브 커맨드를 사용하여 `main` 브랜치 벤치마크를 실행하세요.

--- a/services/console/src/chunks/docs-how-to/github-actions/ko/pull-requests-closed.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/ko/pull-requests-closed.mdx
@@ -19,7 +19,7 @@ PR이 닫힌 후 PR 브랜치를 정리하려면 `closed` 타입의 `pull_reques
    전체 개요는 [GitHub Actions `runs-on` 문서][github actions runs-on]를 참조하십시오.
    (예: `runs-on: ubuntu-latest`)
 6. PR 브랜치 소스 코드를 체크아웃합니다.
-   (예: `uses: actions/checkout@v4`)
+   (예: `uses: actions/checkout@v6`)
 7. [GitHub Action][bencher cli github action]을 사용하여 Bencher CLI를 설치합니다.
    (예: `uses: bencherdev/bencher@main`)
 8.  PR 브랜치를 아카이브하기 위해 `bencher archive` CLI 서브커맨드를 사용하십시오.

--- a/services/console/src/chunks/docs-how-to/github-actions/ko/pull-requests-fork-closed.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/ko/pull-requests-fork-closed.mdx
@@ -20,7 +20,7 @@ import PullRequestsForkClosedCode from "../pull-requests-fork-closed-code.mdx";
    전체 개요는 [GitHub Actions `runs-on` 문서][github actions runs-on]를 참조하십시오.
    (예: `runs-on: ubuntu-latest`)
 5. PR 브랜치 소스 코드를 체크아웃합니다.
-   (예: `uses: actions/checkout@v4`)
+   (예: `uses: actions/checkout@v6`)
 6. [GitHub Action][bencher cli github action]을 사용하여 Bencher CLI를 설치합니다.
    (예: `uses: bencherdev/bencher@main`)
 7. PR 브랜치를 아카이브하기 위해 `bencher archive` CLI 서브커맨드를 사용합니다.

--- a/services/console/src/chunks/docs-how-to/github-actions/ko/pull-requests-fork-run.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/ko/pull-requests-fork-run.mdx
@@ -23,7 +23,7 @@ import PullRequestsForkRunCode from "../pull-requests-fork-run-code.mdx";
    를 참조하세요.
    (예: `runs-on: ubuntu-latest`)
 6. 포크 PR 브랜치의 소스 코드를 체크아웃합니다.
-   (예: `uses: actions/checkout@v4`)
+   (예: `uses: actions/checkout@v6`)
 7. 벤치마크를 실행하고 결과를 파일에 저장합니다.
    (예: `/bin/echo '{ ... }' > benchmark_results.json`)
 8. 벤치마크 결과 파일을 아티팩트로 업로드합니다.

--- a/services/console/src/chunks/docs-how-to/github-actions/ko/pull-requests.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/ko/pull-requests.mdx
@@ -35,7 +35,7 @@ import PullRequestsClosed from "./pull-requests-closed.mdx";
    전체 개요는 [GitHub Actions `runs-on` 문서][github actions runs-on]를 참조하세요.
    (예: `runs-on: ubuntu-latest`)
 7. PR 브랜치의 소스 코드를 체크아웃합니다.
-   (예: `uses: actions/checkout@v4`)
+   (예: `uses: actions/checkout@v6`)
 8. [GitHub Action][bencher cli github action]을 사용하여 Bencher CLI를 설치합니다.
    (예: `uses: bencherdev/bencher@main`)
 9. PR 브랜치 벤치마크를 실행하기 위해 <code><a href="/ko/docs/explanation/bencher-run/">bencher run</a></code> CLI 서브커맨드를 사용합니다.

--- a/services/console/src/chunks/docs-how-to/github-actions/pt/base-branch.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/pt/base-branch.mdx
@@ -24,7 +24,7 @@ Essa linha de base histórica pode então ser usada para detectar regressões de
    para uma visão geral completa.
    (ex: `runs-on: ubuntu-latest`)
 6. Faça o checkout do código-fonte da sua ramificação base.
-   (ex: `uses: actions/checkout@v4`)
+   (ex: `uses: actions/checkout@v6`)
 7. Instale o Bencher CLI usando [a Ação do GitHub][bencher cli github action].
    (ex: `uses: bencherdev/bencher@main`)
 8. Use o subcomando <code><a href="/pt/docs/explanation/bencher-run/">bencher run</a></code> do CLI

--- a/services/console/src/chunks/docs-how-to/github-actions/pt/pull-requests-closed.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/pt/pull-requests-closed.mdx
@@ -25,7 +25,7 @@ Este fluxo de trabalho arquivará o branch do PR usando o comando `bencher archi
    para uma visão completa.
    (ex: `runs-on: ubuntu-latest`)
 6. Faça o checkout do código-fonte do branch do PR.
-   (ex: `uses: actions/checkout@v4`)
+   (ex: `uses: actions/checkout@v6`)
 7. Instale o Bencher CLI usando [a Ação do GitHub][bencher cli github action].
    (ex: `uses: bencherdev/bencher@main`)
 8. Use o subcomando `bencher archive` da CLI para arquivar o branch do PR.

--- a/services/console/src/chunks/docs-how-to/github-actions/pt/pull-requests-fork-closed.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/pt/pull-requests-fork-closed.mdx
@@ -21,7 +21,7 @@ Este fluxo de trabalho arquivará o branch de PR do fork usando o comando `bench
    para uma visão geral completa.
    (ex: `runs-on: ubuntu-latest`)
 5. Faça checkout do código fonte do branch de PR.
-   (ex: `uses: actions/checkout@v4`)
+   (ex: `uses: actions/checkout@v6`)
 6. Instale o Bencher CLI usando [a Ação do GitHub][bencher cli github action].
    (ex: `uses: bencherdev/bencher@main`)
 7. Use o subcomando `bencher archive` do CLI para arquivar o branch de PR.

--- a/services/console/src/chunks/docs-how-to/github-actions/pt/pull-requests-fork-run.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/pt/pull-requests-fork-run.mdx
@@ -23,7 +23,7 @@ import PullRequestsForkRunCode from "../pull-requests-fork-run-code.mdx";
    para uma visão completa.
    (ex: `runs-on: ubuntu-latest`)
 6. Faça o checkout do código-fonte do fork PR.
-   (ex: `uses: actions/checkout@v4`)
+   (ex: `uses: actions/checkout@v6`)
 7. Execute seus benchmarks e salve os resultados em um arquivo.
    (ex: `/bin/echo '{ ... }' > benchmark_results.json`)
 8. Envie o arquivo de resultados de benchmark como um artefato.

--- a/services/console/src/chunks/docs-how-to/github-actions/pt/pull-requests.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/pt/pull-requests.mdx
@@ -44,7 +44,7 @@ então basta criar outro workflow para executar `on` eventos de `pull_request` d
    para uma visão geral completa.
    (ex: `runs-on: ubuntu-latest`)
 7. Faça o checkout do código fonte da branch do PR.
-   (ex: `uses: actions/checkout@v4`)
+   (ex: `uses: actions/checkout@v6`)
 8. Instale o Bencher CLI usando [a GitHub Action][bencher cli github action].
    (ex: `uses: bencherdev/bencher@main`)
 9. Use o subcomando CLI <code><a href="/pt/docs/explanation/bencher-run/">bencher run</a></code>

--- a/services/console/src/chunks/docs-how-to/github-actions/pull-requests-closed-code.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/pull-requests-closed-code.mdx
@@ -10,7 +10,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: bencherdev/bencher@main
       - name: Archive closed PR branch with Bencher
         run: |

--- a/services/console/src/chunks/docs-how-to/github-actions/pull-requests-code.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/pull-requests-code.mdx
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: bencherdev/bencher@main
       - name: Track PR Benchmarks with Bencher
         run: |

--- a/services/console/src/chunks/docs-how-to/github-actions/pull-requests-fork-closed-code.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/pull-requests-fork-closed-code.mdx
@@ -8,7 +8,7 @@ jobs:
     name: Archive closed fork PR branch with Bencher
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: bencherdev/bencher@main
       - name: Archive closed fork PR branch with Bencher
         run: |

--- a/services/console/src/chunks/docs-how-to/github-actions/pull-requests-fork-reviewer-code.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/pull-requests-fork-reviewer-code.mdx
@@ -15,7 +15,7 @@ jobs:
     name: Continuous Benchmarking Fork PRs with Bencher
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}

--- a/services/console/src/chunks/docs-how-to/github-actions/pull-requests-fork-run-code.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/pull-requests-fork-run-code.mdx
@@ -10,7 +10,7 @@ jobs:
     name: Run Fork PR Benchmarks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Mock Benchmarking
         run: |
           /bin/echo '{ "bencher::mock_0": { "latency": { "value": 1.0 } } }' > benchmark_results.json

--- a/services/console/src/chunks/docs-how-to/github-actions/ru/base-branch.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/ru/base-branch.mdx
@@ -24,7 +24,7 @@ import BaseBranchCode from "../base-branch-code.mdx";
    для получения подробной информации.
    (например, `runs-on: ubuntu-latest`)
 6. Получите исходный код вашей основной ветки.
-   (например, `uses: actions/checkout@v4`)
+   (например, `uses: actions/checkout@v6`)
 7. Установите Bencher CLI, используя [GitHub Action][bencher cli github action].
    (например, `uses: bencherdev/bencher@main`)
 8. Используйте подкaманды CLI <code><a href="/ru/docs/explanation/bencher-run/">bencher run</a></code>

--- a/services/console/src/chunks/docs-how-to/github-actions/ru/pull-requests-closed.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/ru/pull-requests-closed.mdx
@@ -22,7 +22,7 @@ import PullRequestsClosedCode from "../pull-requests-closed-code.mdx";
    См. [документацию по GitHub Actions `runs-on`][github actions runs-on] для полного обзора.
    (например, `runs-on: ubuntu-latest`)
 6. Выполните проверку исходного кода PR-ветки.
-   (например, `uses: actions/checkout@v4`)
+   (например, `uses: actions/checkout@v6`)
 7. Установите Bencher CLI, используя [GitHub Action][bencher cli github action].
    (например, `uses: bencherdev/bencher@main`)
 8. Используйте подкоманду CLI `bencher archive` для архивирования PR-ветки.

--- a/services/console/src/chunks/docs-how-to/github-actions/ru/pull-requests-fork-closed.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/ru/pull-requests-fork-closed.mdx
@@ -17,7 +17,7 @@ import PullRequestsForkClosedCode from "../pull-requests-fork-closed-code.mdx";
    См. [документацию по GitHub Actions `runs-on`][github actions runs-on] для полного обзора.
    (например, `runs-on: ubuntu-latest`)
 5. Выполните проверку исходного кода ветки PR.
-   (например, `uses: actions/checkout@v4`)
+   (например, `uses: actions/checkout@v6`)
 6. Установите Bencher CLI, используя [действие GitHub Action][bencher cli github action].
    (например, `uses: bencherdev/bencher@main`)
 7. Используйте подкоманду CLI `bencher archive` для архивирования ветки PR.

--- a/services/console/src/chunks/docs-how-to/github-actions/ru/pull-requests-fork-run.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/ru/pull-requests-fork-run.mdx
@@ -23,7 +23,7 @@ import PullRequestsForkRunCode from "../pull-requests-fork-run-code.mdx";
    для полного обзора.
    (например: `runs-on: ubuntu-latest`)
 6. Выполните checkout исходного кода ветки fork PR.
-   (например: `uses: actions/checkout@v4`)
+   (например: `uses: actions/checkout@v6`)
 7. Запустите тесты производительности и сохраните результаты в файл.
    (например: `/bin/echo '{ ... }' > benchmark_results.json`)
 8. Загрузите файл с результатами тестов производительности как артефакт.

--- a/services/console/src/chunks/docs-how-to/github-actions/ru/pull-requests.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/ru/pull-requests.mdx
@@ -44,7 +44,7 @@ import PullRequestsClosed from "./pull-requests-closed.mdx";
    для полного обзора.
    (пример: `runs-on: ubuntu-latest`)
 7. Проверьте исходный код ветки PR.
-   (пример: `uses: actions/checkout@v4`)
+   (пример: `uses: actions/checkout@v6`)
 8. Установите Bencher CLI с использованием [GitHub Action][bencher cli github action].
    (пример: `uses: bencherdev/bencher@main`)
 9. Используйте <code><a href="/ru/docs/explanation/bencher-run/">bencher run</a></code> CLI подкоманду

--- a/services/console/src/chunks/docs-how-to/github-actions/zh/base-branch.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/zh/base-branch.mdx
@@ -20,7 +20,7 @@ import BaseBranchCode from "../base-branch-code.mdx";
    请参阅 [GitHub Actions `runs-on` 文档][github actions runs-on] 以获取完整概述。
    (例如：`runs-on: ubuntu-latest`)
 6. 检出您的基础分支源代码。
-   (例如：`uses: actions/checkout@v4`)
+   (例如：`uses: actions/checkout@v6`)
 7. 使用 [GitHub Action][bencher cli github action] 安装 Bencher CLI。
    (例如：`uses: bencherdev/bencher@main`)
 8. 使用 <code><a href="/zh/docs/explanation/bencher-run/">bencher run</a></code> CLI 子命令

--- a/services/console/src/chunks/docs-how-to/github-actions/zh/pull-requests-closed.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/zh/pull-requests-closed.mdx
@@ -25,7 +25,7 @@ import PullRequestsClosedCode from "../pull-requests-closed-code.mdx";
    以获取完整概述。
    (例如：`runs-on: ubuntu-latest`)
 6. 签出 PR 分支源代码。
-   (例如：`uses: actions/checkout@v4`)
+   (例如：`uses: actions/checkout@v6`)
 7. 使用 [GitHub Action][bencher cli github action] 安装 Bencher CLI。
    (例如：`uses: bencherdev/bencher@main`)
 8. 使用 `bencher archive` CLI 子命令归档 PR 分支。

--- a/services/console/src/chunks/docs-how-to/github-actions/zh/pull-requests-fork-closed.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/zh/pull-requests-fork-closed.mdx
@@ -17,7 +17,7 @@ import PullRequestsForkClosedCode from "../pull-requests-fork-closed-code.mdx";
    查看 [GitHub Actions `runs-on` 文档][github actions runs-on] 以获取完整概览。
    （例如：`runs-on: ubuntu-latest`）
 5. 检出 PR 分支源代码。
-   （例如：`uses: actions/checkout@v4`）
+   （例如：`uses: actions/checkout@v6`）
 6. 使用[GitHub Action][bencher cli github action] 安装 Bencher CLI。
    （例如：`uses: bencherdev/bencher@main`）
 7. 使用 `bencher archive` CLI 子命令归档 PR 分支。

--- a/services/console/src/chunks/docs-how-to/github-actions/zh/pull-requests-fork-run.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/zh/pull-requests-fork-run.mdx
@@ -23,7 +23,7 @@ import PullRequestsForkRunCode from "../pull-requests-fork-run-code.mdx";
    了解完整概况。
    （例如：`runs-on: ubuntu-latest`）
 6. 检出fork PR分支的源代码。
-   （例如：`uses: actions/checkout@v4`）
+   （例如：`uses: actions/checkout@v6`）
 7. 运行基准测试并将结果保存到文件。
    （例如：`/bin/echo '{ ... }' > benchmark_results.json`）
 8. 将基准测试结果文件作为工件上传。

--- a/services/console/src/chunks/docs-how-to/github-actions/zh/pull-requests.mdx
+++ b/services/console/src/chunks/docs-how-to/github-actions/zh/pull-requests.mdx
@@ -37,7 +37,7 @@ import PullRequestsClosed from "./pull-requests-closed.mdx";
    查看 [GitHub Actions `runs-on` 文档][github actions runs-on] 以获取完整概览。
    （例如：`runs-on: ubuntu-latest`）
 7. 检出 PR 分支的源代码。
-   （例如：`uses: actions/checkout@v4`）
+   （例如：`uses: actions/checkout@v6`）
 8. 使用 [GitHub Action][bencher cli github action] 安装 Bencher CLI。
    （例如：`uses: bencherdev/bencher@main`）
 9. 使用 <code><a href="/zh/docs/explanation/bencher-run/">bencher run</a></code> CLI 子命令运行您的拉取请求分支基准测试。


### PR DESCRIPTION
A lot of docs refer to `actions/checkout@v4` when the latest version is v6. This PR updates all these files, and the pipelines in the repo, so everyone is using the latest, greatest and safest action version.