### PR TITLE
Move to `immediate_transaction` for transactions that include a write

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,7 @@ The clippy script will install the target automatically and warn if no cross-com
   - `write_conn!()` - For single writer access
 - Use `diesel::QueryResult<T>` instead of `Result<T, diesel::result::Error>` — it is a type alias and more idiomatic
 - Database write methods that may be called both standalone and from within an outer transaction should NOT wrap in `conn.transaction()` internally. Instead, the standalone callers should wrap the call in a transaction. This avoids unnecessary SQLite savepoints when the method is called from batch operations.
+- Use the `write_transaction!()` macro (or `conn.immediate_transaction(...)` on an existing writer `&mut DbConnection`) for any transaction that writes — never `conn.transaction(...)`.
 
 ## Scripts Policy
 

--- a/lib/bencher_config/src/config_tx.rs
+++ b/lib/bencher_config/src/config_tx.rs
@@ -216,6 +216,11 @@ async fn into_context(
     database_connection
         .batch_execute("PRAGMA synchronous = NORMAL")
         .map_err(ConfigTxError::Pragma)?;
+    // Surfaces `SQLITE_BUSY_SNAPSHOT` (517) etc. distinctly from plain `SQLITE_BUSY` (5)
+    // in error messages, instead of both rendering as "database is locked".
+    database_connection
+        .batch_execute("PRAGMA extended_result_codes = ON")
+        .map_err(ConfigTxError::Pragma)?;
 
     #[cfg(feature = "plus")]
     if plus
@@ -427,6 +432,8 @@ impl diesel::r2d2::CustomizeConnection<DbConnection, diesel::r2d2::Error>
         conn.batch_execute(&format!("PRAGMA busy_timeout = {}", self.busy_timeout))
             .map_err(diesel::r2d2::Error::QueryError)?;
         conn.batch_execute("PRAGMA synchronous = NORMAL")
+            .map_err(diesel::r2d2::Error::QueryError)?;
+        conn.batch_execute("PRAGMA extended_result_codes = ON")
             .map_err(diesel::r2d2::Error::QueryError)?;
         Ok(())
     }

--- a/lib/bencher_schema/src/context/mod.rs
+++ b/lib/bencher_schema/src/context/mod.rs
@@ -121,6 +121,23 @@ macro_rules! write_conn {
     };
 }
 
+// `BEGIN IMMEDIATE` (not the diesel default `BEGIN` deferred): take the writer lock at
+// transaction start. Deferred begins as a reader and fails the read→write upgrade with
+// `SQLITE_BUSY_SNAPSHOT` (which bypasses `busy_timeout`) when the WAL has advanced since
+// `BEGIN` — e.g. between a Litestream PASSIVE checkpoint and the first `INSERT`.
+// `BEGIN IMMEDIATE` has no read-snapshot to invalidate, so contention waits via `busy_timeout`.
+//
+// Does NOT compose: nested calls fail with "cannot start a transaction within a transaction"
+// (unlike `transaction()`, which auto-savepoints when nested). Helper functions called from
+// inside an outer transaction must keep `transaction()`.
+#[macro_export]
+macro_rules! write_transaction {
+    ($context:expr, |$conn:ident| $body:expr) => {{
+        let mut __guard = $context.database.connection.lock().await;
+        __guard.immediate_transaction(|$conn| $body)
+    }};
+}
+
 impl ApiContext {
     #[cfg(feature = "plus")]
     pub fn biller(&self) -> Result<&Biller, HttpError> {

--- a/lib/bencher_schema/src/model/organization/mod.rs
+++ b/lib/bencher_schema/src/model/organization/mod.rs
@@ -13,7 +13,7 @@ use bencher_json::{
 use bencher_rbac::{Organization, organization::Permission};
 #[cfg(feature = "plus")]
 use diesel::BelongingToDsl as _;
-use diesel::{Connection as _, ExpressionMethods as _, QueryDsl as _, Queryable, RunQueryDsl as _};
+use diesel::{ExpressionMethods as _, QueryDsl as _, Queryable, RunQueryDsl as _};
 use dropshot::HttpError;
 use organization_role::{InsertOrganizationRole, QueryOrganizationRole};
 #[cfg(feature = "plus")]
@@ -36,7 +36,7 @@ use crate::{
     model::user::auth::AuthUser,
     public_conn, resource_conflict_err, resource_not_found_err,
     schema::{self, organization as organization_table},
-    write_conn,
+    write_conn, write_transaction,
 };
 
 use super::user::QueryUser;
@@ -176,28 +176,25 @@ impl QueryOrganization {
         let timestamp = DateTime::now();
         let user_id = auth_user.id;
 
-        let query_organization = {
-            let conn = write_conn!(context);
-            conn.transaction(|conn| {
-                let id = Self::insert(conn, &insert_organization)?;
+        let query_organization = write_transaction!(context, |conn| {
+            let id = Self::insert(conn, &insert_organization)?;
 
-                // Connect the user to the organization as a `Leader`
-                let insert_org_role = InsertOrganizationRole {
-                    user_id,
-                    organization_id: id,
-                    role: OrganizationRole::Leader,
-                    created: timestamp,
-                    modified: timestamp,
-                };
-                diesel::insert_into(schema::organization_role::table)
-                    .values(&insert_org_role)
-                    .execute(conn)?;
+            // Connect the user to the organization as a `Leader`
+            let insert_org_role = InsertOrganizationRole {
+                user_id,
+                organization_id: id,
+                role: OrganizationRole::Leader,
+                created: timestamp,
+                modified: timestamp,
+            };
+            diesel::insert_into(schema::organization_role::table)
+                .values(&insert_org_role)
+                .execute(conn)?;
 
-                diesel::QueryResult::Ok(id)
-            })
-            .map_err(resource_conflict_err!(Organization, &insert_organization))
-            .map(|id| insert_organization.into_query(id))?
-        };
+            diesel::QueryResult::Ok(id)
+        })
+        .map_err(resource_conflict_err!(Organization, &insert_organization))
+        .map(|id| insert_organization.into_query(id))?;
 
         #[cfg(feature = "otel")]
         bencher_otel::ApiMeter::increment(bencher_otel::ApiCounter::OrganizationCreate);
@@ -209,12 +206,10 @@ impl QueryOrganization {
         context: &ApiContext,
         insert_organization: InsertOrganization,
     ) -> Result<Self, HttpError> {
-        let query_organization = {
-            let conn = write_conn!(context);
-            conn.transaction(|conn| Self::insert(conn, &insert_organization))
+        let query_organization =
+            write_transaction!(context, |conn| Self::insert(conn, &insert_organization))
                 .map_err(resource_conflict_err!(Organization, &insert_organization))
-                .map(|id| insert_organization.into_query(id))?
-        };
+                .map(|id| insert_organization.into_query(id))?;
 
         #[cfg(feature = "otel")]
         bencher_otel::ApiMeter::increment(bencher_otel::ApiCounter::OrganizationCreate);
@@ -703,7 +698,7 @@ impl From<&QueryOrganization> for Organization {
 
 #[cfg(test)]
 mod tests {
-    use diesel::{Connection as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
+    use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 
     use bencher_json::DateTime;
 
@@ -716,7 +711,7 @@ mod tests {
         let uuid = "00000000-0000-0000-0000-000000000010";
 
         let (rowid, select_id) = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 diesel::insert_into(schema::organization::table)
                     .values((
                         schema::organization::uuid.eq(uuid),
@@ -760,7 +755,7 @@ mod tests {
         // Insert second + verify
         let second_uuid = "00000000-0000-0000-0000-000000000011";
         let (rowid, select_id) = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 diesel::insert_into(schema::organization::table)
                     .values((
                         schema::organization::uuid.eq(second_uuid),

--- a/lib/bencher_schema/src/model/project/benchmark.rs
+++ b/lib/bencher_schema/src/model/project/benchmark.rs
@@ -2,7 +2,7 @@ use bencher_json::{
     BenchmarkName, BenchmarkNameId, BenchmarkSlug, BenchmarkUuid, DateTime, JsonBenchmark, NameId,
     project::benchmark::{JsonNewBenchmark, JsonUpdateBenchmark},
 };
-use diesel::{Connection as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
+use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 use dropshot::HttpError;
 
 use super::{ProjectId, QueryProject};
@@ -18,7 +18,7 @@ use crate::{
         sql::last_insert_rowid,
     },
     schema::{self, benchmark as benchmark_table},
-    write_conn,
+    write_conn, write_transaction,
 };
 
 crate::macros::typed_id::typed_id!(BenchmarkId);
@@ -121,8 +121,7 @@ impl QueryBenchmark {
         let insert_benchmark =
             InsertBenchmark::from_json(auth_conn!(context), project_id, json_benchmark);
 
-        let conn = write_conn!(context);
-        conn.transaction(|conn| {
+        write_transaction!(context, |conn| {
             diesel::insert_into(schema::benchmark::table)
                 .values(&insert_benchmark)
                 .execute(conn)?;
@@ -259,7 +258,7 @@ impl UpdateBenchmark {
 
 #[cfg(test)]
 mod tests {
-    use diesel::{Connection as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
+    use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 
     use bencher_json::DateTime;
 
@@ -277,7 +276,7 @@ mod tests {
         let uuid = "00000000-0000-0000-0000-000000000010";
 
         let (rowid, select_id) = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 diesel::insert_into(schema::benchmark::table)
                     .values((
                         schema::benchmark::uuid.eq(uuid),
@@ -323,7 +322,7 @@ mod tests {
         // Insert second + verify
         let second_uuid = "00000000-0000-0000-0000-000000000011";
         let (rowid, select_id) = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 diesel::insert_into(schema::benchmark::table)
                     .values((
                         schema::benchmark::uuid.eq(second_uuid),
@@ -363,7 +362,7 @@ mod tests {
 
         // Insert and read back within same transaction
         let (inserted_id, readback_name) = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 diesel::insert_into(schema::benchmark::table)
                     .values((
                         schema::benchmark::uuid.eq(uuid),

--- a/lib/bencher_schema/src/model/project/branch/head.rs
+++ b/lib/bencher_schema/src/model/project/branch/head.rs
@@ -3,8 +3,8 @@ use bencher_json::{
     project::head::{JsonVersion, VersionNumber},
 };
 use diesel::{
-    Connection as _, ExpressionMethods as _, JoinOnDsl as _, NullableExpressionMethods as _,
-    QueryDsl as _, RunQueryDsl as _, SelectableHelper as _,
+    ExpressionMethods as _, JoinOnDsl as _, NullableExpressionMethods as _, QueryDsl as _,
+    RunQueryDsl as _, SelectableHelper as _,
 };
 
 use dropshot::HttpError;
@@ -26,7 +26,7 @@ use crate::{
         threshold::{InsertThreshold, alert::QueryAlert},
     },
     schema::{self, head as head_table},
-    write_conn,
+    write_conn, write_transaction,
 };
 
 crate::macros::typed_id::typed_id!(HeadId);
@@ -276,44 +276,39 @@ impl InsertHead {
         let old_head_id = query_branch.head_id;
 
         // Phase 2: Batch all writes in a single transaction
-        let (new_head_id, silenced_alerts) = {
-            let conn = write_conn!(context);
-            conn.transaction(|conn| {
-                // Insert the new head
-                diesel::insert_into(schema::head::table)
-                    .values(&insert_head)
-                    .execute(conn)?;
-                let new_head_id: HeadId = diesel::select(last_insert_rowid()).get_result(conn)?;
+        let (new_head_id, silenced_alerts) = write_transaction!(context, |conn| {
+            // Insert the new head
+            diesel::insert_into(schema::head::table)
+                .values(&insert_head)
+                .execute(conn)?;
+            let new_head_id: HeadId = diesel::select(last_insert_rowid()).get_result(conn)?;
 
-                // Update the branch to point to the new head
-                diesel::update(
-                    schema::branch::table.filter(schema::branch::id.eq(query_branch.id)),
-                )
+            // Update the branch to point to the new head
+            diesel::update(schema::branch::table.filter(schema::branch::id.eq(query_branch.id)))
                 .set(schema::branch::head_id.eq(new_head_id))
                 .execute(conn)?;
 
-                // If there is an old head, mark it as replaced and silence its alerts
-                let silenced_alerts = if let Some(old_head_id) = old_head_id {
-                    let update_head = UpdateHead::replace();
-                    diesel::update(schema::head::table.filter(schema::head::id.eq(old_head_id)))
-                        .set(&update_head)
-                        .execute(conn)?;
+            // If there is an old head, mark it as replaced and silence its alerts
+            let silenced_alerts = if let Some(old_head_id) = old_head_id {
+                let update_head = UpdateHead::replace();
+                diesel::update(schema::head::table.filter(schema::head::id.eq(old_head_id)))
+                    .set(&update_head)
+                    .execute(conn)?;
 
-                    QueryAlert::silence_all(conn, old_head_id)?
-                } else {
-                    0
-                };
+                QueryAlert::silence_all(conn, old_head_id)?
+            } else {
+                0
+            };
 
-                diesel::QueryResult::Ok((new_head_id, silenced_alerts))
-            })
-            .map_err(|e| {
-                issue_error(
-                    "Failed to create head for branch",
-                    "Failed to create head for branch in batch transaction:",
-                    e,
-                )
-            })?
-        };
+            diesel::QueryResult::Ok((new_head_id, silenced_alerts))
+        })
+        .map_err(|e| {
+            issue_error(
+                "Failed to create head for branch",
+                "Failed to create head for branch in batch transaction:",
+                e,
+            )
+        })?;
         slog::debug!(
             log,
             "Created head {new_head_id:?} for branch: {insert_head:?} (silenced {silenced_alerts} alerts)"
@@ -1105,8 +1100,6 @@ mod tests {
     /// Test that inserting a head and updating branch `head_id` works in a single transaction.
     #[test]
     fn for_branch_inserts_head_and_updates_branch() {
-        use diesel::Connection as _;
-
         let mut conn = setup_test_db();
         let base = create_base_entities(&mut conn);
 
@@ -1122,7 +1115,7 @@ mod tests {
 
         // Run the transaction: insert new head + update branch
         let new_head_id = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 use super::InsertHead;
                 use crate::macros::sql::last_insert_rowid;
 
@@ -1152,8 +1145,6 @@ mod tests {
     /// Test that old head gets marked as replaced in a transaction.
     #[test]
     fn for_branch_replaces_old_head() {
-        use diesel::Connection as _;
-
         let mut conn = setup_test_db();
         let base = create_base_entities(&mut conn);
 
@@ -1170,7 +1161,7 @@ mod tests {
         assert!(get_head_replaced(&mut conn, branch.head_id).is_none());
 
         // Run transaction: insert new head, update branch, mark old head replaced
-        conn.transaction(|conn| {
+        conn.immediate_transaction(|conn| {
             use super::{InsertHead, UpdateHead};
             use crate::macros::sql::last_insert_rowid;
 
@@ -1203,8 +1194,6 @@ mod tests {
     #[test]
     #[expect(clippy::too_many_lines)]
     fn for_branch_silences_old_head_alerts() {
-        use diesel::Connection as _;
-
         let mut conn = setup_test_db();
         let base = create_base_entities(&mut conn);
 
@@ -1305,7 +1294,7 @@ mod tests {
         );
 
         // Run transaction: silence alerts for old head
-        conn.transaction(|conn| {
+        conn.immediate_transaction(|conn| {
             use super::super::super::threshold::alert::{AlertId, UpdateAlert};
 
             let alerts = schema::alert::table
@@ -1339,8 +1328,6 @@ mod tests {
     /// Test that transaction works correctly when branch has no old head.
     #[test]
     fn for_branch_no_old_head_skips_replace() {
-        use diesel::Connection as _;
-
         let mut conn = setup_test_db();
         let base = create_base_entities(&mut conn);
 
@@ -1369,7 +1356,7 @@ mod tests {
 
         // Run transaction: insert new head, update branch, no old head to replace
         let new_head_id = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 use super::InsertHead;
                 use crate::macros::sql::last_insert_rowid;
 

--- a/lib/bencher_schema/src/model/project/branch/mod.rs
+++ b/lib/bencher_schema/src/model/project/branch/mod.rs
@@ -3,8 +3,7 @@ use bencher_json::{
     project::branch::{JsonUpdateBranch, JsonUpdateStartPoint},
 };
 use diesel::{
-    Connection as _, ExpressionMethods as _, JoinOnDsl as _, QueryDsl as _, RunQueryDsl as _,
-    SelectableHelper as _,
+    ExpressionMethods as _, JoinOnDsl as _, QueryDsl as _, RunQueryDsl as _, SelectableHelper as _,
 };
 use dropshot::HttpError;
 use slog::Logger;
@@ -26,7 +25,7 @@ use crate::{
         sql::last_insert_rowid,
     },
     schema::{self, branch as branch_table},
-    write_conn,
+    write_conn, write_transaction,
 };
 
 pub mod head;
@@ -384,17 +383,14 @@ impl InsertBranch {
 
         // Create branch
         let insert_branch = Self::from_json_inner(auth_conn!(context), project_id, name, slug);
-        let query_branch = {
-            let conn = write_conn!(context);
-            conn.transaction(|conn| {
-                diesel::insert_into(schema::branch::table)
-                    .values(&insert_branch)
-                    .execute(conn)?;
-                diesel::select(last_insert_rowid()).get_result(conn)
-            })
-            .map_err(resource_conflict_err!(Branch, &insert_branch))
-            .map(|id| insert_branch.into_query(id))?
-        };
+        let query_branch = write_transaction!(context, |conn| {
+            diesel::insert_into(schema::branch::table)
+                .values(&insert_branch)
+                .execute(conn)?;
+            diesel::select(last_insert_rowid()).get_result(conn)
+        })
+        .map_err(resource_conflict_err!(Branch, &insert_branch))
+        .map(|id| insert_branch.into_query(id))?;
         slog::debug!(log, "Created branch {query_branch:?}");
 
         // Get the branch head version for the start point
@@ -516,7 +512,7 @@ impl UpdateBranch {
 
 #[cfg(test)]
 mod tests {
-    use diesel::{Connection as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
+    use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 
     use bencher_json::DateTime;
 
@@ -534,7 +530,7 @@ mod tests {
         let uuid = "00000000-0000-0000-0000-000000000010";
 
         let (rowid, select_id) = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 diesel::insert_into(schema::branch::table)
                     .values((
                         schema::branch::uuid.eq(uuid),
@@ -580,7 +576,7 @@ mod tests {
         // Insert second + verify
         let second_uuid = "00000000-0000-0000-0000-000000000011";
         let (rowid, select_id) = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 diesel::insert_into(schema::branch::table)
                     .values((
                         schema::branch::uuid.eq(second_uuid),

--- a/lib/bencher_schema/src/model/project/branch/version.rs
+++ b/lib/bencher_schema/src/model/project/branch/version.rs
@@ -392,7 +392,7 @@ mod tests {
     #[test]
     fn increment_creates_first_version() {
         use bencher_json::project::head::VersionNumber;
-        use diesel::{Connection as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
+        use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 
         let mut conn = setup_test_db();
         let base = create_base_entities(&mut conn);
@@ -406,7 +406,7 @@ mod tests {
         );
 
         let version_id = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 super::InsertVersion::increment(conn, base.project_id, branch.head_id, None)
             })
             .expect("Failed to increment version");
@@ -432,7 +432,7 @@ mod tests {
     #[test]
     fn increment_increments_version_number() {
         use bencher_json::project::head::VersionNumber;
-        use diesel::{Connection as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
+        use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 
         let mut conn = setup_test_db();
         let base = create_base_entities(&mut conn);
@@ -446,14 +446,14 @@ mod tests {
         );
 
         // First increment — version number should be 0
-        conn.transaction(|conn| {
+        conn.immediate_transaction(|conn| {
             super::InsertVersion::increment(conn, base.project_id, branch.head_id, None)
         })
         .expect("Failed to increment first version");
 
         // Second increment — version number should be 1
         let version_id = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 super::InsertVersion::increment(conn, base.project_id, branch.head_id, None)
             })
             .expect("Failed to increment second version");

--- a/lib/bencher_schema/src/model/project/measure.rs
+++ b/lib/bencher_schema/src/model/project/measure.rs
@@ -5,7 +5,7 @@ use bencher_json::{
         built_in::{self, BuiltInMeasure},
     },
 };
-use diesel::{Connection as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
+use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 use dropshot::HttpError;
 
 use crate::{
@@ -21,7 +21,7 @@ use crate::{
     },
     model::project::QueryProject,
     schema::{self, measure as measure_table},
-    write_conn,
+    write_conn, write_transaction,
 };
 
 use super::ProjectId;
@@ -212,8 +212,7 @@ impl QueryMeasure {
         let insert_measure =
             InsertMeasure::from_json(auth_conn!(context), project_id, json_measure);
 
-        let conn = write_conn!(context);
-        conn.transaction(|conn| {
+        write_transaction!(context, |conn| {
             diesel::insert_into(schema::measure::table)
                 .values(&insert_measure)
                 .execute(conn)?;
@@ -360,7 +359,7 @@ impl UpdateMeasure {
 
 #[cfg(test)]
 mod tests {
-    use diesel::{Connection as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
+    use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 
     use bencher_json::DateTime;
 
@@ -378,7 +377,7 @@ mod tests {
         let uuid = "00000000-0000-0000-0000-000000000010";
 
         let (rowid, select_id) = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 diesel::insert_into(schema::measure::table)
                     .values((
                         schema::measure::uuid.eq(uuid),
@@ -426,7 +425,7 @@ mod tests {
         // Insert second + verify
         let second_uuid = "00000000-0000-0000-0000-000000000011";
         let (rowid, select_id) = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 diesel::insert_into(schema::measure::table)
                     .values((
                         schema::measure::uuid.eq(second_uuid),
@@ -467,7 +466,7 @@ mod tests {
 
         // Insert and read back within same transaction
         let (inserted_id, readback_name) = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 diesel::insert_into(schema::measure::table)
                     .values((
                         schema::measure::uuid.eq(uuid),

--- a/lib/bencher_schema/src/model/project/mod.rs
+++ b/lib/bencher_schema/src/model/project/mod.rs
@@ -7,8 +7,8 @@ use bencher_json::{
 };
 use bencher_rbac::{Organization, Project, project::Permission};
 use diesel::{
-    BoolExpressionMethods as _, Connection as _, ExpressionMethods as _, QueryDsl as _,
-    RunQueryDsl as _, TextExpressionMethods as _,
+    BoolExpressionMethods as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _,
+    TextExpressionMethods as _,
 };
 use dropshot::HttpError;
 use project_role::InsertProjectRole;
@@ -34,7 +34,7 @@ use crate::{
     },
     public_conn,
     schema::{self, project as project_table},
-    write_conn,
+    write_conn, write_transaction,
 };
 
 use super::organization::OrganizationId;
@@ -321,28 +321,25 @@ impl QueryProject {
         let timestamp = DateTime::now();
         let user_id = auth_user.id();
 
-        let query_project = {
-            let conn = write_conn!(context);
-            conn.transaction(|conn| {
-                let id = Self::insert(conn, &insert_project)?;
+        let query_project = write_transaction!(context, |conn| {
+            let id = Self::insert(conn, &insert_project)?;
 
-                // Connect the user to the project as a `Maintainer`
-                let insert_proj_role = InsertProjectRole {
-                    user_id,
-                    project_id: id,
-                    role: ProjectRole::Maintainer,
-                    created: timestamp,
-                    modified: timestamp,
-                };
-                diesel::insert_into(schema::project_role::table)
-                    .values(&insert_proj_role)
-                    .execute(conn)?;
+            // Connect the user to the project as a `Maintainer`
+            let insert_proj_role = InsertProjectRole {
+                user_id,
+                project_id: id,
+                role: ProjectRole::Maintainer,
+                created: timestamp,
+                modified: timestamp,
+            };
+            diesel::insert_into(schema::project_role::table)
+                .values(&insert_proj_role)
+                .execute(conn)?;
 
-                diesel::QueryResult::Ok(id)
-            })
-            .map_err(resource_conflict_err!(Project, &insert_project))
-            .map(|id| insert_project.into_query(id))?
-        };
+            diesel::QueryResult::Ok(id)
+        })
+        .map_err(resource_conflict_err!(Project, &insert_project))
+        .map(|id| insert_project.into_query(id))?;
         slog::debug!(log, "Created project: {query_project:?}");
 
         #[cfg(feature = "plus")]
@@ -359,12 +356,9 @@ impl QueryProject {
         context: &ApiContext,
         insert_project: InsertProject,
     ) -> Result<Self, HttpError> {
-        let query_project = {
-            let conn = write_conn!(context);
-            conn.transaction(|conn| Self::insert(conn, &insert_project))
-                .map_err(resource_conflict_err!(Project, &insert_project))
-                .map(|id| insert_project.into_query(id))?
-        };
+        let query_project = write_transaction!(context, |conn| Self::insert(conn, &insert_project))
+            .map_err(resource_conflict_err!(Project, &insert_project))
+            .map(|id| insert_project.into_query(id))?;
         slog::debug!(log, "Created project: {query_project:?}");
 
         #[cfg(feature = "plus")]
@@ -797,7 +791,7 @@ impl From<&QueryProject> for Project {
 
 #[cfg(test)]
 mod tests {
-    use diesel::{Connection as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
+    use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 
     use bencher_json::DateTime;
 
@@ -815,7 +809,7 @@ mod tests {
         let uuid = "00000000-0000-0000-0000-000000000010";
 
         let (rowid, select_id) = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 diesel::insert_into(schema::project::table)
                     .values((
                         schema::project::uuid.eq(uuid),
@@ -863,7 +857,7 @@ mod tests {
         // Insert second + verify
         let second_uuid = "00000000-0000-0000-0000-000000000011";
         let (rowid, select_id) = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 diesel::insert_into(schema::project::table)
                     .values((
                         schema::project::uuid.eq(second_uuid),

--- a/lib/bencher_schema/src/model/project/plot/mod.rs
+++ b/lib/bencher_schema/src/model/project/plot/mod.rs
@@ -3,9 +3,7 @@ use bencher_json::{
     project::plot::{JsonPlotPatch, JsonPlotPatchNull, JsonUpdatePlot, XAxis},
 };
 use bencher_rank::{Rank, RankGenerator, Ranked};
-use diesel::{
-    BelongingToDsl as _, Connection as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _,
-};
+use diesel::{BelongingToDsl as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 use dropshot::HttpError;
 
 use super::{
@@ -110,7 +108,7 @@ impl QueryPlot {
         // If the rank cannot be calculated, then we need to redistribute the ranks.
         // Wrap the redistribution in a transaction for atomicity.
         let now = DateTime::now();
-        conn.transaction(|conn| {
+        conn.immediate_transaction(|conn| {
             let plot_ranker = RankGenerator::new(plots.len());
             for (plot, rank) in plots.iter().zip(plot_ranker) {
                 let update_plot = UpdatePlot {
@@ -158,7 +156,7 @@ impl QueryPlot {
         // Wrap the redistribution in a transaction for atomicity.
         let all_plots = QueryPlot::all_for_project(conn, query_project)?;
         let now = DateTime::now();
-        conn.transaction(|conn| {
+        conn.immediate_transaction(|conn| {
             let plot_ranker = RankGenerator::new(all_plots.len());
             for (plot, rank) in all_plots.iter().zip(plot_ranker) {
                 let update_plot = UpdatePlot {
@@ -319,7 +317,7 @@ impl InsertPlot {
             modified: timestamp,
         };
         let plot_id = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 diesel::insert_into(plot_table::table)
                     .values(&insert_plot)
                     .execute(conn)?;
@@ -393,8 +391,6 @@ impl UpdatePlot {
 #[cfg(test)]
 mod tests {
     use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _, SelectableHelper as _};
-
-    use diesel::Connection as _;
 
     use bencher_json::project::plot::XAxis;
 
@@ -631,7 +627,7 @@ mod tests {
 
         // Insert plot + all components in a single transaction
         let plot_id = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 let timestamp = bencher_json::DateTime::now();
                 let insert_plot = InsertPlot {
                     uuid: bencher_json::PlotUuid::new(),
@@ -736,7 +732,7 @@ mod tests {
         );
 
         // Batch insert branches and measures
-        conn.transaction(|conn| {
+        conn.immediate_transaction(|conn| {
             InsertPlotBranch::from_resolved(conn, plot_id, &[b1.branch_id, b2.branch_id])?;
             InsertPlotMeasure::from_resolved(conn, plot_id, &[m1, m2])?;
             diesel::QueryResult::Ok(())

--- a/lib/bencher_schema/src/model/project/report/mod.rs
+++ b/lib/bencher_schema/src/model/project/report/mod.rs
@@ -9,8 +9,8 @@ use bencher_json::{
 };
 use diesel::OptionalExtension as _;
 use diesel::{
-    Connection as _, ExpressionMethods as _, NullableExpressionMethods as _, QueryDsl as _,
-    RunQueryDsl as _, SelectableHelper as _,
+    ExpressionMethods as _, NullableExpressionMethods as _, QueryDsl as _, RunQueryDsl as _,
+    SelectableHelper as _,
 };
 
 use dropshot::HttpError;
@@ -43,7 +43,7 @@ use crate::{
     },
     public_conn,
     schema::{self, report as report_table},
-    view, write_conn,
+    view, write_transaction,
 };
 
 /// Encapsulates all context from a run request for report creation.
@@ -268,46 +268,42 @@ impl QueryReport {
 
         // Single transaction wraps version + report + job for true atomicity.
         // If any insert fails, all are rolled back.
-        let insert_report_uuid = {
-            let conn = write_conn!(context);
-            conn.transaction(|conn| {
-                // If the version was already found outside the transaction, use it.
-                // Otherwise, increment a new version inside the transaction.
-                let version_id = if let Some(version_id) = existing_version_id {
-                    version_id
-                } else {
-                    InsertVersion::increment(conn, project_id, head_id, json_report.hash.clone())?
-                };
+        let insert_report_uuid = write_transaction!(context, |conn| {
+            // If the version was already found outside the transaction, use it.
+            // Otherwise, increment a new version inside the transaction.
+            let version_id = if let Some(version_id) = existing_version_id {
+                version_id
+            } else {
+                InsertVersion::increment(conn, project_id, head_id, json_report.hash.clone())?
+            };
 
-                // Create a new report and add it to the database
-                let insert_report = InsertReport::from_json(
-                    idempotency_key,
-                    public_user.user_id(),
-                    project_id,
-                    head_id,
-                    version_id,
-                    testbed_id,
-                    spec_id,
-                    &json_report,
-                    adapter,
-                    now,
-                );
+            // Create a new report and add it to the database
+            let insert_report = InsertReport::from_json(
+                idempotency_key,
+                public_user.user_id(),
+                project_id,
+                head_id,
+                version_id,
+                testbed_id,
+                spec_id,
+                &json_report,
+                adapter,
+                now,
+            );
 
-                diesel::insert_into(schema::report::table)
-                    .values(&insert_report)
-                    .execute(conn)?;
+            diesel::insert_into(schema::report::table)
+                .values(&insert_report)
+                .execute(conn)?;
 
-                #[cfg(feature = "plus")]
-                if let Some(pending_job) = pending_job {
-                    let report_id =
-                        diesel::select(last_insert_rowid()).get_result::<ReportId>(conn)?;
-                    pending_job.insert(conn, report_id, now)?;
-                }
+            #[cfg(feature = "plus")]
+            if let Some(pending_job) = pending_job {
+                let report_id = diesel::select(last_insert_rowid()).get_result::<ReportId>(conn)?;
+                pending_job.insert(conn, report_id, now)?;
+            }
 
-                diesel::QueryResult::Ok(insert_report.uuid)
-            })
-            .map_err(resource_conflict_err!(Report, &json_report))?
-        };
+            diesel::QueryResult::Ok(insert_report.uuid)
+        })
+        .map_err(resource_conflict_err!(Report, &json_report))?;
 
         // Read full report via public_conn (outside write lock)
         let query_report = schema::report::table
@@ -825,7 +821,7 @@ pub fn upsert_metric_count(
 
 #[cfg(test)]
 mod tests {
-    use diesel::{Connection as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
+    use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 
     use bencher_json::DateTime;
 
@@ -872,7 +868,7 @@ mod tests {
 
         // Insert a report and immediately call last_insert_rowid inside a transaction
         let (rowid, select_id) = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 diesel::insert_into(schema::report::table)
                     .values((
                         schema::report::uuid.eq(report_uuid),
@@ -947,7 +943,7 @@ mod tests {
         // Insert second report and verify last_insert_rowid points to the second one
         let second_uuid = "00000000-0000-0000-0000-000000000051";
         let (rowid, select_id) = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 diesel::insert_into(schema::report::table)
                     .values((
                         schema::report::uuid.eq(second_uuid),
@@ -1015,7 +1011,7 @@ mod tests {
 
         // Insert a report to get a valid ReportId
         let report_id: ReportId = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 diesel::insert_into(schema::report::table)
                     .values((
                         schema::report::uuid.eq("00000000-0000-0000-0000-000000000050"),

--- a/lib/bencher_schema/src/model/project/report/results/detector/prepared.rs
+++ b/lib/bencher_schema/src/model/project/report/results/detector/prepared.rs
@@ -71,7 +71,7 @@ impl PreparedDetection {
 #[cfg(test)]
 mod tests {
     use bencher_json::{BoundaryUuid, project::boundary::BoundaryLimit};
-    use diesel::{Connection as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
+    use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 
     use crate::{
         context::DbConnection,
@@ -188,7 +188,7 @@ mod tests {
             ignore_benchmark: false,
         };
 
-        conn.transaction(|conn| detection.write(conn, metric_id))
+        conn.immediate_transaction(|conn| detection.write(conn, metric_id))
             .expect("Failed to write detection");
 
         // Assert 1 boundary row exists with correct fields
@@ -225,7 +225,7 @@ mod tests {
             ignore_benchmark: false,
         };
 
-        conn.transaction(|conn| detection.write(conn, metric_id))
+        conn.immediate_transaction(|conn| detection.write(conn, metric_id))
             .expect("Failed to write detection");
 
         // Assert 1 boundary exists
@@ -260,7 +260,7 @@ mod tests {
             ignore_benchmark: true,
         };
 
-        conn.transaction(|conn| detection.write(conn, metric_id))
+        conn.immediate_transaction(|conn| detection.write(conn, metric_id))
             .expect("Failed to write detection");
 
         // Assert 1 boundary exists

--- a/lib/bencher_schema/src/model/project/report/results/mod.rs
+++ b/lib/bencher_schema/src/model/project/report/results/mod.rs
@@ -8,7 +8,7 @@ use bencher_json::{
     BenchmarkName, BenchmarkNameId, JsonNewMetric, MeasureNameId, Slug,
     project::report::{Adapter, Iteration, JsonReportSettings},
 };
-use diesel::{Connection as _, RunQueryDsl as _};
+use diesel::RunQueryDsl as _;
 use dropshot::HttpError;
 use slog::Logger;
 
@@ -27,7 +27,7 @@ use crate::{
         report::report_benchmark::{InsertReportBenchmark, ReportBenchmarkId},
         testbed::TestbedId,
     },
-    schema, write_conn,
+    schema, write_transaction,
 };
 
 pub mod detector;
@@ -164,49 +164,46 @@ impl ReportResults {
         #[cfg(feature = "otel")]
         let write_start = context.clock.now();
 
-        {
-            let conn = write_conn!(context);
-            conn.transaction(|conn| {
-                for prepared in prepared_benchmarks {
-                    // Insert report_benchmark
-                    diesel::insert_into(schema::report_benchmark::table)
-                        .values(&prepared.insert_report_benchmark)
+        write_transaction!(context, |conn| {
+            for prepared in prepared_benchmarks {
+                // Insert report_benchmark
+                diesel::insert_into(schema::report_benchmark::table)
+                    .values(&prepared.insert_report_benchmark)
+                    .execute(conn)?;
+                let report_benchmark_id: ReportBenchmarkId =
+                    diesel::select(last_insert_rowid()).get_result(conn)?;
+
+                // Insert all metrics for this benchmark
+                for prepared_metric in prepared.metrics {
+                    let insert_metric = InsertMetric::from_json(
+                        report_benchmark_id,
+                        prepared_metric.measure_id,
+                        prepared_metric.metric,
+                    );
+                    diesel::insert_into(schema::metric::table)
+                        .values(&insert_metric)
                         .execute(conn)?;
-                    let report_benchmark_id: ReportBenchmarkId =
-                        diesel::select(last_insert_rowid()).get_result(conn)?;
 
-                    // Insert all metrics for this benchmark
-                    for prepared_metric in prepared.metrics {
-                        let insert_metric = InsertMetric::from_json(
-                            report_benchmark_id,
-                            prepared_metric.measure_id,
-                            prepared_metric.metric,
-                        );
-                        diesel::insert_into(schema::metric::table)
-                            .values(&insert_metric)
-                            .execute(conn)?;
-
-                        // If there's a prepared detection, write boundary + optional alert
-                        if let Some(prepared_detection) = prepared_metric.detection {
-                            let metric_id = diesel::select(last_insert_rowid()).get_result(conn)?;
-                            prepared_detection.write(conn, metric_id)?;
-                        }
+                    // If there's a prepared detection, write boundary + optional alert
+                    if let Some(prepared_detection) = prepared_metric.detection {
+                        let metric_id = diesel::select(last_insert_rowid()).get_result(conn)?;
+                        prepared_detection.write(conn, metric_id)?;
                     }
                 }
+            }
 
-                // Upsert metric count summary (count computed before acquiring write lock)
-                super::upsert_metric_count(conn, self.report_id, iteration_metric_count)?;
+            // Upsert metric count summary (count computed before acquiring write lock)
+            super::upsert_metric_count(conn, self.report_id, iteration_metric_count)?;
 
-                diesel::QueryResult::Ok(())
-            })
-            .map_err(|e| {
-                issue_error(
-                    "Failed to write report results",
-                    "Failed to write report results in batch transaction:",
-                    e,
-                )
-            })?;
-        }
+            diesel::QueryResult::Ok(())
+        })
+        .map_err(|e| {
+            issue_error(
+                "Failed to write report results",
+                "Failed to write report results in batch transaction:",
+                e,
+            )
+        })?;
 
         #[cfg(feature = "otel")]
         {

--- a/lib/bencher_schema/src/model/project/testbed.rs
+++ b/lib/bencher_schema/src/model/project/testbed.rs
@@ -5,7 +5,7 @@ use bencher_json::{
 };
 #[cfg(feature = "plus")]
 use bencher_json::{JsonSpec, SpecResourceId, project::testbed::JsonTestbedPatchNull};
-use diesel::{Connection as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
+use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 use dropshot::HttpError;
 
 use super::{ProjectId, QueryProject};
@@ -26,7 +26,7 @@ use crate::{
         sql::last_insert_rowid,
     },
     schema::{self, testbed as testbed_table},
-    write_conn,
+    write_conn, write_transaction,
 };
 
 crate::macros::typed_id::typed_id!(TestbedId);
@@ -308,8 +308,7 @@ impl QueryTestbed {
             context.clock.now(),
         )?;
 
-        let conn = write_conn!(context);
-        conn.transaction(|conn| {
+        write_transaction!(context, |conn| {
             diesel::insert_into(schema::testbed::table)
                 .values(&insert_testbed)
                 .execute(conn)?;
@@ -986,8 +985,6 @@ mod tests {
 
     #[test]
     fn last_insert_rowid_returns_testbed_id() {
-        use diesel::Connection as _;
-
         use super::TestbedId;
         use crate::macros::sql::last_insert_rowid;
 
@@ -996,7 +993,7 @@ mod tests {
         let uuid = "00000000-0000-0000-0000-000000000020";
 
         let (rowid, select_id) = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 diesel::insert_into(schema::testbed::table)
                     .values((
                         schema::testbed::uuid.eq(uuid),
@@ -1023,8 +1020,6 @@ mod tests {
 
     #[test]
     fn last_insert_rowid_matches_second_testbed() {
-        use diesel::Connection as _;
-
         use super::TestbedId;
         use crate::macros::sql::last_insert_rowid;
 
@@ -1047,7 +1042,7 @@ mod tests {
         // Insert second + verify
         let second_uuid = "00000000-0000-0000-0000-000000000021";
         let (rowid, select_id) = conn
-            .transaction(|conn| {
+            .immediate_transaction(|conn| {
                 diesel::insert_into(schema::testbed::table)
                     .values((
                         schema::testbed::uuid.eq(second_uuid),

--- a/lib/bencher_schema/src/model/project/threshold/mod.rs
+++ b/lib/bencher_schema/src/model/project/threshold/mod.rs
@@ -435,58 +435,6 @@ impl InsertThreshold {
         Ok(threshold_id)
     }
 
-    pub fn lower_boundary(
-        conn: &mut DbConnection,
-        project_id: ProjectId,
-        branch_id: BranchId,
-        testbed_id: TestbedId,
-        measure_id: MeasureId,
-    ) -> Result<ThresholdId, HttpError> {
-        conn.immediate_transaction(|conn| {
-            Self::from_model_inner(
-                conn,
-                project_id,
-                branch_id,
-                testbed_id,
-                measure_id,
-                Model::lower_boundary(),
-            )
-        })
-        .map_err(|e| {
-            crate::error::issue_error(
-                "Failed to create lower boundary threshold",
-                "Failed to create lower boundary threshold:",
-                e,
-            )
-        })
-    }
-
-    pub fn upper_boundary(
-        conn: &mut DbConnection,
-        project_id: ProjectId,
-        branch_id: BranchId,
-        testbed_id: TestbedId,
-        measure_id: MeasureId,
-    ) -> Result<ThresholdId, HttpError> {
-        conn.immediate_transaction(|conn| {
-            Self::from_model_inner(
-                conn,
-                project_id,
-                branch_id,
-                testbed_id,
-                measure_id,
-                Model::upper_boundary(),
-            )
-        })
-        .map_err(|e| {
-            crate::error::issue_error(
-                "Failed to create upper boundary threshold",
-                "Failed to create upper boundary threshold:",
-                e,
-            )
-        })
-    }
-
     pub async fn from_start_point(
         log: &Logger,
         context: &ApiContext,

--- a/lib/bencher_schema/src/model/project/threshold/mod.rs
+++ b/lib/bencher_schema/src/model/project/threshold/mod.rs
@@ -8,9 +8,8 @@ use bencher_json::{
     },
 };
 use diesel::{
-    BelongingToDsl as _, Connection as _, ExpressionMethods as _, JoinOnDsl as _,
-    NullableExpressionMethods as _, OptionalExtension as _, QueryDsl as _, RunQueryDsl as _,
-    SelectableHelper as _,
+    BelongingToDsl as _, ExpressionMethods as _, JoinOnDsl as _, NullableExpressionMethods as _,
+    OptionalExtension as _, QueryDsl as _, RunQueryDsl as _, SelectableHelper as _,
 };
 use dropshot::HttpError;
 use model::UpdateModel;
@@ -35,7 +34,7 @@ use crate::{
         sql::last_insert_rowid,
     },
     schema::{self, threshold as threshold_table},
-    write_conn,
+    write_transaction,
 };
 
 pub mod alert;
@@ -133,15 +132,13 @@ impl QueryThreshold {
             ThresholdModelAction::NoChange => Ok(()),
             ThresholdModelAction::Update(model) => self.update_from_model(context, model).await,
             ThresholdModelAction::Remove => {
-                let conn = write_conn!(context);
-                conn.transaction(|conn| self.remove_current_model(conn))
-                    .map_err(|e| {
-                        crate::error::issue_error(
-                            "Failed to remove threshold model",
-                            "Failed to remove threshold model:",
-                            e,
-                        )
-                    })
+                write_transaction!(context, |conn| self.remove_current_model(conn)).map_err(|e| {
+                    crate::error::issue_error(
+                        "Failed to remove threshold model",
+                        "Failed to remove threshold model:",
+                        e,
+                    )
+                })
             },
         }
     }
@@ -149,15 +146,13 @@ impl QueryThreshold {
     async fn update_from_model(&self, context: &ApiContext, model: Model) -> Result<(), HttpError> {
         #[cfg(feature = "plus")]
         InsertModel::rate_limit(context, self).await?;
-        let conn = write_conn!(context);
-        conn.transaction(|conn| self.update_from_model_inner(conn, model))
-            .map_err(|e| {
-                crate::error::issue_error(
-                    "Failed to update threshold model",
-                    "Failed to update threshold model:",
-                    e,
-                )
-            })
+        write_transaction!(context, |conn| self.update_from_model_inner(conn, model)).map_err(|e| {
+            crate::error::issue_error(
+                "Failed to update threshold model",
+                "Failed to update threshold model:",
+                e,
+            )
+        })
     }
 
     fn update_from_model_inner(
@@ -396,8 +391,7 @@ impl InsertThreshold {
 
         #[cfg(feature = "plus")]
         Self::rate_limit(context, project_id).await?;
-        let conn = write_conn!(context);
-        conn.transaction(|conn| {
+        write_transaction!(context, |conn| {
             Self::from_model_inner(conn, project_id, branch_id, testbed_id, measure_id, model)
         })
         .map_err(|e| {
@@ -448,7 +442,7 @@ impl InsertThreshold {
         testbed_id: TestbedId,
         measure_id: MeasureId,
     ) -> Result<ThresholdId, HttpError> {
-        conn.transaction(|conn| {
+        conn.immediate_transaction(|conn| {
             Self::from_model_inner(
                 conn,
                 project_id,
@@ -474,7 +468,7 @@ impl InsertThreshold {
         testbed_id: TestbedId,
         measure_id: MeasureId,
     ) -> Result<ThresholdId, HttpError> {
-        conn.transaction(|conn| {
+        conn.immediate_transaction(|conn| {
             Self::from_model_inner(
                 conn,
                 project_id,
@@ -528,8 +522,7 @@ impl InsertThreshold {
         if has_writes {
             let project_id = query_branch.project_id;
             let branch_id = query_branch.id;
-            let conn = write_conn!(context);
-            conn.transaction(|conn| {
+            write_transaction!(context, |conn| {
                 for action in actions {
                     match action {
                         StartPointAction::Create(testbed_id, measure_id, model) => {
@@ -754,8 +747,7 @@ impl InsertThreshold {
             .any(|a| !matches!(a, ThresholdAction::NoChange))
             || !orphans.is_empty();
         if has_writes {
-            let conn = write_conn!(context);
-            conn.transaction(|conn| {
+            write_transaction!(context, |conn| {
                 for action in actions {
                     match action {
                         ThresholdAction::Create(measure_id, model) => {

--- a/lib/bencher_schema/src/model/runner/job.rs
+++ b/lib/bencher_schema/src/model/runner/job.rs
@@ -5,8 +5,8 @@ use bencher_json::{
     project::report::JsonReportSettings, runner::JsonIterationOutput, runner::job::JsonNewRunJob,
 };
 use diesel::{
-    BoolExpressionMethods as _, Connection as _, ExpressionMethods as _, QueryDsl as _,
-    RunQueryDsl as _, result::QueryResult,
+    BoolExpressionMethods as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _,
+    result::QueryResult,
 };
 use dropshot::HttpError;
 use tokio::sync::Mutex;
@@ -29,7 +29,7 @@ use crate::{
         user::public::PublicUser,
     },
     schema::{self, job as job_table},
-    write_conn,
+    write_conn, write_transaction,
 };
 
 crate::macros::typed_id::typed_id!(JobId);
@@ -170,32 +170,28 @@ impl QueryJob {
 
         // Update report times and record job duration atomically
         let report_id = self.report_id;
-        {
-            let conn = write_conn!(context);
-            conn.transaction(|conn| {
-                let updated = diesel::update(
-                    schema::report::table.filter(schema::report::id.eq(report_id)),
-                )
-                .set((
-                    schema::report::start_time.eq(start_time),
-                    schema::report::end_time.eq(end_time),
-                ))
-                .execute(conn)?;
-                if updated == 0 {
-                    return Err(diesel::result::Error::NotFound);
-                }
-                insert_job_duration(conn, report_id, job_duration)
-            })
-            .map_err(|e| {
-                issue_error(
-                    "Failed to update report times and insert job duration",
-                    &format!(
-                        "Failed to update report times / insert job duration for report {report_id}.",
-                    ),
-                    e,
-                )
-            })?;
-        }
+        write_transaction!(context, |conn| {
+            let updated =
+                diesel::update(schema::report::table.filter(schema::report::id.eq(report_id)))
+                    .set((
+                        schema::report::start_time.eq(start_time),
+                        schema::report::end_time.eq(end_time),
+                    ))
+                    .execute(conn)?;
+            if updated == 0 {
+                return Err(diesel::result::Error::NotFound);
+            }
+            insert_job_duration(conn, report_id, job_duration)
+        })
+        .map_err(|e| {
+            issue_error(
+                "Failed to update report times and insert job duration",
+                &format!(
+                    "Failed to update report times / insert job duration for report {report_id}.",
+                ),
+                e,
+            )
+        })?;
 
         #[cfg(feature = "otel")]
         {
@@ -463,7 +459,7 @@ fn insert_job_duration(
 #[cfg(test)]
 mod tests {
     use bencher_json::{DateTime, Entitlements, PlanLevel};
-    use diesel::{Connection as _, QueryDsl as _};
+    use diesel::QueryDsl as _;
     use pretty_assertions::assert_eq;
 
     use super::*;
@@ -634,7 +630,7 @@ mod tests {
         );
         create_head_version(conn, branch.head_id, version_id);
 
-        conn.transaction(|conn| {
+        conn.immediate_transaction(|conn| {
             diesel::insert_into(schema::report::table)
                 .values((
                     schema::report::uuid.eq("00000000-0000-0000-0000-000000000050"),

--- a/lib/bencher_schema/src/model/server/plus/mod.rs
+++ b/lib/bencher_schema/src/model/server/plus/mod.rs
@@ -335,5 +335,6 @@ fn configure_standalone_connection(
 ) -> diesel::QueryResult<()> {
     conn.batch_execute(&format!("PRAGMA busy_timeout = {busy_timeout}"))?;
     conn.batch_execute("PRAGMA synchronous = NORMAL")?;
+    conn.batch_execute("PRAGMA extended_result_codes = ON")?;
     Ok(())
 }

--- a/plus/api_specs/src/specs.rs
+++ b/plus/api_specs/src/specs.rs
@@ -14,11 +14,11 @@ use bencher_schema::{
         spec::{InsertSpec, QuerySpec, SpecId, UpdateSpec},
         user::{admin::AdminUser, auth::BearerToken},
     },
-    schema, write_conn,
+    schema, write_conn, write_transaction,
 };
 use diesel::{
-    BoolExpressionMethods as _, Connection as _, ExpressionMethods as _, QueryDsl as _,
-    RunQueryDsl as _, TextExpressionMethods as _,
+    BoolExpressionMethods as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _,
+    TextExpressionMethods as _,
 };
 use dropshot::{HttpError, Path, Query, RequestContext, TypedBody, endpoint};
 use schemars::JsonSchema;
@@ -168,20 +168,17 @@ async fn post_inner(context: &ApiContext, json_spec: JsonNewSpec) -> Result<Json
     let now = context.clock.now();
 
     // Hold write lock + transaction across slug check + clear + insert
-    let uuid = {
-        let conn = write_conn!(context);
-        conn.transaction(|conn| {
-            if is_fallback {
-                QuerySpec::clear_fallback(conn)?;
-            }
-            let insert_spec = InsertSpec::new(conn, &json_spec, now);
-            diesel::insert_into(schema::spec::table)
-                .values(&insert_spec)
-                .execute(conn)?;
-            Ok::<_, diesel::result::Error>(insert_spec.uuid)
-        })
-        .map_err(resource_conflict_err!(Spec, &json_spec))?
-    };
+    let uuid = write_transaction!(context, |conn| {
+        if is_fallback {
+            QuerySpec::clear_fallback(conn)?;
+        }
+        let insert_spec = InsertSpec::new(conn, &json_spec, now);
+        diesel::insert_into(schema::spec::table)
+            .values(&insert_spec)
+            .execute(conn)?;
+        Ok::<_, diesel::result::Error>(insert_spec.uuid)
+    })
+    .map_err(resource_conflict_err!(Spec, &json_spec))?;
 
     let query_spec = QuerySpec::from_uuid(auth_conn!(context), uuid)?;
     Ok(query_spec.into_json())
@@ -263,33 +260,30 @@ async fn patch_inner(
     let update_spec = UpdateSpec::new(json_spec.clone(), now);
 
     // Hold write lock + transaction across clear + update + testbed cleanup
-    {
-        let is_archiving = json_spec.archived == Some(true);
-        let spec_id = query_spec.id;
-        let conn = write_conn!(context);
-        conn.transaction(|conn| {
-            if is_setting_fallback {
-                QuerySpec::clear_fallback(conn)?;
-            }
+    let is_archiving = json_spec.archived == Some(true);
+    let spec_id = query_spec.id;
+    write_transaction!(context, |conn| {
+        if is_setting_fallback {
+            QuerySpec::clear_fallback(conn)?;
+        }
 
-            diesel::update(schema::spec::table.filter(schema::spec::id.eq(spec_id)))
-                .set(&update_spec)
+        diesel::update(schema::spec::table.filter(schema::spec::id.eq(spec_id)))
+            .set(&update_spec)
+            .execute(conn)?;
+
+        // Clear stale testbed spec references when archiving a spec
+        if is_archiving {
+            diesel::update(schema::testbed::table.filter(schema::testbed::spec_id.eq(spec_id)))
+                .set((
+                    schema::testbed::spec_id.eq(None::<SpecId>),
+                    schema::testbed::modified.eq(now),
+                ))
                 .execute(conn)?;
+        }
 
-            // Clear stale testbed spec references when archiving a spec
-            if is_archiving {
-                diesel::update(schema::testbed::table.filter(schema::testbed::spec_id.eq(spec_id)))
-                    .set((
-                        schema::testbed::spec_id.eq(None::<SpecId>),
-                        schema::testbed::modified.eq(now),
-                    ))
-                    .execute(conn)?;
-            }
-
-            Ok::<_, diesel::result::Error>(())
-        })
-        .map_err(resource_conflict_err!(Spec, (&query_spec, &json_spec)))?;
-    }
+        Ok::<_, diesel::result::Error>(())
+    })
+    .map_err(resource_conflict_err!(Spec, (&query_spec, &json_spec)))?;
 
     let spec = QuerySpec::get(auth_conn!(context), query_spec.id)?;
     Ok(spec.into_json())


### PR DESCRIPTION
This changeset moves to using `immediate_transaction` instead of `transaction` for transactions that include a write. Without this there are occasional `SQLITE_BUSY_SNAPSHOT` errors.

Also added `PRAGMA extended_result_codes = ON` to all connections to get better error codes going forward.