### PR TITLE
Move from custom `Deserialize` to `TryFrom<String>`

### DIFF
--- a/lib/bencher_valid/src/benchmark_name.rs
+++ b/lib/bencher_valid/src/benchmark_name.rs
@@ -258,4 +258,15 @@ mod tests {
             (stripped_benchmark_name, true)
         );
     }
+
+    #[test]
+    fn benchmark_name_serde_roundtrip() {
+        let name: BenchmarkName = serde_json::from_str("\"my benchmark\"").unwrap();
+        assert_eq!(name.as_ref(), "my benchmark");
+        let json = serde_json::to_string(&name).unwrap();
+        assert_eq!(json, "\"my benchmark\"");
+
+        let err = serde_json::from_str::<BenchmarkName>("\"\"");
+        assert!(err.is_err());
+    }
 }

--- a/lib/bencher_valid/src/branch_name.rs
+++ b/lib/bencher_valid/src/branch_name.rs
@@ -104,4 +104,17 @@ mod tests {
             assert_eq!(false, is_valid_branch_name(name), "{name}");
         }
     }
+
+    #[test]
+    fn branch_name_serde_roundtrip() {
+        use super::BranchName;
+
+        let name: BranchName = serde_json::from_str("\"main\"").unwrap();
+        assert_eq!(name.as_ref(), "main");
+        let json = serde_json::to_string(&name).unwrap();
+        assert_eq!(json, "\"main\"");
+
+        let err = serde_json::from_str::<BranchName>("\"\"");
+        assert!(err.is_err());
+    }
 }

--- a/lib/bencher_valid/src/email.rs
+++ b/lib/bencher_valid/src/email.rs
@@ -123,4 +123,15 @@ mod tests {
             Email::from_str("ABC.xYz@Example.coM").unwrap()
         );
     }
+
+    #[test]
+    fn email_serde_roundtrip() {
+        let email: Email = serde_json::from_str("\"ABC@Example.COM\"").unwrap();
+        assert_eq!(email.as_ref(), "abc@example.com");
+        let json = serde_json::to_string(&email).unwrap();
+        assert_eq!(json, "\"abc@example.com\"");
+
+        let err = serde_json::from_str::<Email>("\"not-an-email\"");
+        assert!(err.is_err());
+    }
 }

--- a/lib/bencher_valid/src/git_hash.rs
+++ b/lib/bencher_valid/src/git_hash.rs
@@ -90,4 +90,18 @@ mod tests {
             assert_eq!(false, is_valid_git_hash(hash), "{hash}");
         }
     }
+
+    #[test]
+    fn git_hash_serde_roundtrip() {
+        use super::GitHash;
+
+        let hash: GitHash =
+            serde_json::from_str("\"1234567890abcdefaaaaaaaaaaaaaaaaaaaaaaaa\"").unwrap();
+        assert_eq!(hash.as_ref(), "1234567890abcdefaaaaaaaaaaaaaaaaaaaaaaaa");
+        let json = serde_json::to_string(&hash).unwrap();
+        assert_eq!(json, "\"1234567890abcdefaaaaaaaaaaaaaaaaaaaaaaaa\"");
+
+        let err = serde_json::from_str::<GitHash>("\"abcd\"");
+        assert!(err.is_err());
+    }
 }

--- a/lib/bencher_valid/src/jwt.rs
+++ b/lib/bencher_valid/src/jwt.rs
@@ -182,4 +182,18 @@ mod tests {
     fn jwt_test_token() {
         assert_eq!(true, is_valid_jwt(Jwt::test_token().as_ref()));
     }
+
+    #[test]
+    fn jwt_serde_roundtrip() {
+        let jwt_str = format!("{HEADER}.{PAYLOAD}.{SIGNATURE}");
+        let json_str = format!("\"{jwt_str}\"");
+
+        let jwt: Jwt = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(jwt.as_ref(), jwt_str);
+        let json = serde_json::to_string(&jwt).unwrap();
+        assert_eq!(json, json_str);
+
+        let err = serde_json::from_str::<Jwt>("\"not-a-jwt\"");
+        assert!(err.is_err());
+    }
 }

--- a/lib/bencher_valid/src/non_empty.rs
+++ b/lib/bencher_valid/src/non_empty.rs
@@ -85,4 +85,17 @@ mod tests {
     fn is_valid_non_empty_false() {
         assert_eq!(false, is_valid_non_empty(LEN_0_STR));
     }
+
+    #[test]
+    fn non_empty_serde_roundtrip() {
+        use super::NonEmpty;
+
+        let non_empty: NonEmpty = serde_json::from_str("\"hello\"").unwrap();
+        assert_eq!(non_empty.as_ref(), "hello");
+        let json = serde_json::to_string(&non_empty).unwrap();
+        assert_eq!(json, "\"hello\"");
+
+        let err = serde_json::from_str::<NonEmpty>("\"\"");
+        assert!(err.is_err());
+    }
 }

--- a/lib/bencher_valid/src/plus/brand.rs
+++ b/lib/bencher_valid/src/plus/brand.rs
@@ -21,7 +21,7 @@ const UNKNOWN: &str = "unknown";
 #[typeshare::typeshare]
 #[derive(Debug, Display, Clone, Copy, Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[serde(try_from = "String", rename_all = "snake_case")]
+#[serde(try_from = "String", into = "String", rename_all = "snake_case")]
 pub enum CardBrand {
     Amex,
     Diners,
@@ -111,5 +111,18 @@ mod tests {
         assert_eq!(false, is_valid_card_brand(" amex"));
         assert_eq!(false, is_valid_card_brand("amex "));
         assert_eq!(false, is_valid_card_brand(" amex "));
+    }
+
+    #[test]
+    fn card_brand_serde_roundtrip() {
+        use super::CardBrand;
+
+        let brand: CardBrand = serde_json::from_str("\"amex\"").unwrap();
+        assert_eq!(brand, CardBrand::Amex);
+        let json = serde_json::to_string(&brand).unwrap();
+        assert_eq!(json, "\"amex\"");
+
+        let err = serde_json::from_str::<CardBrand>("\"invalid\"");
+        assert!(err.is_err());
     }
 }

--- a/lib/bencher_valid/src/plus/cvc.rs
+++ b/lib/bencher_valid/src/plus/cvc.rs
@@ -89,4 +89,17 @@ mod tests {
         assert_eq!(false, is_valid_card_cvc("12345"));
         assert_eq!(false, is_valid_card_cvc("bad"));
     }
+
+    #[test]
+    fn card_cvc_serde_roundtrip() {
+        use super::CardCvc;
+
+        let cvc: CardCvc = serde_json::from_str("\"123\"").unwrap();
+        assert_eq!(cvc.as_ref(), "123");
+        let json = serde_json::to_string(&cvc).unwrap();
+        assert_eq!(json, "\"123\"");
+
+        let err = serde_json::from_str::<CardCvc>("\"bad\"");
+        assert!(err.is_err());
+    }
 }

--- a/lib/bencher_valid/src/plus/last_four.rs
+++ b/lib/bencher_valid/src/plus/last_four.rs
@@ -94,4 +94,17 @@ mod tests {
             assert_eq!(false, is_valid_last_four(invalid_number));
         }
     }
+
+    #[test]
+    fn last_four_serde_roundtrip() {
+        use super::LastFour;
+
+        let last_four: LastFour = serde_json::from_str("\"1234\"").unwrap();
+        assert_eq!(last_four.as_ref(), "1234");
+        let json = serde_json::to_string(&last_four).unwrap();
+        assert_eq!(json, "\"1234\"");
+
+        let err = serde_json::from_str::<LastFour>("\"XXXX\"");
+        assert!(err.is_err());
+    }
 }

--- a/lib/bencher_valid/src/plus/number.rs
+++ b/lib/bencher_valid/src/plus/number.rs
@@ -181,4 +181,17 @@ mod tests {
             assert_eq!(false, is_valid_card_number(invalid_number));
         }
     }
+
+    #[test]
+    fn card_number_serde_roundtrip() {
+        use super::CardNumber;
+
+        let number: CardNumber = serde_json::from_str("\"4917300800000000\"").unwrap();
+        assert_eq!(number.as_ref(), "4917300800000000");
+        let json = serde_json::to_string(&number).unwrap();
+        assert_eq!(json, "\"4917300800000000\"");
+
+        let err = serde_json::from_str::<CardNumber>("\"bad\"");
+        assert!(err.is_err());
+    }
 }

--- a/lib/bencher_valid/src/plus/plan_level.rs
+++ b/lib/bencher_valid/src/plus/plan_level.rs
@@ -32,7 +32,7 @@ const BENCHER_ENTERPRISE: &str = "Bencher Enterprise";
     Deserialize,
 )]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[serde(try_from = "String", rename_all = "snake_case")]
+#[serde(try_from = "String", into = "String", rename_all = "snake_case")]
 pub enum PlanLevel {
     #[default]
     Free,
@@ -104,5 +104,18 @@ mod tests {
         assert_eq!(false, is_valid_plan_level(" free"));
         assert_eq!(false, is_valid_plan_level("free "));
         assert_eq!(false, is_valid_plan_level(" free "));
+    }
+
+    #[test]
+    fn plan_level_serde_roundtrip() {
+        use super::PlanLevel;
+
+        let level: PlanLevel = serde_json::from_str("\"team\"").unwrap();
+        assert_eq!(level, PlanLevel::Team);
+        let json = serde_json::to_string(&level).unwrap();
+        assert_eq!(json, "\"team\"");
+
+        let err = serde_json::from_str::<PlanLevel>("\"invalid\"");
+        assert!(err.is_err());
     }
 }

--- a/lib/bencher_valid/src/plus/plan_status.rs
+++ b/lib/bencher_valid/src/plus/plan_status.rs
@@ -21,7 +21,7 @@ const UNPAID: &str = "unpaid";
 #[typeshare::typeshare]
 #[derive(Debug, Display, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[serde(try_from = "String", rename_all = "snake_case")]
+#[serde(try_from = "String", into = "String", rename_all = "snake_case")]
 pub enum PlanStatus {
     Active,
     Canceled,
@@ -116,5 +116,18 @@ mod tests {
         assert_eq!(false, is_valid_plan_status(" active"));
         assert_eq!(false, is_valid_plan_status("active "));
         assert_eq!(false, is_valid_plan_status(" active "));
+    }
+
+    #[test]
+    fn plan_status_serde_roundtrip() {
+        use super::PlanStatus;
+
+        let status: PlanStatus = serde_json::from_str("\"incomplete_expired\"").unwrap();
+        assert_eq!(status, PlanStatus::IncompleteExpired);
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(json, "\"incomplete_expired\"");
+
+        let err = serde_json::from_str::<PlanStatus>("\"invalid\"");
+        assert!(err.is_err());
     }
 }

--- a/lib/bencher_valid/src/resource_name.rs
+++ b/lib/bencher_valid/src/resource_name.rs
@@ -93,4 +93,17 @@ mod tests {
             assert_eq!(false, is_valid_resource_name(value), "{value}");
         }
     }
+
+    #[test]
+    fn resource_name_serde_roundtrip() {
+        use super::ResourceName;
+
+        let name: ResourceName = serde_json::from_str("\"My Resource\"").unwrap();
+        assert_eq!(name.as_ref(), "My Resource");
+        let json = serde_json::to_string(&name).unwrap();
+        assert_eq!(json, "\"My Resource\"");
+
+        let err = serde_json::from_str::<ResourceName>("\"\"");
+        assert!(err.is_err());
+    }
 }

--- a/lib/bencher_valid/src/secret.rs
+++ b/lib/bencher_valid/src/secret.rs
@@ -76,3 +76,20 @@ impl From<Secret> for String {
         secret.0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Secret;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn secret_serde_roundtrip() {
+        let secret: Secret = serde_json::from_str("\"my-secret-key\"").unwrap();
+        assert_eq!(secret.as_ref(), "my-secret-key");
+        let json = serde_json::to_string(&secret).unwrap();
+        assert_eq!(json, "\"my-secret-key\"");
+
+        let err = serde_json::from_str::<Secret>("\"\"");
+        assert!(err.is_err());
+    }
+}

--- a/lib/bencher_valid/src/slug.rs
+++ b/lib/bencher_valid/src/slug.rs
@@ -204,4 +204,15 @@ mod tests {
     fn benchmark_name_issue_610() {
         assert!(Slug::new("...").is_none());
     }
+
+    #[test]
+    fn slug_serde_roundtrip() {
+        let slug: Slug = serde_json::from_str("\"a-valid-slug\"").unwrap();
+        assert_eq!(slug.as_ref(), "a-valid-slug");
+        let json = serde_json::to_string(&slug).unwrap();
+        assert_eq!(json, "\"a-valid-slug\"");
+
+        let err = serde_json::from_str::<Slug>("\"NOT A VALID SLUG\"");
+        assert!(err.is_err());
+    }
 }

--- a/lib/bencher_valid/src/url.rs
+++ b/lib/bencher_valid/src/url.rs
@@ -100,4 +100,17 @@ mod tests {
             assert_eq!(false, is_valid_url(url), "{url}");
         }
     }
+
+    #[test]
+    fn url_serde_roundtrip() {
+        use super::Url;
+
+        let url: Url = serde_json::from_str("\"https://example.com\"").unwrap();
+        assert_eq!(url.as_ref(), "https://example.com");
+        let json = serde_json::to_string(&url).unwrap();
+        assert_eq!(json, "\"https://example.com\"");
+
+        let err = serde_json::from_str::<Url>("\"not a url\"");
+        assert!(err.is_err());
+    }
 }

--- a/lib/bencher_valid/src/user_name.rs
+++ b/lib/bencher_valid/src/user_name.rs
@@ -121,4 +121,17 @@ mod tests {
             assert_eq!(false, is_valid_user_name(name), "{name}");
         }
     }
+
+    #[test]
+    fn user_name_serde_roundtrip() {
+        use super::UserName;
+
+        let name: UserName = serde_json::from_str("\"Muriel Bagge\"").unwrap();
+        assert_eq!(name.as_ref(), "Muriel Bagge");
+        let json = serde_json::to_string(&name).unwrap();
+        assert_eq!(json, "\"Muriel Bagge\"");
+
+        let err = serde_json::from_str::<UserName>("\"Muriel!\"");
+        assert!(err.is_err());
+    }
 }


### PR DESCRIPTION
Instead of using custom `Deserialize` impls, this changeset moves over to using `TryFrom<String>`.
This allows us to use `#[serde(try_from = "String")]`.