### PR TITLE
Remove diagram generation from Console builds

### DIFF
--- a/services/console/CLAUDE.md
+++ b/services/console/CLAUDE.md
@@ -70,7 +70,7 @@ npm run wasm
 
 Architecture and schema diagrams are defined as Mermaid `.mmd` files in `diagrams/` and pre-rendered to SVGs in `diagrams/output/` using `@mermaid-js/mermaid-cli`.
 
-When modifying `.mmd` files, run `npm run diagrams` and commit the updated SVGs.
+`npm run diagrams` is **not** run automatically by `npm run dev` or `npm run setup` because `mmdc` output is not deterministic and would produce noisy diffs on every dev startup. When modifying `.mmd` files, run `npm run diagrams` manually and commit the updated SVGs.
 
 ## Documentation
 

--- a/services/console/package.json
+++ b/services/console/package.json
@@ -11,7 +11,7 @@
 		"wasm:not-plus": "IS_BENCHER_PLUS=false npm run wasm",
 		"copy": "rm -rf ./public/download ./public/diagrams && cp -r ../cli/templates/output ./public/download && cp ../runner/templates/output/* ./public/download/ && cp ../api/openapi.json ./public/download/openapi.json && cp -r diagrams/output ./public/diagrams",
 		"diagrams": "mkdir -p diagrams/output && mmdc -i diagrams/architecture.mmd -o diagrams/output/architecture.svg && mmdc -i diagrams/schema.mmd -o diagrams/output/schema.svg && mmdc -i diagrams/bare-metal.mmd -o diagrams/output/bare-metal.svg",
-		"setup": "npm run typeshare && npm run wasm && npm run diagrams && npm run copy",
+		"setup": "npm run typeshare && npm run wasm && npm run copy",
 		"dev": "npm run setup && export BENCHER_API_URL=http://127.0.0.1:61016 && export OAUTH_GITHUB=true && export OAUTH_GOOGLE=true && astro dev --port 3000",
 		"dev:not-plus": "IS_BENCHER_PLUS=false npm run dev",
 		"start": "astro dev --port 3000",


### PR DESCRIPTION
This changeset removes diagram generation from the Console builds due to Mermaid diagram SVG generation being non-deterministic.