### PR TITLE
Fix gungraun benchmark name (#778)

### DIFF
--- a/lib/bencher_adapter/src/adapters/rust/gungraun.rs
+++ b/lib/bencher_adapter/src/adapters/rust/gungraun.rs
@@ -103,7 +103,31 @@ fn single_benchmark<'a>()
         |(benchmark_name, measures)| {
             // trim here to avoid loose `\r` chars at the end of the string because of the
             // `not_benchmark_name_end` parser. It's maybe not a bad idea anyways.
-            let benchmark_name = benchmark_name.trim().parse().ok()?;
+            let trimmed = benchmark_name.trim();
+
+            // As of v0.18.0, the possible values and cases to handle for the first line(s) are
+            //
+            // `file::group::func`, No id (which is fine, the module path is unique in this case)
+            // `file::group::func :description`, No/Empty id
+            // `file::group::func (rest`, No id, the description in this case starts with a `(`
+            // `file::group::func id`, No description, (also fine)
+            // `file::group::func id:`, This was a possibility but not in recent releases
+            // `file::group::func id:description`, The standard case
+            let (module_path, rest) = trimmed.split_once(' ').unwrap_or((trimmed, ""));
+            let id_end = rest
+                .chars()
+                .position(|c| !(c.is_ascii_alphanumeric() || c == '_'))
+                .or(Some(rest.len()))
+                .and_then(|c| (c > 0).then_some(c));
+
+            let benchmark_name = if let Some(id_end) = id_end {
+                // The `None` case should not happen and would be a hard error
+                trimmed.get(0..module_path.len() + 1 + id_end)?
+            } else {
+                module_path
+            };
+
+            let benchmark_name = benchmark_name.parse().ok()?;
             let measures = measures.into_iter().flatten().collect();
 
             Some((benchmark_name, measures))
@@ -514,7 +538,7 @@ pub(crate) mod test_rust_gungraun {
             compare_benchmark(
                 &expected,
                 &results,
-                "rust_iai_callgrind::bench_fibonacci_group::bench_fibonacci short:10",
+                "rust_iai_callgrind::bench_fibonacci_group::bench_fibonacci short",
             );
         }
 
@@ -531,7 +555,7 @@ pub(crate) mod test_rust_gungraun {
             compare_benchmark(
                 &expected,
                 &results,
-                "rust_iai_callgrind::bench_fibonacci_group::bench_fibonacci long:30",
+                "rust_iai_callgrind::bench_fibonacci_group::bench_fibonacci long",
             );
         }
     }
@@ -593,7 +617,7 @@ pub(crate) mod test_rust_gungraun {
             compare_benchmark(
                 &expected,
                 &results,
-                "rust_iai_callgrind::bench_fibonacci_group::bench_fibonacci short:10",
+                "rust_iai_callgrind::bench_fibonacci_group::bench_fibonacci short",
             );
         }
 
@@ -603,7 +627,7 @@ pub(crate) mod test_rust_gungraun {
             compare_benchmark(
                 &expected,
                 &results,
-                "rust_iai_callgrind::bench_fibonacci_group::bench_fibonacci long:30",
+                "rust_iai_callgrind::bench_fibonacci_group::bench_fibonacci long",
             );
         }
     }
@@ -1011,7 +1035,7 @@ pub(crate) mod test_rust_gungraun {
             compare_benchmark(
                 &expected,
                 &results,
-                "rust_iai_callgrind::bench::multiple_lines id:string with two\nlines",
+                "rust_iai_callgrind::bench::multiple_lines id_0",
             );
         }
 
@@ -1030,7 +1054,7 @@ pub(crate) mod test_rust_gungraun {
             compare_benchmark(
                 &expected,
                 &results,
-                "rust_iai_callgrind::bench::multiple_lines id:string with multiple\nlines\nand one more",
+                "rust_iai_callgrind::bench::multiple_lines id_1",
             );
         }
     }
@@ -1060,7 +1084,7 @@ pub(crate) mod test_rust_gungraun {
             compare_benchmark(
                 &expected,
                 &results,
-                "rust_iai_callgrind::bench::multiple_lines id:first with one line",
+                "rust_iai_callgrind::bench::multiple_lines id_0",
             );
         }
 
@@ -1079,7 +1103,7 @@ pub(crate) mod test_rust_gungraun {
             compare_benchmark(
                 &expected,
                 &results,
-                "rust_iai_callgrind::bench::multiple_lines id:two\nlines",
+                "rust_iai_callgrind::bench::multiple_lines id_1",
             );
         }
 
@@ -1098,9 +1122,60 @@ pub(crate) mod test_rust_gungraun {
             compare_benchmark(
                 &expected,
                 &results,
-                "rust_iai_callgrind::bench::multiple_lines id:last with one line",
+                "rust_iai_callgrind::bench::multiple_lines id_2",
             );
         }
+    }
+
+    #[test]
+    fn name_with_valid_benchmark_ids() {
+        use gungraun::*;
+
+        let results =
+            convert_file_path::<AdapterRustGungraun>("./tool_output/rust/gungraun/valid_ids.txt");
+
+        let mut expected = HashMap::new();
+        expected.extend([(Instructions::SLUG_STR, 1734.0)]);
+
+        assert_eq!(results.inner.len(), 9);
+
+        compare_benchmark(&expected, &results, "rust_gungraun::some_group::no_id");
+        compare_benchmark(
+            &expected,
+            &results,
+            "rust_gungraun::some_group::no_id_but_description_0",
+        );
+        compare_benchmark(
+            &expected,
+            &results,
+            "rust_gungraun::some_group::no_id_but_description_1",
+        );
+        compare_benchmark(
+            &expected,
+            &results,
+            "rust_gungraun::some_group::no_id_multiline_description",
+        );
+        compare_benchmark(&expected, &results, "rust_gungraun::some_group::just_id id");
+        compare_benchmark(
+            &expected,
+            &results,
+            "rust_gungraun::some_group::id_with_alnum id_123_xyz",
+        );
+        compare_benchmark(
+            &expected,
+            &results,
+            "rust_gungraun::some_group::id_with_empty_description id_0",
+        );
+        compare_benchmark(
+            &expected,
+            &results,
+            "rust_gungraun::some_group::id_with_description id_with_description",
+        );
+        compare_benchmark(
+            &expected,
+            &results,
+            "rust_gungraun::some_group::id_with_description id_space_after_color",
+        );
     }
 
     #[derive(Default)]
@@ -1147,7 +1222,7 @@ pub(crate) mod test_rust_gungraun {
             compare_benchmark(
                 &expected,
                 results,
-                "rust_iai_callgrind::bench_fibonacci_group::bench_fibonacci short:10",
+                "rust_iai_callgrind::bench_fibonacci_group::bench_fibonacci short",
             );
         }
 
@@ -1183,7 +1258,7 @@ pub(crate) mod test_rust_gungraun {
             compare_benchmark(
                 &expected,
                 results,
-                "rust_iai_callgrind::bench_fibonacci_group::bench_fibonacci long:30",
+                "rust_iai_callgrind::bench_fibonacci_group::bench_fibonacci long",
             );
         }
     }

--- a/lib/bencher_adapter/tool_output/rust/gungraun/name_on_multiple_lines.txt
+++ b/lib/bencher_adapter/tool_output/rust/gungraun/name_on_multiple_lines.txt
@@ -3,7 +3,7 @@ running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
 
-rust_iai_callgrind::bench::multiple_lines id:string with two
+rust_iai_callgrind::bench::multiple_lines id_0:string with two
 lines
   Instructions:                   1|N/A             (*********)
   L1 Hits:                        2|N/A             (*********)
@@ -11,7 +11,7 @@ lines
   RAM Hits:                       4|N/A             (*********)
   Total read+write:               5|N/A             (*********)
   Estimated Cycles:               6|N/A             (*********)
-rust_iai_callgrind::bench::multiple_lines id:string with multiple
+rust_iai_callgrind::bench::multiple_lines id_1:string with multiple
 lines
 and one more
   Instructions:                   7|N/A             (*********)

--- a/lib/bencher_adapter/tool_output/rust/gungraun/name_on_multiple_lines_mixed.txt
+++ b/lib/bencher_adapter/tool_output/rust/gungraun/name_on_multiple_lines_mixed.txt
@@ -3,14 +3,14 @@ running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
 
-rust_iai_callgrind::bench::multiple_lines id:first with one line
+rust_iai_callgrind::bench::multiple_lines id_0:first with one line
   Instructions:                   1|N/A             (*********)
   L1 Hits:                        2|N/A             (*********)
   L2 Hits:                        3|N/A             (*********)
   RAM Hits:                       4|N/A             (*********)
   Total read+write:               5|N/A             (*********)
   Estimated Cycles:               6|N/A             (*********)
-rust_iai_callgrind::bench::multiple_lines id:two
+rust_iai_callgrind::bench::multiple_lines id_1:two
 lines
   Instructions:                   7|N/A             (*********)
   L1 Hits:                        8|N/A             (*********)
@@ -18,7 +18,7 @@ lines
   RAM Hits:                      10|N/A             (*********)
   Total read+write:              11|N/A             (*********)
   Estimated Cycles:              12|N/A             (*********)
-rust_iai_callgrind::bench::multiple_lines id:last with one line
+rust_iai_callgrind::bench::multiple_lines id_2:last with one line
   Instructions:                  13|N/A             (*********)
   L1 Hits:                       14|N/A             (*********)
   L2 Hits:                       15|N/A             (*********)

--- a/lib/bencher_adapter/tool_output/rust/gungraun/valid_ids.txt
+++ b/lib/bencher_adapter/tool_output/rust/gungraun/valid_ids.txt
@@ -1,0 +1,24 @@
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+rust_gungraun::some_group::no_id
+  Instructions:                1734|N/A             (*********)
+rust_gungraun::some_group::no_id_but_description_0 :some description
+  Instructions:                1734|N/A             (*********)
+rust_gungraun::some_group::no_id_but_description_1 () -> echo
+  Instructions:                1734|N/A             (*********)
+rust_gungraun::some_group::no_id_multiline_description :multiline
+description
+  Instructions:                1734|N/A             (*********)
+rust_gungraun::some_group::just_id id
+  Instructions:                1734|N/A             (*********)
+rust_gungraun::some_group::id_with_alnum id_123_xyz
+  Instructions:                1734|N/A             (*********)
+rust_gungraun::some_group::id_with_empty_description id_0:
+  Instructions:                1734|N/A             (*********)
+rust_gungraun::some_group::id_with_description id_with_description:some description
+  Instructions:                1734|N/A             (*********)
+rust_gungraun::some_group::id_with_description id_space_after_color: some description
+  Instructions:                1734|N/A             (*********)


### PR DESCRIPTION
Fix gungraun benchmark name parsing to exclude (truncated) descriptions

This PR fixes the gungraun adapter to correctly parse benchmark names by using only the module path and optional id, excluding the description. Previously, the entire first line(s) (including truncated descriptions) was used as the benchmark name. The benchmark name is now also much shorter which makes it very unlikely to hit the `MAX_BENCHMARK_NAME_LEN` limit.

- Updated parsing logic in single_benchmark() to properly extract benchmark names.
- Updated tests:
   - Fixed existing test expectations (benchmark names no longer include descriptions)
   - Added test covering all valid ID formats

Before: `file::group::function id:some description possibly truncated with ...`
After: `file::group::function id`

Fixes: #778
Related: #638