### PR TITLE
Add a helper task for indexing doc pages

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -14,6 +14,7 @@ plus = [
     "dep:reqwest",
     "dep:serde_json",
     "bencher_client/plus",
+    "bencher_client/rustls-tls",
     "bencher_json/plus",
     "bencher_license/plus",
     "clap/env",

--- a/xtask/src/parser/mod.rs
+++ b/xtask/src/parser/mod.rs
@@ -7,7 +7,7 @@ pub use live::TaskLive;
 #[cfg(feature = "plus")]
 pub use plus::{
     email_list::TaskEmailList,
-    index::{TaskIndex, TaskIndexDelete, TaskIndexUpdate, TaskSearchEngine},
+    index::{TaskIndex, TaskIndexDelete, TaskIndexDocs, TaskIndexUpdate, TaskSearchEngine},
     license::{TaskBillingCycle, TaskLicense, TaskLicenseGenerate, TaskLicenseValidate},
     stats::TaskStats,
 };

--- a/xtask/src/parser/plus/index.rs
+++ b/xtask/src/parser/plus/index.rs
@@ -2,9 +2,9 @@ use clap::{Parser, Subcommand, ValueEnum};
 
 #[derive(Subcommand, Debug)]
 pub enum TaskIndex {
-    /// Generate a license key
+    /// Submit URLs to search engine indexes
     Update(TaskIndexUpdate),
-    /// Validate a license key
+    /// Remove URLs from search engine indexes
     Delete(TaskIndexDelete),
     /// Submit an English page path and all 8 translated variants
     Docs(TaskIndexDocs),

--- a/xtask/src/parser/plus/index.rs
+++ b/xtask/src/parser/plus/index.rs
@@ -6,6 +6,8 @@ pub enum TaskIndex {
     Update(TaskIndexUpdate),
     /// Validate a license key
     Delete(TaskIndexDelete),
+    /// Submit an English page path and all 8 translated variants
+    Docs(TaskIndexDocs),
 }
 
 #[derive(Parser, Debug)]
@@ -19,6 +21,16 @@ pub struct TaskIndexUpdate {
 }
 
 pub type TaskIndexDelete = TaskIndexUpdate;
+
+#[derive(Parser, Debug)]
+pub struct TaskIndexDocs {
+    /// Search engine
+    #[clap(value_enum, long)]
+    pub engine: Option<TaskSearchEngine>,
+
+    /// Path (e.g. /learn/benchmarking/rust/criterion/)
+    pub path: Vec<String>,
+}
 
 #[derive(ValueEnum, Debug, Clone, Copy)]
 #[clap(rename_all = "snake_case")]

--- a/xtask/src/task/plus/index/docs.rs
+++ b/xtask/src/task/plus/index/docs.rs
@@ -1,0 +1,157 @@
+use url::Url;
+
+use crate::parser::TaskIndexDocs;
+
+use super::update::Update;
+
+const BENCHER_DEV: &str = "https://bencher.dev";
+
+// Canonical list lives in `services/console/src/i18n/ui.ts:6-16`.
+// English is handled separately (no prefix), so this only holds the 8 prefixed locales.
+const NON_EN_LANGS: [&str; 8] = ["de", "es", "fr", "ja", "ko", "pt", "ru", "zh"];
+
+#[derive(Debug)]
+pub struct Docs {
+    update: Update,
+}
+
+impl TryFrom<TaskIndexDocs> for Docs {
+    type Error = anyhow::Error;
+
+    fn try_from(docs: TaskIndexDocs) -> Result<Self, Self::Error> {
+        let TaskIndexDocs { engine, path } = docs;
+        if path.is_empty() {
+            anyhow::bail!("Path is empty");
+        }
+        let url = path
+            .into_iter()
+            .map(|p| expand_path(&p))
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .flatten()
+            .collect();
+        Ok(Self {
+            update: Update::new(engine.map(Into::into), url),
+        })
+    }
+}
+
+impl Docs {
+    pub async fn exec(&self) -> anyhow::Result<()> {
+        self.update.exec().await
+    }
+}
+
+fn expand_path(path: &str) -> anyhow::Result<Vec<Url>> {
+    if !path.starts_with('/') {
+        anyhow::bail!("Path `{path}` must start with `/`");
+    }
+    let base = Url::parse(&format!("{BENCHER_DEV}{path}"))?;
+    validate_en_path(&base)?;
+    // English first (original, unprefixed), then the 8 translated variants.
+    let mut urls = vec![base.clone()];
+    urls.extend(NON_EN_LANGS.iter().map(|lang| lang_url(&base, lang)));
+    Ok(urls)
+}
+
+fn validate_en_path(url: &Url) -> anyhow::Result<()> {
+    if let Some(first) = url.path_segments().and_then(|mut s| s.next())
+        && NON_EN_LANGS.contains(&first)
+    {
+        anyhow::bail!(
+            "Path already has a non-English locale prefix `/{first}/`; pass the English (unprefixed) path"
+        );
+    }
+    Ok(())
+}
+
+fn lang_url(base: &Url, lang: &str) -> Url {
+    let mut url = base.clone();
+    // `base.path()` always starts with `/`, so this yields `/{lang}/...`.
+    let new_path = format!("/{lang}{}", base.path());
+    url.set_path(&new_path);
+    url
+}
+
+#[cfg(test)]
+mod tests {
+    use url::Url;
+
+    use super::{expand_path, lang_url, validate_en_path};
+
+    #[test]
+    fn expand_path_constructs_all_urls() {
+        let urls = expand_path("/learn/benchmarking/rust/criterion/").unwrap();
+        assert_eq!(urls.len(), 9);
+        assert_eq!(
+            urls.first().map(Url::as_str),
+            Some("https://bencher.dev/learn/benchmarking/rust/criterion/"),
+        );
+        assert_eq!(
+            urls.get(1).map(Url::as_str),
+            Some("https://bencher.dev/de/learn/benchmarking/rust/criterion/"),
+        );
+    }
+
+    #[test]
+    fn expand_path_rejects_missing_leading_slash() {
+        let err = expand_path("learn/benchmarking/").unwrap_err().to_string();
+        assert!(err.contains("must start with `/`"), "error was: {err}");
+    }
+
+    #[test]
+    fn expand_path_rejects_locale_prefix() {
+        let err = expand_path("/de/learn/benchmarking/")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("/de/"), "error was: {err}");
+    }
+
+    #[test]
+    fn lang_url_prepends_locale() {
+        let base = Url::parse("https://bencher.dev/learn/benchmarking/rust/criterion/").unwrap();
+        assert_eq!(
+            lang_url(&base, "de").as_str(),
+            "https://bencher.dev/de/learn/benchmarking/rust/criterion/",
+        );
+    }
+
+    #[test]
+    fn lang_url_preserves_trailing_slash() {
+        let with_slash = Url::parse("https://bencher.dev/learn/").unwrap();
+        assert_eq!(
+            lang_url(&with_slash, "ja").as_str(),
+            "https://bencher.dev/ja/learn/",
+        );
+        let without_slash = Url::parse("https://bencher.dev/learn").unwrap();
+        assert_eq!(
+            lang_url(&without_slash, "ja").as_str(),
+            "https://bencher.dev/ja/learn",
+        );
+    }
+
+    #[test]
+    fn lang_url_handles_root() {
+        let root = Url::parse("https://bencher.dev/").unwrap();
+        assert_eq!(lang_url(&root, "fr").as_str(), "https://bencher.dev/fr/");
+    }
+
+    #[test]
+    fn validate_accepts_en_path() {
+        let url = Url::parse("https://bencher.dev/learn/benchmarking/rust/criterion/").unwrap();
+        assert!(validate_en_path(&url).is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_root() {
+        let root = Url::parse("https://bencher.dev/").unwrap();
+        assert!(validate_en_path(&root).is_ok());
+    }
+
+    #[test]
+    fn validate_allows_lookalike_path() {
+        // `deutsch` starts with `de` but is not an exact segment match.
+        let url = Url::parse("https://bencher.dev/deutsch/learn/").unwrap();
+        assert!(validate_en_path(&url).is_ok());
+    }
+}

--- a/xtask/src/task/plus/index/engine.rs
+++ b/xtask/src/task/plus/index/engine.rs
@@ -47,7 +47,7 @@ impl SearchEngine {
     }
 
     fn google() -> anyhow::Result<GoogleIndex> {
-        let service_key = std::fs::read_to_string("./plus/bencher_google/google.json")?;
+        let service_key = std::fs::read_to_string("./plus/bencher_google_index/google.json")?;
         GoogleIndex::from_str(&service_key).map_err(Into::into)
     }
 }

--- a/xtask/src/task/plus/index/mod.rs
+++ b/xtask/src/task/plus/index/mod.rs
@@ -1,6 +1,7 @@
 use crate::parser::TaskIndex;
 
 mod delete;
+mod docs;
 mod engine;
 mod update;
 
@@ -8,6 +9,7 @@ mod update;
 pub enum Index {
     Update(update::Update),
     Delete(delete::Delete),
+    Docs(docs::Docs),
 }
 
 impl TryFrom<TaskIndex> for Index {
@@ -17,6 +19,7 @@ impl TryFrom<TaskIndex> for Index {
         Ok(match index {
             TaskIndex::Update(update) => Self::Update(update.try_into()?),
             TaskIndex::Delete(delete) => Self::Delete(delete.try_into()?),
+            TaskIndex::Docs(docs) => Self::Docs(docs.try_into()?),
         })
     }
 }
@@ -26,6 +29,7 @@ impl Index {
         match self {
             Self::Update(update) => update.exec().await,
             Self::Delete(delete) => delete.exec().await,
+            Self::Docs(docs) => docs.exec().await,
         }
     }
 }

--- a/xtask/src/task/plus/index/update.rs
+++ b/xtask/src/task/plus/index/update.rs
@@ -24,6 +24,10 @@ impl TryFrom<TaskIndexUpdate> for Update {
 }
 
 impl Update {
+    pub fn new(engine: Option<SearchEngine>, url: Vec<url::Url>) -> Self {
+        Self { engine, url }
+    }
+
     pub async fn exec(&self) -> anyhow::Result<()> {
         for url in &self.url {
             if let Some(engine) = self.engine {


### PR DESCRIPTION
This changeset adds the `cargo xtask index docs` subcommand. This is a convenience wrapper around the existing `cargo xtask index update` subcommand to handle the common use case of wanting to index all 9 language version for a given [Bencher Docs](https://bencher.dev/docs/) path.