### PR TITLE
Fix WebSocket TLS cert verification by including webpki root certificates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4915,7 +4915,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]
@@ -5689,7 +5689,7 @@ dependencies = [
  "smtp-proto",
  "tokio",
  "tokio-rustls 0.26.4",
- "webpki-roots",
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]
@@ -7660,7 +7660,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]
@@ -9519,6 +9519,7 @@ dependencies = [
  "sha1",
  "thiserror 2.0.17",
  "utf-8",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -9691,7 +9692,7 @@ dependencies = [
  "serde_json",
  "ureq-proto",
  "utf-8",
- "webpki-roots",
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]
@@ -9987,6 +9988,15 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ tokio = "1.48"
 tokio-rustls = {version =  "0.26", default-features = false, features = ["logging", "tls12", "ring"]}
 tokio-tungstenite = "0.26"
 tokio-util = { version = "0.7", features = ["io"] }
-tungstenite = { version = "0.26", features = ["__rustls-tls"] }
+tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
 typeshare = "1.0"
 ureq = "3.0"
 url = "2.5"


### PR DESCRIPTION
The tungstenite dependency was using the internal `__rustls-tls` feature
which enables rustls but does not include any root certificate store.
This caused "invalid peer certificate: UnknownIssuer" errors because
rustls had no trusted CAs to verify server certificates against.

Switch to `rustls-tls-webpki-roots` which bundles Mozilla's trusted
root certificates, matching how the HTTP client already works.