### PR TITLE
Fix Alert JSON to return the Report Spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Built for teams where performance matters:
 Most teams start on GitHub Actions runners with a benchmark comparison script.
 That approach breaks down when noisy shared CI runners hide real performance regressions.
 
-- Typical CI runners have **>30% variance**,
-- Bencher Bare Metal runners have **<2% variance**.
+- Typical CI runners: **>30% variance**
+- Bencher Bare Metal runners: **<2% variance**
 
 When a number moves, it means something.
 

--- a/lib/api_projects/src/thresholds.rs
+++ b/lib/api_projects/src/thresholds.rs
@@ -23,7 +23,7 @@ use bencher_schema::{
             branch::QueryBranch,
             measure::QueryMeasure,
             testbed::QueryTestbed,
-            threshold::{InsertThreshold, QueryThreshold, model::QueryModel},
+            threshold::{InsertThreshold, QueryThreshold, ThresholdSpec, model::QueryModel},
         },
         user::{
             auth::{AuthUser, BearerToken},
@@ -416,6 +416,7 @@ async fn get_one_inner(
             public_conn!(context, public_user),
             Some(query_model),
             None,
+            ThresholdSpec::Testbed,
         )
     } else {
         query_threshold.into_json(public_conn!(context, public_user))

--- a/lib/bencher_schema/src/model/project/report/mod.rs
+++ b/lib/bencher_schema/src/model/project/report/mod.rs
@@ -431,7 +431,7 @@ impl QueryReport {
         let branch = QueryBranch::get_json_for_report(conn, &query_project, head_id, version_id)?;
         let testbed = QueryTestbed::get_json_for_report(conn, &query_project, testbed_id, spec_id)?;
         let results = get_report_results(log, conn, &query_project, id)?;
-        let alerts = get_report_alerts(conn, &query_project, id, head_id, version_id)?;
+        let alerts = get_report_alerts(conn, &query_project, id, head_id, version_id, spec_id)?;
         #[cfg(feature = "plus")]
         let job = get_report_job(conn, id)?;
 
@@ -677,6 +677,7 @@ fn get_report_alerts(
     report_id: ReportId,
     head_id: HeadId,
     version_id: VersionId,
+    spec_id: Option<SpecId>,
 ) -> Result<JsonReportAlerts, HttpError> {
     let alerts = schema::alert::table
         .inner_join(
@@ -728,6 +729,7 @@ fn get_report_alerts(
             created,
             head_id,
             version_id,
+            spec_id,
             iteration,
             query_benchmark,
             query_metric,

--- a/lib/bencher_schema/src/model/project/threshold/alert.rs
+++ b/lib/bencher_schema/src/model/project/threshold/alert.rs
@@ -17,11 +17,14 @@ use crate::{
     context::DbConnection,
     error::resource_not_found_err,
     macros::fn_get::{fn_get, fn_get_id, fn_get_uuid},
-    model::project::{
-        ProjectId, QueryProject,
-        benchmark::QueryBenchmark,
-        branch::{head::HeadId, version::VersionId},
-        metric::QueryMetric,
+    model::{
+        project::{
+            ProjectId, QueryProject,
+            benchmark::QueryBenchmark,
+            branch::{head::HeadId, version::VersionId},
+            metric::QueryMetric,
+        },
+        spec::SpecId,
     },
     schema::{self, alert as alert_table},
 };
@@ -90,6 +93,7 @@ impl QueryAlert {
             created,
             head_id,
             version_id,
+            spec_id,
             iteration,
             query_benchmark,
             query_metric,
@@ -110,6 +114,7 @@ impl QueryAlert {
                 schema::report::created,
                 schema::report::head_id,
                 schema::report::version_id,
+                schema::report::spec_id,
                 schema::report_benchmark::iteration,
                 QueryBenchmark::as_select(),
                 QueryMetric::as_select(),
@@ -120,6 +125,7 @@ impl QueryAlert {
                 DateTime,
                 HeadId,
                 VersionId,
+                Option<SpecId>,
                 Iteration,
                 QueryBenchmark,
                 QueryMetric,
@@ -134,6 +140,7 @@ impl QueryAlert {
             created,
             head_id,
             version_id,
+            spec_id,
             iteration,
             query_benchmark,
             query_metric,
@@ -150,6 +157,7 @@ impl QueryAlert {
         created: DateTime,
         head_id: HeadId,
         version_id: VersionId,
+        spec_id: Option<SpecId>,
         iteration: Iteration,
         query_benchmark: QueryBenchmark,
         query_metric: QueryMetric,
@@ -168,6 +176,7 @@ impl QueryAlert {
             query_boundary.model_id,
             head_id,
             version_id,
+            spec_id,
         )?;
         Ok(JsonAlert {
             uuid,
@@ -266,6 +275,11 @@ mod tests {
     use bencher_json::project::{alert::AlertStatus, boundary::BoundaryLimit};
     use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 
+    #[cfg(feature = "plus")]
+    use crate::test_util::{
+        CreateSpecArgs, clear_testbed_spec, create_spec, set_report_spec, set_testbed_spec,
+    };
+
     use crate::{
         schema,
         test_util::{
@@ -281,11 +295,12 @@ mod tests {
         ProjectId,
         branch::{BranchId, head::HeadId, version::VersionId},
         measure::MeasureId,
+        report::ReportId,
         testbed::TestbedId,
     };
 
     /// Helper to create the full entity chain needed for an alert.
-    /// Returns the alert id.
+    /// Returns the alert id and the report id.
     #[expect(clippy::too_many_arguments)]
     fn create_alert_chain(
         conn: &mut diesel::SqliteConnection,
@@ -296,7 +311,7 @@ mod tests {
         branch_id: BranchId,
         measure_id: MeasureId,
         uuids: &AlertChainUuids<'_>,
-    ) -> AlertId {
+    ) -> (AlertId, ReportId) {
         let report_id = create_report(
             conn,
             uuids.report_uuid,
@@ -337,13 +352,14 @@ mod tests {
         let model_id = create_model(conn, threshold_id, uuids.model_uuid, 0);
         let boundary_id =
             create_boundary(conn, uuids.boundary_uuid, metric_id, threshold_id, model_id);
-        create_alert(
+        let alert_id = create_alert(
             conn,
             uuids.alert_uuid,
             boundary_id,
             BoundaryLimit::Upper,
             AlertStatus::Active,
-        )
+        );
+        (alert_id, report_id)
     }
 
     struct AlertChainUuids<'a> {
@@ -396,7 +412,7 @@ mod tests {
         );
 
         // Create 3 alerts on the same head
-        let alert1 = create_alert_chain(
+        let (alert1, _) = create_alert_chain(
             &mut conn,
             base.project_id,
             branch.head_id,
@@ -424,7 +440,7 @@ mod tests {
             "throughput",
             "throughput",
         );
-        let alert2 = create_alert_chain(
+        let (alert2, _) = create_alert_chain(
             &mut conn,
             base.project_id,
             branch.head_id,
@@ -452,7 +468,7 @@ mod tests {
             "filesize",
             "filesize",
         );
-        let alert3 = create_alert_chain(
+        let (alert3, _) = create_alert_chain(
             &mut conn,
             base.project_id,
             branch.head_id,
@@ -552,7 +568,7 @@ mod tests {
         );
 
         // Create alert on head1
-        let alert_head1 = create_alert_chain(
+        let (alert_head1, _) = create_alert_chain(
             &mut conn,
             base.project_id,
             branch1.head_id,
@@ -582,7 +598,7 @@ mod tests {
         );
 
         // Create alert on head2
-        let alert_head2 = create_alert_chain(
+        let (alert_head2, _) = create_alert_chain(
             &mut conn,
             base.project_id,
             branch2.head_id,
@@ -671,5 +687,274 @@ mod tests {
                 .execute(&mut conn)
                 .expect("Failed to bulk silence alerts");
         assert_eq!(updated, 0);
+    }
+
+    #[cfg(feature = "plus")]
+    struct AlertSpecSetup {
+        testbed: TestbedId,
+        branch: BranchId,
+        head: HeadId,
+        version: VersionId,
+        measure: MeasureId,
+        project: ProjectId,
+    }
+
+    #[cfg(feature = "plus")]
+    fn setup_alert_spec_entities(conn: &mut diesel::SqliteConnection) -> AlertSpecSetup {
+        let base = create_base_entities(conn);
+        let branch = create_branch_with_head(
+            conn,
+            base.project_id,
+            "00000000-0000-0000-0000-000000000110",
+            "main",
+            "main",
+            "00000000-0000-0000-0000-000000000111",
+        );
+        let testbed = create_testbed(
+            conn,
+            base.project_id,
+            "00000000-0000-0000-0000-000000000120",
+            "localhost",
+            "localhost",
+        );
+        let version = create_version(
+            conn,
+            base.project_id,
+            "00000000-0000-0000-0000-000000000130",
+            1,
+            None,
+        );
+        create_head_version(conn, branch.head_id, version);
+        let measure = create_measure(
+            conn,
+            base.project_id,
+            "00000000-0000-0000-0000-000000000140",
+            "latency",
+            "latency",
+        );
+        AlertSpecSetup {
+            testbed,
+            branch: branch.branch_id,
+            head: branch.head_id,
+            version,
+            measure,
+            project: base.project_id,
+        }
+    }
+
+    #[cfg(feature = "plus")]
+    const ALERT_SPEC_UUIDS: AlertChainUuids<'_> = AlertChainUuids {
+        report_uuid: "00000000-0000-0000-0000-000000000200",
+        benchmark_uuid: "00000000-0000-0000-0000-000000000201",
+        benchmark_name: "bench_spec",
+        benchmark_slug: "bench-spec",
+        report_benchmark_uuid: "00000000-0000-0000-0000-000000000202",
+        metric_uuid: "00000000-0000-0000-0000-000000000203",
+        threshold_uuid: "00000000-0000-0000-0000-000000000204",
+        model_uuid: "00000000-0000-0000-0000-000000000205",
+        boundary_uuid: "00000000-0000-0000-0000-000000000206",
+        alert_uuid: "00000000-0000-0000-0000-000000000207",
+    };
+
+    #[cfg(feature = "plus")]
+    fn spec_a_args() -> CreateSpecArgs<'static> {
+        CreateSpecArgs {
+            uuid: "00000000-0000-0000-0000-000000000150",
+            name: "Spec A",
+            slug: "spec-a",
+            os: "linux",
+            architecture: "x86_64",
+            cpu: 4,
+            memory: 0x2_0000_0000,
+            disk: 0x4000_0000,
+            network: false,
+        }
+    }
+
+    #[cfg(feature = "plus")]
+    fn spec_b_args() -> CreateSpecArgs<'static> {
+        CreateSpecArgs {
+            uuid: "00000000-0000-0000-0000-000000000160",
+            name: "Spec B",
+            slug: "spec-b",
+            os: "linux",
+            architecture: "aarch64",
+            cpu: 8,
+            memory: 0x4_0000_0000,
+            disk: 0x8000_0000,
+            network: true,
+        }
+    }
+
+    #[cfg(feature = "plus")]
+    #[test]
+    fn alert_spec_both_none() {
+        use super::QueryAlert;
+
+        let mut conn = setup_test_db();
+        let s = setup_alert_spec_entities(&mut conn);
+        let (alert_id, _) = create_alert_chain(
+            &mut conn,
+            s.project,
+            s.head,
+            s.version,
+            s.testbed,
+            s.branch,
+            s.measure,
+            &ALERT_SPEC_UUIDS,
+        );
+
+        let alert = QueryAlert::get(&mut conn, alert_id).unwrap();
+        let json_alert = alert.into_json(&mut conn).unwrap();
+        assert!(
+            json_alert.threshold.testbed.spec.is_none(),
+            "both report and testbed have no spec"
+        );
+    }
+
+    #[cfg(feature = "plus")]
+    #[test]
+    fn alert_spec_both_same() {
+        use super::QueryAlert;
+
+        let mut conn = setup_test_db();
+        let s = setup_alert_spec_entities(&mut conn);
+
+        let spec_a = create_spec(&mut conn, spec_a_args());
+        set_testbed_spec(&mut conn, s.testbed, spec_a);
+
+        let (alert_id, report_id) = create_alert_chain(
+            &mut conn,
+            s.project,
+            s.head,
+            s.version,
+            s.testbed,
+            s.branch,
+            s.measure,
+            &ALERT_SPEC_UUIDS,
+        );
+        set_report_spec(&mut conn, report_id, spec_a);
+
+        let alert = QueryAlert::get(&mut conn, alert_id).unwrap();
+        let json_alert = alert.into_json(&mut conn).unwrap();
+        let spec = json_alert
+            .threshold
+            .testbed
+            .spec
+            .expect("spec should be present");
+        assert_eq!(
+            spec.uuid.to_string(),
+            spec_a_args().uuid,
+            "alert should use the shared spec"
+        );
+    }
+
+    #[cfg(feature = "plus")]
+    #[test]
+    fn alert_spec_no_report_testbed_gains() {
+        use super::QueryAlert;
+
+        let mut conn = setup_test_db();
+        let s = setup_alert_spec_entities(&mut conn);
+
+        let (alert_id, _) = create_alert_chain(
+            &mut conn,
+            s.project,
+            s.head,
+            s.version,
+            s.testbed,
+            s.branch,
+            s.measure,
+            &ALERT_SPEC_UUIDS,
+        );
+
+        let spec_a = create_spec(&mut conn, spec_a_args());
+        set_testbed_spec(&mut conn, s.testbed, spec_a);
+
+        let alert = QueryAlert::get(&mut conn, alert_id).unwrap();
+        let json_alert = alert.into_json(&mut conn).unwrap();
+        assert!(
+            json_alert.threshold.testbed.spec.is_none(),
+            "alert should use report spec (None), not testbed's current spec"
+        );
+    }
+
+    #[cfg(feature = "plus")]
+    #[test]
+    fn alert_spec_report_has_testbed_changes() {
+        use super::QueryAlert;
+
+        let mut conn = setup_test_db();
+        let s = setup_alert_spec_entities(&mut conn);
+
+        let spec_a = create_spec(&mut conn, spec_a_args());
+        set_testbed_spec(&mut conn, s.testbed, spec_a);
+
+        let (alert_id, report_id) = create_alert_chain(
+            &mut conn,
+            s.project,
+            s.head,
+            s.version,
+            s.testbed,
+            s.branch,
+            s.measure,
+            &ALERT_SPEC_UUIDS,
+        );
+        set_report_spec(&mut conn, report_id, spec_a);
+
+        let spec_b = create_spec(&mut conn, spec_b_args());
+        set_testbed_spec(&mut conn, s.testbed, spec_b);
+
+        let alert = QueryAlert::get(&mut conn, alert_id).unwrap();
+        let json_alert = alert.into_json(&mut conn).unwrap();
+        let spec = json_alert
+            .threshold
+            .testbed
+            .spec
+            .expect("spec should be present");
+        assert_eq!(
+            spec.uuid.to_string(),
+            spec_a_args().uuid,
+            "alert should use report's spec_a, not testbed's current spec_b"
+        );
+    }
+
+    #[cfg(feature = "plus")]
+    #[test]
+    fn alert_spec_report_has_testbed_cleared() {
+        use super::QueryAlert;
+
+        let mut conn = setup_test_db();
+        let s = setup_alert_spec_entities(&mut conn);
+
+        let spec_a = create_spec(&mut conn, spec_a_args());
+        set_testbed_spec(&mut conn, s.testbed, spec_a);
+
+        let (alert_id, report_id) = create_alert_chain(
+            &mut conn,
+            s.project,
+            s.head,
+            s.version,
+            s.testbed,
+            s.branch,
+            s.measure,
+            &ALERT_SPEC_UUIDS,
+        );
+        set_report_spec(&mut conn, report_id, spec_a);
+
+        clear_testbed_spec(&mut conn, s.testbed);
+
+        let alert = QueryAlert::get(&mut conn, alert_id).unwrap();
+        let json_alert = alert.into_json(&mut conn).unwrap();
+        let spec = json_alert
+            .threshold
+            .testbed
+            .spec
+            .expect("spec should be present");
+        assert_eq!(
+            spec.uuid.to_string(),
+            spec_a_args().uuid,
+            "alert should use report's spec_a, even though testbed's spec was cleared"
+        );
     }
 }

--- a/lib/bencher_schema/src/model/project/threshold/mod.rs
+++ b/lib/bencher_schema/src/model/project/threshold/mod.rs
@@ -22,7 +22,6 @@ use super::{
     measure::{MeasureId, QueryMeasure},
     testbed::{QueryTestbed, TestbedId},
 };
-use crate::model::spec::SpecId;
 use crate::{
     auth_conn,
     context::{ApiContext, DbConnection},
@@ -34,6 +33,7 @@ use crate::{
         fn_get::{fn_get, fn_get_id, fn_get_uuid},
         sql::last_insert_rowid,
     },
+    model::spec::SpecId,
     schema::{self, threshold as threshold_table},
     write_transaction,
 };

--- a/lib/bencher_schema/src/model/project/threshold/mod.rs
+++ b/lib/bencher_schema/src/model/project/threshold/mod.rs
@@ -22,6 +22,7 @@ use super::{
     measure::{MeasureId, QueryMeasure},
     testbed::{QueryTestbed, TestbedId},
 };
+use crate::model::spec::SpecId;
 use crate::{
     auth_conn,
     context::{ApiContext, DbConnection},
@@ -58,6 +59,14 @@ pub struct QueryThreshold {
     pub model_id: Option<ModelId>,
     pub created: DateTime,
     pub modified: DateTime,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ThresholdSpec {
+    /// Use the testbed's own current spec (standalone threshold views)
+    Testbed,
+    /// Use the report's spec (alert views) — may be None for non-job reports
+    Report(Option<SpecId>),
 }
 
 impl QueryThreshold {
@@ -211,15 +220,21 @@ impl QueryThreshold {
         model_id: ModelId,
         head_id: HeadId,
         version_id: VersionId,
+        spec_id: Option<SpecId>,
     ) -> Result<JsonThreshold, HttpError> {
         let query_threshold = Self::get(conn, threshold_id)?;
         let query_model = QueryModel::get(conn, model_id)?;
-        query_threshold.into_json_for_model(conn, Some(query_model), Some((head_id, version_id)))
+        query_threshold.into_json_for_model(
+            conn,
+            Some(query_model),
+            Some((head_id, version_id)),
+            ThresholdSpec::Report(spec_id),
+        )
     }
 
     pub fn into_json(self, conn: &mut DbConnection) -> Result<JsonThreshold, HttpError> {
         let query_model = self.model(conn)?;
-        self.into_json_for_model(conn, query_model, None)
+        self.into_json_for_model(conn, query_model, None, ThresholdSpec::Testbed)
     }
 
     pub fn into_json_for_model(
@@ -227,6 +242,7 @@ impl QueryThreshold {
         conn: &mut DbConnection,
         query_model: Option<QueryModel>,
         head_version: Option<(HeadId, VersionId)>,
+        threshold_spec: ThresholdSpec,
     ) -> Result<JsonThreshold, HttpError> {
         let model = if let Some(query_model) = &query_model {
             assert_parentage(
@@ -256,8 +272,14 @@ impl QueryThreshold {
             let query_branch = QueryBranch::get(conn, branch_id)?;
             query_branch.into_json_for_project(conn, &query_project)?
         };
-        let testbed =
-            QueryTestbed::get(conn, testbed_id)?.into_json_for_project(conn, &query_project)?;
+        let testbed = match threshold_spec {
+            ThresholdSpec::Report(spec_id) => {
+                QueryTestbed::get_json_for_report(conn, &query_project, testbed_id, spec_id)?
+            },
+            ThresholdSpec::Testbed => {
+                QueryTestbed::get(conn, testbed_id)?.into_json_for_project(conn, &query_project)?
+            },
+        };
         let measure = QueryMeasure::get(conn, measure_id)?.into_json_for_project(&query_project);
         Ok(JsonThreshold {
             uuid,

--- a/lib/bencher_schema/src/test_util.rs
+++ b/lib/bencher_schema/src/test_util.rs
@@ -428,6 +428,14 @@ pub fn clear_testbed_spec(conn: &mut SqliteConnection, testbed_id: TestbedId) {
         .expect("Failed to clear testbed spec_id");
 }
 
+/// Set report `spec_id`.
+pub fn set_report_spec(conn: &mut SqliteConnection, report_id: ReportId, spec_id: SpecId) {
+    diesel::update(schema::report::table.filter(schema::report::id.eq(report_id)))
+        .set(schema::report::spec_id.eq(Some(spec_id)))
+        .execute(conn)
+        .expect("Failed to set report spec_id");
+}
+
 /// Delete a spec by id.
 pub fn delete_spec(conn: &mut SqliteConnection, spec_id: SpecId) {
     diesel::delete(schema::spec::table.filter(schema::spec::id.eq(spec_id)))

--- a/lib/bencher_schema/src/test_util.rs
+++ b/lib/bencher_schema/src/test_util.rs
@@ -139,10 +139,11 @@ pub fn create_branch_with_head(
         .expect("Failed to get head id");
 
     // Update branch to point to head
-    diesel::update(schema::branch::table.filter(schema::branch::id.eq(branch_id)))
+    let updated = diesel::update(schema::branch::table.filter(schema::branch::id.eq(branch_id)))
         .set(schema::branch::head_id.eq(head_id))
         .execute(conn)
         .expect("Failed to update branch head_id");
+    assert_eq!(updated, 1, "expected exactly 1 branch row updated");
 
     BranchIds { branch_id, head_id }
 }
@@ -299,10 +300,12 @@ pub fn create_model(
         .expect("Failed to get model id");
 
     // Update threshold to reference model
-    diesel::update(schema::threshold::table.filter(schema::threshold::id.eq(threshold_id)))
-        .set(schema::threshold::model_id.eq(model_id))
-        .execute(conn)
-        .expect("Failed to update threshold with model_id");
+    let updated =
+        diesel::update(schema::threshold::table.filter(schema::threshold::id.eq(threshold_id)))
+            .set(schema::threshold::model_id.eq(model_id))
+            .execute(conn)
+            .expect("Failed to update threshold with model_id");
+    assert_eq!(updated, 1, "expected exactly 1 threshold row updated");
 
     model_id
 }
@@ -414,41 +417,46 @@ pub fn get_testbed_spec_id(conn: &mut SqliteConnection, testbed_id: TestbedId) -
 
 /// Set testbed `spec_id`.
 pub fn set_testbed_spec(conn: &mut SqliteConnection, testbed_id: TestbedId, spec_id: SpecId) {
-    diesel::update(schema::testbed::table.filter(schema::testbed::id.eq(testbed_id)))
+    let updated = diesel::update(schema::testbed::table.filter(schema::testbed::id.eq(testbed_id)))
         .set(schema::testbed::spec_id.eq(Some(spec_id)))
         .execute(conn)
         .expect("Failed to set testbed spec_id");
+    assert_eq!(updated, 1, "expected exactly 1 testbed row updated");
 }
 
 /// Clear testbed `spec_id`.
 pub fn clear_testbed_spec(conn: &mut SqliteConnection, testbed_id: TestbedId) {
-    diesel::update(schema::testbed::table.filter(schema::testbed::id.eq(testbed_id)))
+    let updated = diesel::update(schema::testbed::table.filter(schema::testbed::id.eq(testbed_id)))
         .set(schema::testbed::spec_id.eq(None::<SpecId>))
         .execute(conn)
         .expect("Failed to clear testbed spec_id");
+    assert_eq!(updated, 1, "expected exactly 1 testbed row updated");
 }
 
 /// Set report `spec_id`.
 pub fn set_report_spec(conn: &mut SqliteConnection, report_id: ReportId, spec_id: SpecId) {
-    diesel::update(schema::report::table.filter(schema::report::id.eq(report_id)))
+    let updated = diesel::update(schema::report::table.filter(schema::report::id.eq(report_id)))
         .set(schema::report::spec_id.eq(Some(spec_id)))
         .execute(conn)
         .expect("Failed to set report spec_id");
+    assert_eq!(updated, 1, "expected exactly 1 report row updated");
 }
 
 /// Delete a spec by id.
 pub fn delete_spec(conn: &mut SqliteConnection, spec_id: SpecId) {
-    diesel::delete(schema::spec::table.filter(schema::spec::id.eq(spec_id)))
+    let deleted = diesel::delete(schema::spec::table.filter(schema::spec::id.eq(spec_id)))
         .execute(conn)
         .expect("Failed to delete spec");
+    assert_eq!(deleted, 1, "expected exactly 1 spec row deleted");
 }
 
 /// Archive a testbed.
 pub fn archive_testbed(conn: &mut SqliteConnection, testbed_id: TestbedId) {
-    diesel::update(schema::testbed::table.filter(schema::testbed::id.eq(testbed_id)))
+    let updated = diesel::update(schema::testbed::table.filter(schema::testbed::id.eq(testbed_id)))
         .set(schema::testbed::archived.eq(Some(DateTime::TEST)))
         .execute(conn)
         .expect("Failed to archive testbed");
+    assert_eq!(updated, 1, "expected exactly 1 testbed row updated");
 }
 
 /// Get testbed `archived` timestamp.
@@ -639,18 +647,21 @@ pub fn get_head_replaced(conn: &mut SqliteConnection, head_id: HeadId) -> Option
 
 /// Archive a benchmark.
 pub fn archive_benchmark(conn: &mut SqliteConnection, benchmark_id: BenchmarkId) {
-    diesel::update(schema::benchmark::table.filter(schema::benchmark::id.eq(benchmark_id)))
-        .set(schema::benchmark::archived.eq(Some(DateTime::TEST)))
-        .execute(conn)
-        .expect("Failed to archive benchmark");
+    let updated =
+        diesel::update(schema::benchmark::table.filter(schema::benchmark::id.eq(benchmark_id)))
+            .set(schema::benchmark::archived.eq(Some(DateTime::TEST)))
+            .execute(conn)
+            .expect("Failed to archive benchmark");
+    assert_eq!(updated, 1, "expected exactly 1 benchmark row updated");
 }
 
 /// Archive a measure.
 pub fn archive_measure(conn: &mut SqliteConnection, measure_id: MeasureId) {
-    diesel::update(schema::measure::table.filter(schema::measure::id.eq(measure_id)))
+    let updated = diesel::update(schema::measure::table.filter(schema::measure::id.eq(measure_id)))
         .set(schema::measure::archived.eq(Some(DateTime::TEST)))
         .execute(conn)
         .expect("Failed to archive measure");
+    assert_eq!(updated, 1, "expected exactly 1 measure row updated");
 }
 
 /// Get benchmark `archived` timestamp.

--- a/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
+++ b/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
@@ -2,6 +2,7 @@
 - Fix sample standard deviation for Z-score, t-test, and Log Normal Thresholds to use Bessel's correction (divide by `n − 1`) (Thank you [@ggirol-rc](https://github.com/ggirol-rc))
 - Fix t-test Threshold to use the prediction interval (scale the standard deviation by `√(1 + 1/n)`) so the boundary tests whether a new Metric is consistent with the historical distribution rather than whether it contains the historical mean (Thank you [@ggirol-rc](https://github.com/ggirol-rc))
 - Existing Thresholds will produce slightly wider (statistically correct) boundaries; no configuration changes required
+- Fix Alert JSON to return the Spec for the Report in which the Alert was generated instead of the Testbed's current Spec
 
 ## `v0.6.2`
 - Allow unauthenticated `docker push` to unclaimed projects


### PR DESCRIPTION
This changeset fixes the Alert JSON to return the Spec for the Report in which the Alert was generated instead of the Testbed's current Spec.