### PR TITLE
Add API token revocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,7 @@ dependencies = [
  "bencher_api_tests",
  "bencher_endpoint",
  "bencher_json",
+ "bencher_otel",
  "bencher_schema",
  "diesel",
  "dropshot",

--- a/lib/api_users/Cargo.toml
+++ b/lib/api_users/Cargo.toml
@@ -10,11 +10,12 @@ publish = false
 default = []
 plus = ["bencher_endpoint/plus", "bencher_json/plus", "bencher_schema/plus"]
 sentry = ["bencher_schema/sentry"]
-otel = ["bencher_endpoint/otel", "bencher_schema/otel"]
+otel = ["dep:bencher_otel", "bencher_endpoint/otel", "bencher_schema/otel"]
 
 [dependencies]
 bencher_endpoint.workspace = true
 bencher_json = { workspace = true, features = ["server", "schema", "db"] }
+bencher_otel = { workspace = true, optional = true }
 bencher_schema.workspace = true
 diesel.workspace = true
 dropshot.workspace = true

--- a/lib/api_users/src/lib.rs
+++ b/lib/api_users/src/lib.rs
@@ -37,6 +37,7 @@ impl bencher_endpoint::Registrar for Api {
         api_description.register(tokens::user_token_post)?;
         api_description.register(tokens::user_token_get)?;
         api_description.register(tokens::user_token_patch)?;
+        api_description.register(tokens::user_token_delete)?;
 
         Ok(())
     }

--- a/lib/api_users/src/tokens.rs
+++ b/lib/api_users/src/tokens.rs
@@ -49,7 +49,8 @@ pub struct UserTokensQuery {
     pub name: Option<ResourceName>,
     /// Search by token name, slug, or UUID.
     pub search: Option<Search>,
-    /// Include revoked tokens in the results. Defaults to `false`.
+    /// If set to `true`, only returns revoked tokens.
+    /// If not set or set to `false`, only returns non-revoked tokens.
     pub revoked: Option<bool>,
 }
 
@@ -142,7 +143,9 @@ fn get_ls_query<'q>(
         .filter(schema::token::user_id.eq(user_id))
         .into_boxed();
 
-    if !query_params.revoked.unwrap_or(false) {
+    if let Some(true) = query_params.revoked {
+        query = query.filter(schema::token::revoked.is_not_null());
+    } else {
         query = query.filter(schema::token::revoked.is_null());
     }
 

--- a/lib/api_users/src/tokens.rs
+++ b/lib/api_users/src/tokens.rs
@@ -9,7 +9,7 @@ use bencher_json::{
 use bencher_schema::{
     auth_conn,
     context::ApiContext,
-    error::{bad_request_error, resource_conflict_err, resource_not_found_err},
+    error::{conflict_error, resource_conflict_err, resource_not_found_err},
     model::user::{
         QueryUser, UserId,
         auth::{AuthUser, BearerToken},
@@ -378,7 +378,7 @@ async fn delete_inner(
     )?;
 
     if query_token.revoked.is_some() {
-        return Err(bad_request_error("Token has already been revoked"));
+        return Err(conflict_error("Token has already been revoked"));
     }
 
     let now = context.clock.now();

--- a/lib/api_users/src/tokens.rs
+++ b/lib/api_users/src/tokens.rs
@@ -218,6 +218,9 @@ async fn post_inner(
         .execute(write_conn!(context))
         .map_err(resource_conflict_err!(Token, insert_token))?;
 
+    #[cfg(feature = "otel")]
+    bencher_otel::ApiMeter::increment(bencher_otel::ApiCounter::UserTokenCreate);
+
     auth_conn!(context, |conn| {
         schema::token::table
             .filter(schema::token::uuid.eq(&insert_token.uuid))
@@ -382,6 +385,9 @@ async fn delete_inner(
         now
     ))
     .map_err(resource_conflict_err!(Token, (&query_user, &query_token)))?;
+
+    #[cfg(feature = "otel")]
+    bencher_otel::ApiMeter::increment(bencher_otel::ApiCounter::UserTokenRevoke);
 
     Ok(())
 }

--- a/lib/api_users/src/tokens.rs
+++ b/lib/api_users/src/tokens.rs
@@ -377,17 +377,16 @@ async fn delete_inner(
         &path_params.token.to_string(),
     )?;
 
-    if query_token.revoked.is_some() {
-        return Err(conflict_error("Token has already been revoked"));
-    }
-
     let now = context.clock.now();
-    write_transaction!(context, |conn| QueryToken::revoke(
+    let rows = write_transaction!(context, |conn| QueryToken::revoke(
         conn,
         query_token.id,
         now
     ))
     .map_err(resource_conflict_err!(Token, (&query_user, &query_token)))?;
+    if rows == 0 {
+        return Err(conflict_error("Token has already been revoked"));
+    }
 
     #[cfg(feature = "otel")]
     bencher_otel::ApiMeter::increment(bencher_otel::ApiCounter::UserTokenRevoke);

--- a/lib/api_users/src/tokens.rs
+++ b/lib/api_users/src/tokens.rs
@@ -1,5 +1,6 @@
 use bencher_endpoint::{
-    CorsResponse, Endpoint, Get, Patch, Post, ResponseCreated, ResponseOk, TotalCount,
+    CorsResponse, Delete, Endpoint, Get, Patch, Post, ResponseCreated, ResponseDeleted, ResponseOk,
+    TotalCount,
 };
 use bencher_json::{
     JsonDirection, JsonNewToken, JsonPagination, JsonToken, JsonTokens, ResourceName, Search,
@@ -8,14 +9,14 @@ use bencher_json::{
 use bencher_schema::{
     auth_conn,
     context::ApiContext,
-    error::{resource_conflict_err, resource_not_found_err},
+    error::{bad_request_error, resource_conflict_err, resource_not_found_err},
     model::user::{
         QueryUser, UserId,
         auth::{AuthUser, BearerToken},
         same_user,
         token::{InsertToken, QueryToken, UpdateToken},
     },
-    schema, write_conn,
+    schema, write_conn, write_transaction,
 };
 use diesel::{
     BoolExpressionMethods as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _,
@@ -48,6 +49,8 @@ pub struct UserTokensQuery {
     pub name: Option<ResourceName>,
     /// Search by token name, slug, or UUID.
     pub search: Option<Search>,
+    /// Include revoked tokens in the results. Defaults to `false`.
+    pub revoked: Option<bool>,
 }
 
 #[endpoint {
@@ -138,6 +141,10 @@ fn get_ls_query<'q>(
     let mut query = schema::token::table
         .filter(schema::token::user_id.eq(user_id))
         .into_boxed();
+
+    if !query_params.revoked.unwrap_or(false) {
+        query = query.filter(schema::token::revoked.is_null());
+    }
 
     if let Some(name) = query_params.name.as_ref() {
         query = query.filter(schema::token::name.eq(name));
@@ -237,7 +244,7 @@ pub async fn user_token_options(
     _rqctx: RequestContext<ApiContext>,
     _path_params: Path<UserTokenParams>,
 ) -> Result<CorsResponse, HttpError> {
-    Ok(Endpoint::cors(&[Get.into(), Patch.into()]))
+    Ok(Endpoint::cors(&[Get.into(), Patch.into(), Delete.into()]))
 }
 
 /// View a token
@@ -327,4 +334,54 @@ async fn patch_inner(
     auth_conn!(context, |conn| {
         QueryToken::get(conn, query_token.id)?.into_json(conn)
     })
+}
+
+/// Revoke a token
+///
+/// Revoke an API token for a user.
+/// Revocation is terminal: a revoked token can no longer authenticate any request,
+/// and the revocation cannot be undone (for security — a leaked JWT must not become valid again).
+/// Only the authenticated user themselves and server admins have access to this endpoint.
+#[endpoint {
+    method = DELETE,
+    path =  "/v0/users/{user}/tokens/{token}",
+    tags = ["users", "tokens"]
+}]
+pub async fn user_token_delete(
+    rqctx: RequestContext<ApiContext>,
+    bearer_token: BearerToken,
+    path_params: Path<UserTokenParams>,
+) -> Result<ResponseDeleted, HttpError> {
+    let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
+    delete_inner(rqctx.context(), path_params.into_inner(), &auth_user).await?;
+    Ok(Delete::auth_response_deleted())
+}
+
+async fn delete_inner(
+    context: &ApiContext,
+    path_params: UserTokenParams,
+    auth_user: &AuthUser,
+) -> Result<(), HttpError> {
+    let query_user = QueryUser::from_resource_id(auth_conn!(context), &path_params.user)?;
+    same_user!(auth_user, context.rbac, query_user.uuid);
+
+    let query_token = QueryToken::get_user_token(
+        auth_conn!(context),
+        query_user.id,
+        &path_params.token.to_string(),
+    )?;
+
+    if query_token.revoked.is_some() {
+        return Err(bad_request_error("Token has already been revoked"));
+    }
+
+    let now = context.clock.now();
+    write_transaction!(context, |conn| QueryToken::revoke(
+        conn,
+        query_token.id,
+        now
+    ))
+    .map_err(resource_conflict_err!(Token, (&query_user, &query_token)))?;
+
+    Ok(())
 }

--- a/lib/api_users/src/users.rs
+++ b/lib/api_users/src/users.rs
@@ -12,8 +12,9 @@ use bencher_schema::{
         admin::AdminUser,
         auth::{AuthUser, BearerToken},
         same_user,
+        token::QueryToken,
     },
-    schema, write_conn,
+    schema, write_conn, write_transaction,
 };
 use diesel::{
     BoolExpressionMethods as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _,
@@ -234,10 +235,27 @@ async fn patch_inner(
     }
 
     let update_user = UpdateUser::from(json_user.clone());
-    diesel::update(schema::user::table.filter(schema::user::id.eq(query_user.id)))
-        .set(&update_user)
-        .execute(write_conn!(context))
+
+    let email_changed = json_user
+        .email
+        .as_ref()
+        .is_some_and(|new_email| *new_email != query_user.email);
+
+    if email_changed {
+        let now = context.clock.now();
+        write_transaction!(context, |conn| {
+            diesel::update(schema::user::table.filter(schema::user::id.eq(query_user.id)))
+                .set(&update_user)
+                .execute(conn)?;
+            QueryToken::revoke_all(conn, query_user.id, now)
+        })
         .map_err(resource_conflict_err!(User, (&query_user, &json_user)))?;
+    } else {
+        diesel::update(schema::user::table.filter(schema::user::id.eq(query_user.id)))
+            .set(&update_user)
+            .execute(write_conn!(context))
+            .map_err(resource_conflict_err!(User, (&query_user, &json_user)))?;
+    }
 
     Ok(QueryUser::get(auth_conn!(context), query_user.id)?.into_json())
 }

--- a/lib/api_users/tests/tokens.rs
+++ b/lib/api_users/tests/tokens.rs
@@ -473,6 +473,50 @@ async fn tokens_revoke_other_user_forbidden() {
     );
 }
 
+// DELETE /v0/users/{user}/tokens/{token} - admin can revoke another user's token
+#[tokio::test]
+async fn tokens_revoke_admin_can_revoke_other_user() {
+    let server = TestServer::new().await;
+    // First signup is admin on this server.
+    let admin = server.signup("Admin", "revokeadmin@example.com").await;
+    let target = server.signup("Target", "revoketarget@example.com").await;
+    let target_slug: &str = target.slug.as_ref();
+
+    let body = serde_json::json!({ "name": "Target Token" });
+    let create_resp = server
+        .client
+        .post(server.api_url(&format!("/v0/users/{}/tokens", target_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&target.token),
+        )
+        .json(&body)
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(create_resp.status(), StatusCode::CREATED);
+    let created: JsonToken = create_resp.json().await.expect("Failed to parse response");
+
+    let revoke_resp = server
+        .client
+        .delete(server.api_url(&format!(
+            "/v0/users/{}/tokens/{}",
+            target_slug, created.uuid
+        )))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&admin.token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(
+        revoke_resp.status(),
+        StatusCode::NO_CONTENT,
+        "admin must be able to revoke another user's token"
+    );
+}
+
 // DELETE /v0/users/{user}/tokens/{token} - revoking the same token twice is a 4xx
 #[tokio::test]
 async fn tokens_revoke_double_rejected() {
@@ -518,11 +562,7 @@ async fn tokens_revoke_double_rejected() {
         .send()
         .await
         .expect("Request failed");
-    assert!(
-        second.status().is_client_error(),
-        "second revocation must return a 4xx, got: {}",
-        second.status()
-    );
+    assert_eq!(second.status(), StatusCode::CONFLICT);
 }
 
 // POST /v0/users/{user}/tokens - cannot create token for other user

--- a/lib/api_users/tests/tokens.rs
+++ b/lib/api_users/tests/tokens.rs
@@ -232,6 +232,299 @@ async fn tokens_update() {
     assert_eq!(updated.name.as_ref(), "Updated Token");
 }
 
+// DELETE /v0/users/{user}/tokens/{token} - revoke succeeds and hides from default list
+#[tokio::test]
+async fn tokens_revoke_hides_from_list() {
+    let server = TestServer::new().await;
+    let user = server
+        .signup("Test User", "tokensrevokelist@example.com")
+        .await;
+    let user_slug: &str = user.slug.as_ref();
+
+    let body = serde_json::json!({ "name": "Revoke Me" });
+    let create_resp = server
+        .client
+        .post(server.api_url(&format!("/v0/users/{}/tokens", user_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(&body)
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(create_resp.status(), StatusCode::CREATED);
+    let created: JsonToken = create_resp.json().await.expect("Failed to parse response");
+
+    let revoke_resp = server
+        .client
+        .delete(server.api_url(&format!("/v0/users/{}/tokens/{}", user_slug, created.uuid)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(revoke_resp.status(), StatusCode::NO_CONTENT);
+
+    let list_resp = server
+        .client
+        .get(server.api_url(&format!("/v0/users/{}/tokens", user_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(list_resp.status(), StatusCode::OK);
+    let tokens: JsonTokens = list_resp.json().await.expect("Failed to parse response");
+    assert!(
+        tokens.0.iter().all(|t| t.uuid != created.uuid),
+        "revoked token must be hidden from default list: {:?}",
+        tokens
+    );
+
+    let list_with_revoked = server
+        .client
+        .get(server.api_url(&format!("/v0/users/{}/tokens?revoked=true", user_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(list_with_revoked.status(), StatusCode::OK);
+    let tokens: JsonTokens = list_with_revoked
+        .json()
+        .await
+        .expect("Failed to parse response");
+    let entry = tokens
+        .0
+        .iter()
+        .find(|t| t.uuid == created.uuid)
+        .expect("revoked token should appear when `?revoked=true`");
+    assert!(
+        entry.revoked.is_some(),
+        "revoked entry must carry a revoked timestamp: {:?}",
+        entry
+    );
+}
+
+// DELETE /v0/users/{user}/tokens/{token} - revoked token still readable via direct GET
+#[tokio::test]
+async fn tokens_revoke_visible_on_direct_get() {
+    let server = TestServer::new().await;
+    let user = server
+        .signup("Test User", "tokensrevokeget@example.com")
+        .await;
+    let user_slug: &str = user.slug.as_ref();
+
+    let body = serde_json::json!({ "name": "Visible After Revoke" });
+    let create_resp = server
+        .client
+        .post(server.api_url(&format!("/v0/users/{}/tokens", user_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(&body)
+        .send()
+        .await
+        .expect("Request failed");
+    let created: JsonToken = create_resp.json().await.expect("Failed to parse response");
+
+    let revoke_resp = server
+        .client
+        .delete(server.api_url(&format!("/v0/users/{}/tokens/{}", user_slug, created.uuid)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(revoke_resp.status(), StatusCode::NO_CONTENT);
+
+    let get_resp = server
+        .client
+        .get(server.api_url(&format!("/v0/users/{}/tokens/{}", user_slug, created.uuid)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(get_resp.status(), StatusCode::OK);
+    let fetched: JsonToken = get_resp.json().await.expect("Failed to parse response");
+    assert!(
+        fetched.revoked.is_some(),
+        "direct GET on revoked token must expose the revoked timestamp: {:?}",
+        fetched
+    );
+}
+
+// DELETE /v0/users/{user}/tokens/{token} - revoked JWT stops authenticating
+#[tokio::test]
+async fn tokens_revoke_breaks_auth() {
+    let server = TestServer::new().await;
+    let user = server
+        .signup("Test User", "tokensrevokeauth@example.com")
+        .await;
+    let user_slug: &str = user.slug.as_ref();
+
+    let body = serde_json::json!({ "name": "About To Be Revoked" });
+    let create_resp = server
+        .client
+        .post(server.api_url(&format!("/v0/users/{}/tokens", user_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(&body)
+        .send()
+        .await
+        .expect("Request failed");
+    let created: JsonToken = create_resp.json().await.expect("Failed to parse response");
+
+    // The freshly minted JWT authenticates.
+    let pre_auth = server
+        .client
+        .get(server.api_url(&format!("/v0/users/{}/tokens", user_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&created.token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(pre_auth.status(), StatusCode::OK);
+
+    let revoke_resp = server
+        .client
+        .delete(server.api_url(&format!("/v0/users/{}/tokens/{}", user_slug, created.uuid)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(revoke_resp.status(), StatusCode::NO_CONTENT);
+
+    // Same JWT, now rejected as 401.
+    let post_auth = server
+        .client
+        .get(server.api_url(&format!("/v0/users/{}/tokens", user_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&created.token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(post_auth.status(), StatusCode::UNAUTHORIZED);
+}
+
+// DELETE /v0/users/{user}/tokens/{token} - another non-admin user cannot revoke
+#[tokio::test]
+async fn tokens_revoke_other_user_forbidden() {
+    let server = TestServer::new().await;
+    let owner = server.signup("Owner", "revokeowner@example.com").await;
+    // First signup is admin on this server; ensure the attacker is not the owner.
+    let attacker = server
+        .signup("Attacker", "revokeattacker@example.com")
+        .await;
+    let owner_slug: &str = owner.slug.as_ref();
+
+    let body = serde_json::json!({ "name": "Owner Token" });
+    let create_resp = server
+        .client
+        .post(server.api_url(&format!("/v0/users/{}/tokens", owner_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&owner.token),
+        )
+        .json(&body)
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(create_resp.status(), StatusCode::CREATED);
+    let created: JsonToken = create_resp.json().await.expect("Failed to parse response");
+
+    let revoke_resp = server
+        .client
+        .delete(server.api_url(&format!("/v0/users/{}/tokens/{}", owner_slug, created.uuid)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&attacker.token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    // `same_user!` returns 4xx when a non-admin user acts on another user's resource.
+    assert!(
+        revoke_resp.status().is_client_error(),
+        "non-admin attacker must not be able to revoke another user's token, got: {}",
+        revoke_resp.status()
+    );
+}
+
+// DELETE /v0/users/{user}/tokens/{token} - revoking the same token twice is a 4xx
+#[tokio::test]
+async fn tokens_revoke_double_rejected() {
+    let server = TestServer::new().await;
+    let user = server
+        .signup("Test User", "tokensrevoketwice@example.com")
+        .await;
+    let user_slug: &str = user.slug.as_ref();
+
+    let body = serde_json::json!({ "name": "Revoke Twice" });
+    let create_resp = server
+        .client
+        .post(server.api_url(&format!("/v0/users/{}/tokens", user_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(&body)
+        .send()
+        .await
+        .expect("Request failed");
+    let created: JsonToken = create_resp.json().await.expect("Failed to parse response");
+
+    let first = server
+        .client
+        .delete(server.api_url(&format!("/v0/users/{}/tokens/{}", user_slug, created.uuid)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(first.status(), StatusCode::NO_CONTENT);
+
+    let second = server
+        .client
+        .delete(server.api_url(&format!("/v0/users/{}/tokens/{}", user_slug, created.uuid)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    assert!(
+        second.status().is_client_error(),
+        "second revocation must return a 4xx, got: {}",
+        second.status()
+    );
+}
+
 // POST /v0/users/{user}/tokens - cannot create token for other user
 #[tokio::test]
 async fn tokens_create_other_user_forbidden() {

--- a/lib/api_users/tests/users.rs
+++ b/lib/api_users/tests/users.rs
@@ -6,7 +6,7 @@
 //! Integration tests for user CRUD endpoints.
 
 use bencher_api_tests::TestServer;
-use bencher_json::JsonUser;
+use bencher_json::{Email, JsonToken, JsonTokens, JsonUser};
 use http::StatusCode;
 
 // GET /v0/users - admin can list all users
@@ -213,4 +213,157 @@ async fn users_update_admin_forbidden() {
 
     // Non-admin cannot set admin flag
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+// PATCH /v0/users/{user} - changing email revokes all API tokens
+#[tokio::test]
+async fn users_update_email_revokes_tokens() {
+    let server = TestServer::new().await;
+    let user = server.signup("Test User", "emailrevoke@example.com").await;
+    let user_slug: &str = user.slug.as_ref();
+
+    // Create an API token
+    let create_resp = server
+        .client
+        .post(server.api_url(&format!("/v0/users/{}/tokens", user_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(&serde_json::json!({ "name": "My Token" }))
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(create_resp.status(), StatusCode::CREATED);
+    let api_token: JsonToken = create_resp.json().await.expect("Failed to parse response");
+
+    // Verify the API token authenticates
+    let pre_resp = server
+        .client
+        .get(server.api_url(&format!("/v0/users/{}", user_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&api_token.token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(pre_resp.status(), StatusCode::OK);
+
+    // Change email (use session token, not the API token)
+    let new_email: Email = "newemail@example.com".parse().expect("Invalid email");
+    let patch_resp = server
+        .client
+        .patch(server.api_url(&format!("/v0/users/{}", user_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(&serde_json::json!({ "email": new_email }))
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(patch_resp.status(), StatusCode::OK);
+
+    // The old session token has the old email and can no longer authenticate.
+    // Generate a new client token for the new email.
+    let new_session = server
+        .token_key()
+        .new_client(new_email, u32::MAX)
+        .expect("Failed to create client token");
+
+    // The API token should now be revoked — list with ?revoked=true using the new session token
+    let list_resp = server
+        .client
+        .get(server.api_url(&format!("/v0/users/{}/tokens?revoked=true", user_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&new_session),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(list_resp.status(), StatusCode::OK);
+    let tokens: JsonTokens = list_resp.json().await.expect("Failed to parse response");
+    let entry = tokens
+        .0
+        .iter()
+        .find(|t| t.uuid == api_token.uuid)
+        .expect("revoked token should appear when ?revoked=true");
+    assert!(
+        entry.revoked.is_some(),
+        "token must carry a revoked timestamp after email change: {:?}",
+        entry
+    );
+
+    // The API token should no longer authenticate
+    let post_resp = server
+        .client
+        .get(server.api_url(&format!("/v0/users/{}", user_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&api_token.token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    assert!(
+        post_resp.status().is_client_error(),
+        "revoked API token must not authenticate after email change, got: {}",
+        post_resp.status()
+    );
+}
+
+// PATCH /v0/users/{user} - updating name does NOT revoke tokens
+#[tokio::test]
+async fn users_update_name_no_revoke() {
+    let server = TestServer::new().await;
+    let user = server.signup("Test User", "namenorevoke@example.com").await;
+    let user_slug: &str = user.slug.as_ref();
+
+    // Create an API token
+    let create_resp = server
+        .client
+        .post(server.api_url(&format!("/v0/users/{}/tokens", user_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(&serde_json::json!({ "name": "Keep Me" }))
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(create_resp.status(), StatusCode::CREATED);
+    let api_token: JsonToken = create_resp.json().await.expect("Failed to parse response");
+
+    // Update only the name
+    let patch_resp = server
+        .client
+        .patch(server.api_url(&format!("/v0/users/{}", user_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(&serde_json::json!({ "name": "New Name" }))
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(patch_resp.status(), StatusCode::OK);
+
+    // The API token should still work
+    let post_resp = server
+        .client
+        .get(server.api_url(&format!("/v0/users/{}", user_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&api_token.token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(
+        post_resp.status(),
+        StatusCode::OK,
+        "API token must still authenticate after name-only update"
+    );
 }

--- a/lib/bencher_json/src/user/token.rs
+++ b/lib/bencher_json/src/user/token.rs
@@ -35,6 +35,10 @@ pub struct JsonToken {
     pub token: Jwt,
     pub creation: DateTime,
     pub expiration: DateTime,
+    /// The time at which the token was revoked, if any.
+    /// `None` means the token is active.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revoked: Option<DateTime>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/lib/bencher_schema/migrations/2026-04-19-120000_token_revoked/down.sql
+++ b/lib/bencher_schema/migrations/2026-04-19-120000_token_revoked/down.sql
@@ -1,4 +1,4 @@
-DROP INDEX IF EXISTS index_token_active_jwt;
+DROP INDEX IF EXISTS index_token_jwt;
 
 PRAGMA foreign_keys = off;
 

--- a/lib/bencher_schema/migrations/2026-04-19-120000_token_revoked/down.sql
+++ b/lib/bencher_schema/migrations/2026-04-19-120000_token_revoked/down.sql
@@ -1,6 +1,6 @@
-DROP INDEX IF EXISTS index_token_jwt;
-
 PRAGMA foreign_keys = off;
+
+DROP INDEX IF EXISTS index_token_jwt;
 
 -- token: remove revoked column
 CREATE TABLE down_token (

--- a/lib/bencher_schema/migrations/2026-04-19-120000_token_revoked/down.sql
+++ b/lib/bencher_schema/migrations/2026-04-19-120000_token_revoked/down.sql
@@ -1,6 +1,6 @@
 PRAGMA foreign_keys = off;
 
-DROP INDEX IF EXISTS index_token_jwt;
+DROP INDEX IF EXISTS index_token_user_id;
 
 -- token: remove revoked column
 CREATE TABLE down_token (

--- a/lib/bencher_schema/migrations/2026-04-19-120000_token_revoked/down.sql
+++ b/lib/bencher_schema/migrations/2026-04-19-120000_token_revoked/down.sql
@@ -1,0 +1,40 @@
+DROP INDEX IF EXISTS index_token_not_revoked;
+
+PRAGMA foreign_keys = off;
+
+-- token: remove revoked column
+CREATE TABLE down_token (
+    id INTEGER PRIMARY KEY NOT NULL,
+    uuid TEXT NOT NULL UNIQUE,
+    user_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    jwt TEXT NOT NULL,
+    creation BIGINT NOT NULL,
+    expiration BIGINT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES user (id)
+);
+
+INSERT INTO down_token(
+        id,
+        uuid,
+        user_id,
+        name,
+        jwt,
+        creation,
+        expiration
+    )
+SELECT id,
+    uuid,
+    user_id,
+    name,
+    jwt,
+    creation,
+    expiration
+FROM token;
+
+DROP TABLE token;
+
+ALTER TABLE down_token
+    RENAME TO token;
+
+PRAGMA foreign_keys = on;

--- a/lib/bencher_schema/migrations/2026-04-19-120000_token_revoked/down.sql
+++ b/lib/bencher_schema/migrations/2026-04-19-120000_token_revoked/down.sql
@@ -1,4 +1,4 @@
-DROP INDEX IF EXISTS index_token_not_revoked;
+DROP INDEX IF EXISTS index_token_active_jwt;
 
 PRAGMA foreign_keys = off;
 

--- a/lib/bencher_schema/migrations/2026-04-19-120000_token_revoked/up.sql
+++ b/lib/bencher_schema/migrations/2026-04-19-120000_token_revoked/up.sql
@@ -1,3 +1,3 @@
 ALTER TABLE token ADD COLUMN revoked BIGINT;
 
-CREATE UNIQUE INDEX index_token_active_jwt ON token(jwt) WHERE revoked IS NULL;
+CREATE INDEX index_token_jwt ON token(jwt);

--- a/lib/bencher_schema/migrations/2026-04-19-120000_token_revoked/up.sql
+++ b/lib/bencher_schema/migrations/2026-04-19-120000_token_revoked/up.sql
@@ -1,3 +1,3 @@
 ALTER TABLE token ADD COLUMN revoked BIGINT;
 
-CREATE INDEX index_token_not_revoked ON token(id) WHERE revoked IS NULL;
+CREATE UNIQUE INDEX index_token_active_jwt ON token(jwt) WHERE revoked IS NULL;

--- a/lib/bencher_schema/migrations/2026-04-19-120000_token_revoked/up.sql
+++ b/lib/bencher_schema/migrations/2026-04-19-120000_token_revoked/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE token ADD COLUMN revoked BIGINT;
+
+CREATE INDEX index_token_not_revoked ON token(id) WHERE revoked IS NULL;

--- a/lib/bencher_schema/migrations/2026-04-19-120000_token_revoked/up.sql
+++ b/lib/bencher_schema/migrations/2026-04-19-120000_token_revoked/up.sql
@@ -1,3 +1,3 @@
 ALTER TABLE token ADD COLUMN revoked BIGINT;
 
-CREATE INDEX index_token_jwt ON token(jwt);
+CREATE INDEX index_token_user_id ON token(user_id);

--- a/lib/bencher_schema/src/model/user/auth.rs
+++ b/lib/bencher_schema/src/model/user/auth.rs
@@ -9,6 +9,7 @@ use bencher_rbac::{
     server::Permission,
     user::{OrganizationRoles, ProjectRoles},
 };
+use bencher_token::Audience;
 use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 use dropshot::{
     ApiEndpointBodyContentType, ExtensionMode, ExtractorMetadata, HttpError, RequestContext,
@@ -18,8 +19,8 @@ use oso::{PolarValue, ToPolar};
 
 use crate::{
     context::{ApiContext, DbConnection, Rbac},
-    error::{BEARER_TOKEN_FORMAT, bad_request_error},
-    model::{organization::OrganizationId, project::ProjectId},
+    error::{BEARER_TOKEN_FORMAT, bad_request_error, unauthorized_error},
+    model::{organization::OrganizationId, project::ProjectId, user::token::QueryToken},
     public_conn, schema,
 };
 
@@ -51,6 +52,13 @@ impl AuthUser {
         let email = claims.email();
 
         let conn = public_conn!(context);
+        // API keys are persisted in the `token` table and can be revoked;
+        // short-lived client (browser session) JWTs are not stored, so skip them.
+        if claims.aud == Audience::ApiKey.to_string() {
+            QueryToken::get_active_by_jwt(conn, &bearer_token).map_err(|_e| {
+                unauthorized_error("This API token has been revoked and is no longer valid")
+            })?;
+        }
         let query_user = QueryUser::get_with_email(conn, email)?;
         query_user.check_is_locked()?;
         #[cfg(feature = "plus")]

--- a/lib/bencher_schema/src/model/user/auth.rs
+++ b/lib/bencher_schema/src/model/user/auth.rs
@@ -58,7 +58,7 @@ impl AuthUser {
         // externally-signed test fixture) is accepted — we only block tokens we know
         // have been revoked. Short-lived client (browser session) JWTs are never
         // persisted and skip this lookup.
-        if claims.aud == Audience::ApiKey.as_str()
+        if claims.audience() == Audience::ApiKey.as_str()
             && let Some(row) = QueryToken::get_by_jwt(conn, &bearer_token)
                 .optional()
                 .map_err(|e| unauthorized_error(format!("Failed to look up API token: {e}")))?

--- a/lib/bencher_schema/src/model/user/auth.rs
+++ b/lib/bencher_schema/src/model/user/auth.rs
@@ -56,6 +56,8 @@ impl AuthUser {
         // short-lived client (browser session) JWTs are not stored, so skip them.
         if claims.aud == Audience::ApiKey.to_string() {
             QueryToken::get_active_by_jwt(conn, &bearer_token).map_err(|_e| {
+                #[cfg(feature = "otel")]
+                bencher_otel::ApiMeter::increment(bencher_otel::ApiCounter::UserTokenRevokedUse);
                 unauthorized_error("This API token has been revoked and is no longer valid")
             })?;
         }

--- a/lib/bencher_schema/src/model/user/auth.rs
+++ b/lib/bencher_schema/src/model/user/auth.rs
@@ -10,7 +10,7 @@ use bencher_rbac::{
     user::{OrganizationRoles, ProjectRoles},
 };
 use bencher_token::Audience;
-use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
+use diesel::{ExpressionMethods as _, OptionalExtension as _, QueryDsl as _, RunQueryDsl as _};
 use dropshot::{
     ApiEndpointBodyContentType, ExtensionMode, ExtractorMetadata, HttpError, RequestContext,
     ServerContext, SharedExtractor,
@@ -52,14 +52,23 @@ impl AuthUser {
         let email = claims.email();
 
         let conn = public_conn!(context);
-        // API keys are persisted in the `token` table and can be revoked;
-        // short-lived client (browser session) JWTs are not stored, so skip them.
-        if claims.aud == Audience::ApiKey.to_string() {
-            QueryToken::get_active_by_jwt(conn, &bearer_token).map_err(|_e| {
-                #[cfg(feature = "otel")]
-                bencher_otel::ApiMeter::increment(bencher_otel::ApiCounter::UserTokenRevokedUse);
-                unauthorized_error("This API token has been revoked and is no longer valid")
-            })?;
+        // API keys created via `POST /tokens` are persisted in the `token` table and
+        // can be revoked. Reject any JWT whose row has `revoked` set. A JWT with no
+        // row (e.g. one issued before revocation tracking existed, or any
+        // externally-signed test fixture) is accepted — we only block tokens we know
+        // have been revoked. Short-lived client (browser session) JWTs are never
+        // persisted and skip this lookup.
+        if claims.aud == Audience::ApiKey.to_string()
+            && let Some(row) = QueryToken::get_by_jwt(conn, &bearer_token)
+                .optional()
+                .map_err(|e| unauthorized_error(format!("Failed to look up API token: {e}")))?
+            && row.revoked.is_some()
+        {
+            #[cfg(feature = "otel")]
+            bencher_otel::ApiMeter::increment(bencher_otel::ApiCounter::UserTokenRevokedUse);
+            return Err(unauthorized_error(
+                "This API token has been revoked and is no longer valid",
+            ));
         }
         let query_user = QueryUser::get_with_email(conn, email)?;
         query_user.check_is_locked()?;

--- a/lib/bencher_schema/src/model/user/auth.rs
+++ b/lib/bencher_schema/src/model/user/auth.rs
@@ -52,6 +52,9 @@ impl AuthUser {
         let email = claims.email();
 
         let conn = public_conn!(context);
+        let query_user = QueryUser::get_with_email(conn, email)?;
+        query_user.check_is_locked()?;
+
         // API keys created via `POST /tokens` are persisted in the `token` table and
         // can be revoked. Reject any JWT whose row has `revoked` set. A JWT with no
         // row (e.g. one issued before revocation tracking existed, or any
@@ -59,7 +62,7 @@ impl AuthUser {
         // have been revoked. Short-lived client (browser session) JWTs are never
         // persisted and skip this lookup.
         if claims.audience() == Audience::ApiKey.as_str()
-            && let Some(row) = QueryToken::get_by_jwt(conn, &bearer_token)
+            && let Some(row) = QueryToken::get_by_user_jwt(conn, query_user.id, &bearer_token)
                 .optional()
                 .map_err(|e| unauthorized_error(format!("Failed to look up API token: {e}")))?
             && row.revoked.is_some()
@@ -70,8 +73,7 @@ impl AuthUser {
                 "This API token has been revoked and is no longer valid",
             ));
         }
-        let query_user = QueryUser::get_with_email(conn, email)?;
-        query_user.check_is_locked()?;
+
         #[cfg(feature = "plus")]
         context.rate_limiting.user_request(query_user.uuid)?;
 

--- a/lib/bencher_schema/src/model/user/auth.rs
+++ b/lib/bencher_schema/src/model/user/auth.rs
@@ -58,7 +58,7 @@ impl AuthUser {
         // externally-signed test fixture) is accepted — we only block tokens we know
         // have been revoked. Short-lived client (browser session) JWTs are never
         // persisted and skip this lookup.
-        if claims.aud == Audience::ApiKey.to_string()
+        if claims.aud == Audience::ApiKey.as_str()
             && let Some(row) = QueryToken::get_by_jwt(conn, &bearer_token)
                 .optional()
                 .map_err(|e| unauthorized_error(format!("Failed to look up API token: {e}")))?

--- a/lib/bencher_schema/src/model/user/token.rs
+++ b/lib/bencher_schema/src/model/user/token.rs
@@ -75,6 +75,20 @@ impl QueryToken {
         .execute(conn)
     }
 
+    pub fn revoke_all(
+        conn: &mut DbConnection,
+        user_id: UserId,
+        now: DateTime,
+    ) -> diesel::QueryResult<usize> {
+        diesel::update(
+            schema::token::table
+                .filter(schema::token::user_id.eq(user_id))
+                .filter(schema::token::revoked.is_null()),
+        )
+        .set(schema::token::revoked.eq(now))
+        .execute(conn)
+    }
+
     pub fn into_json(self, conn: &mut DbConnection) -> Result<JsonToken, HttpError> {
         let query_user = QueryUser::get(conn, self.user_id)?;
         Ok(self.into_json_for_user(&query_user))

--- a/lib/bencher_schema/src/model/user/token.rs
+++ b/lib/bencher_schema/src/model/user/token.rs
@@ -50,8 +50,13 @@ impl QueryToken {
             .map_err(resource_not_found_err!(Token, (user_id, uuid)))
     }
 
-    pub fn get_by_jwt(conn: &mut DbConnection, jwt: &Jwt) -> diesel::QueryResult<Self> {
+    pub fn get_by_user_jwt(
+        conn: &mut DbConnection,
+        user_id: UserId,
+        jwt: &Jwt,
+    ) -> diesel::QueryResult<Self> {
         schema::token::table
+            .filter(schema::token::user_id.eq(user_id))
             .filter(schema::token::jwt.eq(jwt.as_ref()))
             .first::<QueryToken>(conn)
     }

--- a/lib/bencher_schema/src/model/user/token.rs
+++ b/lib/bencher_schema/src/model/user/token.rs
@@ -50,12 +50,9 @@ impl QueryToken {
             .map_err(resource_not_found_err!(Token, (user_id, uuid)))
     }
 
-    /// Look up an active (non-revoked) token row by its JWT string.
-    /// Used by the authentication layer to reject revoked tokens.
-    pub fn get_active_by_jwt(conn: &mut DbConnection, jwt: &Jwt) -> diesel::QueryResult<Self> {
+    pub fn get_by_jwt(conn: &mut DbConnection, jwt: &Jwt) -> diesel::QueryResult<Self> {
         schema::token::table
             .filter(schema::token::jwt.eq(jwt.as_ref()))
-            .filter(schema::token::revoked.is_null())
             .first::<QueryToken>(conn)
     }
 

--- a/lib/bencher_schema/src/model/user/token.rs
+++ b/lib/bencher_schema/src/model/user/token.rs
@@ -64,10 +64,14 @@ impl QueryToken {
         token_id: TokenId,
         now: DateTime,
     ) -> diesel::QueryResult<()> {
-        diesel::update(schema::token::table.filter(schema::token::id.eq(token_id)))
+        let rows = diesel::update(schema::token::table.filter(schema::token::id.eq(token_id)))
             .set(schema::token::revoked.eq(now))
-            .execute(conn)
-            .map(|_| ())
+            .execute(conn)?;
+        if rows == 1 {
+            Ok(())
+        } else {
+            Err(diesel::result::Error::NotFound)
+        }
     }
 
     pub fn into_json(self, conn: &mut DbConnection) -> Result<JsonToken, HttpError> {

--- a/lib/bencher_schema/src/model/user/token.rs
+++ b/lib/bencher_schema/src/model/user/token.rs
@@ -60,15 +60,14 @@ impl QueryToken {
         conn: &mut DbConnection,
         token_id: TokenId,
         now: DateTime,
-    ) -> diesel::QueryResult<()> {
-        let rows = diesel::update(schema::token::table.filter(schema::token::id.eq(token_id)))
-            .set(schema::token::revoked.eq(now))
-            .execute(conn)?;
-        if rows == 1 {
-            Ok(())
-        } else {
-            Err(diesel::result::Error::NotFound)
-        }
+    ) -> diesel::QueryResult<usize> {
+        diesel::update(
+            schema::token::table
+                .filter(schema::token::id.eq(token_id))
+                .filter(schema::token::revoked.is_null()),
+        )
+        .set(schema::token::revoked.eq(now))
+        .execute(conn)
     }
 
     pub fn into_json(self, conn: &mut DbConnection) -> Result<JsonToken, HttpError> {

--- a/lib/bencher_schema/src/model/user/token.rs
+++ b/lib/bencher_schema/src/model/user/token.rs
@@ -30,6 +30,7 @@ pub struct QueryToken {
     pub jwt: Jwt,
     pub creation: DateTime,
     pub expiration: DateTime,
+    pub revoked: Option<DateTime>,
 }
 
 impl QueryToken {
@@ -49,6 +50,26 @@ impl QueryToken {
             .map_err(resource_not_found_err!(Token, (user_id, uuid)))
     }
 
+    /// Look up an active (non-revoked) token row by its JWT string.
+    /// Used by the authentication layer to reject revoked tokens.
+    pub fn get_active_by_jwt(conn: &mut DbConnection, jwt: &Jwt) -> diesel::QueryResult<Self> {
+        schema::token::table
+            .filter(schema::token::jwt.eq(jwt.as_ref()))
+            .filter(schema::token::revoked.is_null())
+            .first::<QueryToken>(conn)
+    }
+
+    pub fn revoke(
+        conn: &mut DbConnection,
+        token_id: TokenId,
+        now: DateTime,
+    ) -> diesel::QueryResult<()> {
+        diesel::update(schema::token::table.filter(schema::token::id.eq(token_id)))
+            .set(schema::token::revoked.eq(now))
+            .execute(conn)
+            .map(|_| ())
+    }
+
     pub fn into_json(self, conn: &mut DbConnection) -> Result<JsonToken, HttpError> {
         let query_user = QueryUser::get(conn, self.user_id)?;
         Ok(self.into_json_for_user(&query_user))
@@ -56,13 +77,14 @@ impl QueryToken {
 
     pub fn into_json_for_user(self, query_user: &QueryUser) -> JsonToken {
         let Self {
+            id: _,
             uuid,
             user_id,
             name,
             jwt,
             creation,
             expiration,
-            ..
+            revoked,
         } = self;
         assert_parentage(
             BencherResource::User,
@@ -77,6 +99,7 @@ impl QueryToken {
             token: jwt,
             creation,
             expiration,
+            revoked,
         }
     }
 }

--- a/lib/bencher_schema/src/schema.rs
+++ b/lib/bencher_schema/src/schema.rs
@@ -386,6 +386,7 @@ diesel::table! {
         jwt -> Text,
         creation -> BigInt,
         expiration -> BigInt,
+        revoked -> Nullable<BigInt>,
     }
 }
 

--- a/lib/bencher_token/src/audience.rs
+++ b/lib/bencher_token/src/audience.rs
@@ -20,22 +20,25 @@ pub enum Audience {
     OciAuth,
     OciRunner,
 }
+
+impl Audience {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Auth => AUDIENCE_AUTH,
+            Self::Client => AUDIENCE_CLIENT,
+            Self::ApiKey => AUDIENCE_API_KEY,
+            Self::Invite => AUDIENCE_INVITE,
+            Self::OAuth => AUDIENCE_OAUTH,
+            Self::OciPublic => AUDIENCE_OCI_PUBLIC,
+            Self::OciAuth => AUDIENCE_OCI_AUTH,
+            Self::OciRunner => AUDIENCE_OCI_RUNNER,
+        }
+    }
+}
+
 impl fmt::Display for Audience {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Self::Auth => AUDIENCE_AUTH,
-                Self::Client => AUDIENCE_CLIENT,
-                Self::ApiKey => AUDIENCE_API_KEY,
-                Self::Invite => AUDIENCE_INVITE,
-                Self::OAuth => AUDIENCE_OAUTH,
-                Self::OciPublic => AUDIENCE_OCI_PUBLIC,
-                Self::OciAuth => AUDIENCE_OCI_AUTH,
-                Self::OciRunner => AUDIENCE_OCI_RUNNER,
-            }
-        )
+        write!(f, "{}", self.as_str())
     }
 }
 

--- a/lib/bencher_token/src/claims.rs
+++ b/lib/bencher_token/src/claims.rs
@@ -78,6 +78,10 @@ impl Claims {
         }
     }
 
+    pub fn audience(&self) -> &str {
+        &self.aud
+    }
+
     pub fn email(&self) -> &Email {
         &self.sub
     }

--- a/plus/bencher_otel/src/api_meter.rs
+++ b/plus/bencher_otel/src/api_meter.rs
@@ -81,6 +81,10 @@ pub enum ApiCounter {
     UserSsoJoin(AuthMethod),
     UserCheckout,
 
+    UserTokenCreate,
+    UserTokenRevoke,
+    UserTokenRevokedUse,
+
     RequestMax(IntervalKind, AuthorizationKind),
 
     RunClaimedMax(IntervalKind),
@@ -155,8 +159,10 @@ impl ApiCounter {
             Self::UserSsoJoin(_) => "{join}",
             Self::UserCheckout => "{checkout}",
 
-            Self::UserAttemptMax(_, _) => "{attempt}",
-            Self::UserTokenMax(_) => "{token}",
+            Self::UserAttemptMax(_, _) | Self::UserTokenRevokedUse => "{attempt}",
+            Self::UserTokenMax(_)
+            | Self::UserTokenCreate
+            | Self::UserTokenRevoke => "{token}",
             Self::RunnerKeyRotate => "{key}",
 
             Self::Create(_) | Self::CreateMax(_) => "{resource}",
@@ -204,6 +210,10 @@ impl ApiCounter {
             Self::UserClaim => "user.claim",
             Self::UserSsoJoin(_) => "user.sso.join",
             Self::UserCheckout => "user.checkout",
+
+            Self::UserTokenCreate => "user.token.create",
+            Self::UserTokenRevoke => "user.token.revoke",
+            Self::UserTokenRevokedUse => "user.token.revoked.use",
 
             Self::RequestMax(_, _) => "request.max",
 
@@ -278,6 +288,12 @@ impl ApiCounter {
             Self::UserSsoJoin(_) => "Counts the number of user SSO joins",
             Self::UserCheckout => "Counts the number of user checkouts",
 
+            Self::UserTokenCreate => "Counts the number of user API token creations",
+            Self::UserTokenRevoke => "Counts the number of user API token revocations",
+            Self::UserTokenRevokedUse => {
+                "Counts the number of authentication attempts with a revoked API token"
+            },
+
             Self::RequestMax(_, _) => "Counts the number of request maximums reached",
 
             Self::RunClaimedMax(_) => "Counts the number of claimed run maximums reached",
@@ -344,6 +360,9 @@ impl ApiCounter {
             | Self::UserInvite
             | Self::UserClaim
             | Self::UserCheckout
+            | Self::UserTokenCreate
+            | Self::UserTokenRevoke
+            | Self::UserTokenRevokedUse
             | Self::MetricsBilled
             | Self::MetricsBilledFailed
             | Self::EmailSend

--- a/plus/bencher_otel/src/api_meter.rs
+++ b/plus/bencher_otel/src/api_meter.rs
@@ -160,9 +160,7 @@ impl ApiCounter {
             Self::UserCheckout => "{checkout}",
 
             Self::UserAttemptMax(_, _) | Self::UserTokenRevokedUse => "{attempt}",
-            Self::UserTokenMax(_)
-            | Self::UserTokenCreate
-            | Self::UserTokenRevoke => "{token}",
+            Self::UserTokenMax(_) | Self::UserTokenCreate | Self::UserTokenRevoke => "{token}",
             Self::RunnerKeyRotate => "{key}",
 
             Self::Create(_) | Self::CreateMax(_) => "{resource}",

--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -9599,6 +9599,15 @@
           },
           {
             "in": "query",
+            "name": "revoked",
+            "description": "Include revoked tokens in the results. Defaults to `false`.",
+            "schema": {
+              "nullable": true,
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
             "name": "search",
             "description": "Search by token name, slug, or UUID.",
             "schema": {
@@ -9822,6 +9831,84 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/JsonToken"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "users",
+          "tokens"
+        ],
+        "summary": "Revoke a token",
+        "description": "Revoke an API token for a user. Revocation is terminal: a revoked token can no longer authenticate any request, and the revocation cannot be undone (for security — a leaked JWT must not become valid again). Only the authenticated user themselves and server admins have access to this endpoint.",
+        "operationId": "user_token_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "token",
+            "description": "The UUID for a token.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "user",
+            "description": "The slug or UUID for a user.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ResourceId"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion",
+            "headers": {
+              "access-control-allow-headers": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-allow-methods": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-allow-origin": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-expose-headers": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "x-total-count": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
                 }
               }
             }
@@ -15760,6 +15847,15 @@
           },
           "name": {
             "$ref": "#/components/schemas/ResourceName"
+          },
+          "revoked": {
+            "nullable": true,
+            "description": "The time at which the token was revoked, if any. `None` means the token is active.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTime"
+              }
+            ]
           },
           "token": {
             "$ref": "#/components/schemas/Jwt"

--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -9600,7 +9600,7 @@
           {
             "in": "query",
             "name": "revoked",
-            "description": "Include revoked tokens in the results. Defaults to `false`.",
+            "description": "If set to `true`, only returns revoked tokens. If not set or set to `false`, only returns non-revoked tokens.",
             "schema": {
               "nullable": true,
               "type": "boolean"

--- a/services/cli/src/bencher/sub/user/token/list.rs
+++ b/services/cli/src/bencher/sub/user/token/list.rs
@@ -15,6 +15,7 @@ pub struct List {
     pub user: UserResourceId,
     pub name: Option<ResourceName>,
     pub search: Option<String>,
+    pub revoked: bool,
     pub pagination: Pagination,
     pub backend: AuthBackend,
 }
@@ -35,6 +36,7 @@ impl TryFrom<CliTokenList> for List {
             user,
             name,
             search,
+            revoked,
             pagination,
             backend,
         } = list;
@@ -42,6 +44,7 @@ impl TryFrom<CliTokenList> for List {
             user,
             name,
             search,
+            revoked,
             pagination: pagination.into(),
             backend: backend.try_into()?,
         })
@@ -78,6 +81,9 @@ impl SubCmd for List {
                 }
                 if let Some(search) = self.search.clone() {
                     client = client.search(search);
+                }
+                if self.revoked {
+                    client = client.revoked(true);
                 }
                 if let Some(sort) = self.pagination.sort {
                     client = client.sort(sort);

--- a/services/cli/src/bencher/sub/user/token/mod.rs
+++ b/services/cli/src/bencher/sub/user/token/mod.rs
@@ -2,6 +2,7 @@ use crate::{CliError, bencher::sub::SubCmd, parser::user::token::CliToken};
 
 mod create;
 mod list;
+mod revoke;
 mod update;
 mod view;
 
@@ -11,6 +12,7 @@ pub enum Token {
     Create(create::Create),
     View(view::View),
     Update(update::Update),
+    Revoke(revoke::Revoke),
 }
 
 impl TryFrom<CliToken> for Token {
@@ -22,6 +24,7 @@ impl TryFrom<CliToken> for Token {
             CliToken::Create(create) => Self::Create(create.try_into()?),
             CliToken::View(view) => Self::View(view.try_into()?),
             CliToken::Update(update) => Self::Update(update.try_into()?),
+            CliToken::Revoke(revoke) => Self::Revoke(revoke.try_into()?),
         })
     }
 }
@@ -33,6 +36,7 @@ impl SubCmd for Token {
             Self::Create(create) => create.exec().await,
             Self::View(view) => view.exec().await,
             Self::Update(update) => update.exec().await,
+            Self::Revoke(revoke) => revoke.exec().await,
         }
     }
 }

--- a/services/cli/src/bencher/sub/user/token/revoke.rs
+++ b/services/cli/src/bencher/sub/user/token/revoke.rs
@@ -1,0 +1,48 @@
+use bencher_json::{TokenUuid, UserResourceId};
+
+use crate::{
+    CliError,
+    bencher::{backend::AuthBackend, sub::SubCmd},
+    parser::user::token::CliTokenRevoke,
+};
+
+#[derive(Debug)]
+pub struct Revoke {
+    pub user: UserResourceId,
+    pub token: TokenUuid,
+    pub backend: AuthBackend,
+}
+
+impl TryFrom<CliTokenRevoke> for Revoke {
+    type Error = CliError;
+
+    fn try_from(revoke: CliTokenRevoke) -> Result<Self, Self::Error> {
+        let CliTokenRevoke {
+            user,
+            uuid: token,
+            backend,
+        } = revoke;
+        Ok(Self {
+            user,
+            token,
+            backend: backend.try_into()?,
+        })
+    }
+}
+
+impl SubCmd for Revoke {
+    async fn exec(&self) -> Result<(), CliError> {
+        let _json = self
+            .backend
+            .send(|client| async move {
+                client
+                    .user_token_delete()
+                    .user(self.user.clone())
+                    .token(self.token)
+                    .send()
+                    .await
+            })
+            .await?;
+        Ok(())
+    }
+}

--- a/services/cli/src/parser/user/token.rs
+++ b/services/cli/src/parser/user/token.rs
@@ -14,9 +14,12 @@ pub enum CliToken {
     /// View a token
     #[clap(alias = "get")]
     View(CliTokenView),
-    // Update a token
+    /// Update a token
     #[clap(alias = "edit")]
     Update(CliTokenUpdate),
+    /// Revoke a token
+    #[clap(alias = "rm")]
+    Revoke(CliTokenRevoke),
 }
 
 #[derive(Parser, Debug)]
@@ -31,6 +34,10 @@ pub struct CliTokenList {
     /// Token search string
     #[clap(long, value_name = "QUERY")]
     pub search: Option<String>,
+
+    /// Include revoked tokens in the results
+    #[clap(long)]
+    pub revoked: bool,
 
     #[clap(flatten)]
     pub pagination: CliPagination<CliTokensSort>,
@@ -86,6 +93,18 @@ pub struct CliTokenUpdate {
     /// Token name
     #[clap(long)]
     pub name: Option<ResourceName>,
+
+    #[clap(flatten)]
+    pub backend: CliBackend,
+}
+
+#[derive(Parser, Debug)]
+pub struct CliTokenRevoke {
+    /// User slug or UUID
+    pub user: UserResourceId,
+
+    /// Token UUID
+    pub uuid: TokenUuid,
 
     #[clap(flatten)]
     pub backend: CliBackend,

--- a/services/cli/src/parser/user/token.rs
+++ b/services/cli/src/parser/user/token.rs
@@ -35,7 +35,7 @@ pub struct CliTokenList {
     #[clap(long, value_name = "QUERY")]
     pub search: Option<String>,
 
-    /// Include revoked tokens in the results
+    /// Show only revoked tokens instead of active ones
     #[clap(long)]
     pub revoked: bool,
 

--- a/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
+++ b/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
@@ -6,6 +6,7 @@
 - **BREAKING CHANGE** Rename `runner token` to `runner key` across the API, CLI, and environment variables
 - Fix race condition where concurrent branch creation could cause a "branch head is null" 500 error (Thank you [@vmelamed](https://github.com/vmelamed))
 - Self-heal legacy Branches whose `head_id` is still `NULL` from the race condition above so subsequent `bencher run` submissions succeed instead of 500ing (Thank you [@vmelamed](https://github.com/vmelamed))
+- Add API token revocation with `bencher token revoke` and Revoke button in the Console
 
 ## `v0.6.2`
 - Allow unauthenticated `docker push` to unclaimed projects

--- a/services/console/src/components/console/deck/hand/DeckButton.tsx
+++ b/services/console/src/components/console/deck/hand/DeckButton.tsx
@@ -3,12 +3,14 @@ import {
 	type Accessor,
 	Match,
 	type Resource,
+	Show,
 	Switch,
 	createMemo,
 	createResource,
 } from "solid-js";
 import { ActionButton } from "../../../../config/types";
 import type { JsonAuthUser } from "../../../../types/bencher";
+import { fmtDate } from "../../../../util/convert";
 import type { PubResourceKind } from "../../../perf/util";
 import ArchiveButton from "./ArchiveButton";
 import ArchivedButton from "./ArchivedButton";
@@ -148,6 +150,21 @@ const DeckButton = (props: Props) => {
 						</form>
 					</div>
 				</div>
+			</Match>
+			<Match when={props.config?.kind === ActionButton.REVOKED}>
+				<Show when={props.data()?.revoked}>
+					<div class="columns">
+						<div class="column">
+							<div class="notification is-warning">
+								<p>
+									This {props.config.subtitle} was revoked on{" "}
+									{fmtDate(props.data()?.revoked)}. Revocation is permanent and
+									cannot be undone.
+								</p>
+							</div>
+						</div>
+					</div>
+				</Show>
 			</Match>
 			<Match when={props.config?.kind === ActionButton.DELETE && isAllowed()}>
 				<div class="columns">

--- a/services/console/src/components/console/deck/hand/DeckButton.tsx
+++ b/services/console/src/components/console/deck/hand/DeckButton.tsx
@@ -124,7 +124,7 @@ const DeckButton = (props: Props) => {
 					</div>
 				</div>
 			</Match>
-			<Match when={props.config?.kind === ActionButton.REVOKE}>
+			<Match when={props.config?.kind === ActionButton.REVOKE && isAllowed()}>
 				<div class="columns">
 					<div class="column">
 						<form

--- a/services/console/src/components/console/deck/hand/DeckButton.tsx
+++ b/services/console/src/components/console/deck/hand/DeckButton.tsx
@@ -17,6 +17,7 @@ import HeadReplacedButton from "./HeadReplacedButton";
 import ModelReplacedButton from "./ModelReplacedButton";
 import RawButton from "./RawButton";
 import RemoveModelButton from "./RemoveModelButton";
+import RevokeButton from "./RevokeButton";
 
 export interface Props {
 	apiUrl: string;
@@ -117,6 +118,31 @@ const DeckButton = (props: Props) => {
 							<div class="field">
 								<p class="control">
 									<RawButton data={props.data} />
+								</p>
+							</div>
+						</form>
+					</div>
+				</div>
+			</Match>
+			<Match when={props.config?.kind === ActionButton.REVOKE}>
+				<div class="columns">
+					<div class="column">
+						<form
+							onSubmit={(e) => {
+								e.preventDefault();
+							}}
+						>
+							<div class="field">
+								<p class="control">
+									<RevokeButton
+										apiUrl={props.apiUrl}
+										user={props.user}
+										path={props.path}
+										data={props.data}
+										subtitle={props.config.subtitle}
+										isAllowed={isAllowed}
+										handleRefresh={props.handleRefresh}
+									/>
 								</p>
 							</div>
 						</form>

--- a/services/console/src/components/console/deck/hand/RevokeButton.tsx
+++ b/services/console/src/components/console/deck/hand/RevokeButton.tsx
@@ -77,9 +77,7 @@ const RevokeButton = (props: Props) => {
 						}
 					>
 						<div class="content has-text-centered">
-							<h3 class="title is-3">
-								Are you sure? Revocation is permanent.
-							</h3>
+							<h3 class="title is-3">Are you sure? Revocation is permanent.</h3>
 							{props.subtitle && (
 								<h4 class="subtitle is-4">{props.subtitle}</h4>
 							)}
@@ -117,9 +115,8 @@ const RevokeButton = (props: Props) => {
 		>
 			<div class="notification is-warning">
 				<p>
-					This {props.subtitle} was revoked on{" "}
-					{fmtDate(props.data()?.revoked)}. Revocation is permanent and cannot
-					be undone.
+					This {props.subtitle} was revoked on {fmtDate(props.data()?.revoked)}.
+					Revocation is permanent and cannot be undone.
 				</p>
 			</div>
 		</Show>

--- a/services/console/src/components/console/deck/hand/RevokeButton.tsx
+++ b/services/console/src/components/console/deck/hand/RevokeButton.tsx
@@ -1,7 +1,6 @@
 import * as Sentry from "@sentry/astro";
 import { type Accessor, type Resource, Show, createSignal } from "solid-js";
 import type { JsonAuthUser, JsonToken } from "../../../../types/bencher";
-import { fmtDate } from "../../../../util/convert";
 import { httpDelete } from "../../../../util/http";
 import { NotifyKind, pageNotify } from "../../../../util/notify";
 import { validJwt } from "../../../../util/valid";
@@ -52,73 +51,61 @@ const RevokeButton = (props: Props) => {
 	};
 
 	return (
-		<Show
-			when={props.data()?.revoked}
-			fallback={
-				<Show when={props.isAllowed()}>
-					<Show
-						when={revokeClicked()}
-						fallback={
-							<div class="buttons is-right">
-								<button
-									class="button is-small"
-									type="button"
-									onMouseDown={(e) => {
-										e.preventDefault();
-										setRevokeClicked(true);
-									}}
-								>
-									<span class="icon">
-										<i class="fas fa-ban" />
-									</span>
-									<span>Revoke</span>
-								</button>
-							</div>
-						}
-					>
-						<div class="content has-text-centered">
-							<h3 class="title is-3">Are you sure? Revocation is permanent.</h3>
-							{props.subtitle && (
-								<h4 class="subtitle is-4">{props.subtitle}</h4>
-							)}
+		<Show when={!props.data()?.revoked}>
+			<Show when={props.isAllowed()}>
+				<Show
+					when={revokeClicked()}
+					fallback={
+						<div class="buttons is-right">
+							<button
+								class="button is-small"
+								type="button"
+								onMouseDown={(e) => {
+									e.preventDefault();
+									setRevokeClicked(true);
+								}}
+							>
+								<span class="icon">
+									<i class="fas fa-ban" />
+								</span>
+								<span>Revoke</span>
+							</button>
 						</div>
-						<div class="columns">
-							<div class="column">
-								<button
-									class="button is-fullwidth"
-									type="submit"
-									disabled={revoking()}
-									onMouseDown={(e) => {
-										e.preventDefault();
-										sendRevoke();
-									}}
-								>
-									I am 💯 sure
-								</button>
-							</div>
-							<div class="column">
-								<button
-									class="button is-primary is-fullwidth"
-									type="button"
-									onMouseDown={(e) => {
-										e.preventDefault();
-										setRevokeClicked(false);
-									}}
-								>
-									Cancel
-								</button>
-							</div>
+					}
+				>
+					<div class="content has-text-centered">
+						<h3 class="title is-3">Are you sure? Revocation is permanent.</h3>
+						{props.subtitle && <h4 class="subtitle is-4">{props.subtitle}</h4>}
+					</div>
+					<div class="columns">
+						<div class="column">
+							<button
+								class="button is-fullwidth"
+								type="submit"
+								disabled={revoking()}
+								onMouseDown={(e) => {
+									e.preventDefault();
+									sendRevoke();
+								}}
+							>
+								I am 💯 sure
+							</button>
 						</div>
-					</Show>
+						<div class="column">
+							<button
+								class="button is-primary is-fullwidth"
+								type="button"
+								onMouseDown={(e) => {
+									e.preventDefault();
+									setRevokeClicked(false);
+								}}
+							>
+								Cancel
+							</button>
+						</div>
+					</div>
 				</Show>
-			}
-		>
-			<div class="notification is-warning">
-				<p>
-					This {props.subtitle} was revoked on {fmtDate(props.data()?.revoked)}.
-					Revocation is permanent and cannot be undone.
-				</p>
-			</div>
+			</Show>
 		</Show>
 	);
 };

--- a/services/console/src/components/console/deck/hand/RevokeButton.tsx
+++ b/services/console/src/components/console/deck/hand/RevokeButton.tsx
@@ -1,0 +1,129 @@
+import * as Sentry from "@sentry/astro";
+import { type Accessor, type Resource, Show, createSignal } from "solid-js";
+import type { JsonAuthUser } from "../../../../types/bencher";
+import { fmtDate } from "../../../../util/convert";
+import { httpDelete } from "../../../../util/http";
+import { NotifyKind, pageNotify } from "../../../../util/notify";
+import { validJwt } from "../../../../util/valid";
+
+export interface Props {
+	apiUrl: string;
+	user: JsonAuthUser;
+	path: Accessor<string>;
+	data: Resource<{ revoked?: string }>;
+	subtitle: string;
+	isAllowed: Resource<boolean>;
+	handleRefresh: () => void;
+}
+
+const RevokeButton = (props: Props) => {
+	const [revokeClicked, setRevokeClicked] = createSignal(false);
+	const [revoking, setRevoking] = createSignal(false);
+
+	const sendRevoke = () => {
+		setRevoking(true);
+		const data = props.data();
+		if (!data) {
+			setRevoking(false);
+			return;
+		}
+
+		const token = props.user?.token;
+		if (!validJwt(token)) {
+			setRevoking(false);
+			return;
+		}
+
+		httpDelete(props.apiUrl, props.path(), token)
+			.then((_resp) => {
+				setRevoking(false);
+				setRevokeClicked(false);
+				props.handleRefresh();
+			})
+			.catch((error) => {
+				setRevoking(false);
+				console.error(error);
+				Sentry.captureException(error);
+				pageNotify(
+					NotifyKind.ERROR,
+					`Lettuce romaine calm! Failed to revoke: ${error?.response?.data?.message}`,
+				);
+			});
+	};
+
+	return (
+		<Show
+			when={props.data()?.revoked}
+			fallback={
+				<Show when={props.isAllowed()}>
+					<Show
+						when={revokeClicked()}
+						fallback={
+							<div class="buttons is-right">
+								<button
+									class="button is-small"
+									type="button"
+									onMouseDown={(e) => {
+										e.preventDefault();
+										setRevokeClicked(true);
+									}}
+								>
+									<span class="icon">
+										<i class="fas fa-ban" />
+									</span>
+									<span>Revoke</span>
+								</button>
+							</div>
+						}
+					>
+						<div class="content has-text-centered">
+							<h3 class="title is-3">
+								Are you sure? Revocation is permanent.
+							</h3>
+							{props.subtitle && (
+								<h4 class="subtitle is-4">{props.subtitle}</h4>
+							)}
+						</div>
+						<div class="columns">
+							<div class="column">
+								<button
+									class="button is-fullwidth"
+									type="submit"
+									disabled={revoking()}
+									onMouseDown={(e) => {
+										e.preventDefault();
+										sendRevoke();
+									}}
+								>
+									I am 💯 sure
+								</button>
+							</div>
+							<div class="column">
+								<button
+									class="button is-primary is-fullwidth"
+									type="button"
+									onMouseDown={(e) => {
+										e.preventDefault();
+										setRevokeClicked(false);
+									}}
+								>
+									Cancel
+								</button>
+							</div>
+						</div>
+					</Show>
+				</Show>
+			}
+		>
+			<div class="notification is-warning">
+				<p>
+					This {props.subtitle} was revoked on{" "}
+					{fmtDate(props.data()?.revoked)}. Revocation is permanent and cannot
+					be undone.
+				</p>
+			</div>
+		</Show>
+	);
+};
+
+export default RevokeButton;

--- a/services/console/src/components/console/deck/hand/RevokeButton.tsx
+++ b/services/console/src/components/console/deck/hand/RevokeButton.tsx
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/astro";
 import { type Accessor, type Resource, Show, createSignal } from "solid-js";
-import type { JsonAuthUser } from "../../../../types/bencher";
+import type { JsonAuthUser, JsonToken } from "../../../../types/bencher";
 import { fmtDate } from "../../../../util/convert";
 import { httpDelete } from "../../../../util/http";
 import { NotifyKind, pageNotify } from "../../../../util/notify";
@@ -10,7 +10,7 @@ export interface Props {
 	apiUrl: string;
 	user: JsonAuthUser;
 	path: Accessor<string>;
-	data: Resource<{ revoked?: string }>;
+	data: Resource<JsonToken>;
 	subtitle: string;
 	isAllowed: Resource<boolean>;
 	handleRefresh: () => void;

--- a/services/console/src/components/console/table/TableHeader.tsx
+++ b/services/console/src/components/console/table/TableHeader.tsx
@@ -28,11 +28,13 @@ export interface Props {
 	end_date: Accessor<undefined | string>;
 	search: Accessor<undefined | string>;
 	archived: Accessor<undefined | string>;
+	revoked: Accessor<undefined | string>;
 	handleRefresh: () => void;
 	handleStartTime: (start_time: string) => void;
 	handleEndTime: (end_time: string) => void;
 	handleSearch: (search: string) => void;
 	handleArchived: () => void;
+	handleRevoked: () => void;
 }
 
 export interface TableHeaderConfig {
@@ -62,6 +64,7 @@ const TableHeader = (props: Props) => {
 							end_date={props.end_date}
 							search={props.search}
 							archived={props.archived}
+							revoked={props.revoked}
 							title={title}
 							name={props.config?.name}
 							button={button}
@@ -70,6 +73,7 @@ const TableHeader = (props: Props) => {
 							handleEndTime={props.handleEndTime}
 							handleSearch={props.handleSearch}
 							handleArchived={props.handleArchived}
+							handleRevoked={props.handleRevoked}
 						/>
 					)}
 				</For>
@@ -92,6 +96,7 @@ const TableHeaderButton = (props: {
 	end_date: Accessor<undefined | string>;
 	search: Accessor<undefined | string>;
 	archived: Accessor<undefined | string>;
+	revoked: Accessor<undefined | string>;
 	title: string;
 	name: undefined | string;
 	button: TableButton;
@@ -100,6 +105,7 @@ const TableHeaderButton = (props: {
 	handleEndTime: (end_time: string) => void;
 	handleSearch: (search: string) => void;
 	handleArchived: () => void;
+	handleRevoked: () => void;
 }) => {
 	const [isAllowed] = createResource(props.params, (params) =>
 		props.button.is_allowed?.(props.apiUrl, params),
@@ -157,6 +163,26 @@ const TableHeaderButton = (props: {
 							<i class="fas fa-archive" />
 						</span>
 						<span>Archived</span>
+					</button>
+				</Match>
+				<Match when={props.button.kind === Button.REVOKED}>
+					<button
+						class={`button${props.revoked() === "true" ? " is-primary" : ""}`}
+						type="button"
+						title={
+							props.revoked() === "true"
+								? `View active ${props.title}`
+								: `View revoked ${props.title}`
+						}
+						onMouseDown={(e) => {
+							e.preventDefault();
+							props.handleRevoked();
+						}}
+					>
+						<span class="icon">
+							<i class="fas fa-ban" />
+						</span>
+						<span>Revoked</span>
 					</button>
 				</Match>
 				<Match when={props.button.kind === Button.ADD}>

--- a/services/console/src/components/console/table/TablePanel.tsx
+++ b/services/console/src/components/console/table/TablePanel.tsx
@@ -40,6 +40,7 @@ const START_TIME_PARAM = "start_time";
 const END_TIME_PARAM = "end_time";
 const SEARCH_PARAM = "search";
 export const ARCHIVED_PARAM = "archived";
+export const REVOKED_PARAM = "revoked";
 
 const DEFAULT_PER_PAGE = 8;
 const DEFAULT_PAGE = 1;
@@ -90,6 +91,10 @@ const TablePanel = (props: Props) => {
 			initParams[ARCHIVED_PARAM] = null;
 		}
 
+		if (!isBoolParam(searchParams[REVOKED_PARAM])) {
+			initParams[REVOKED_PARAM] = null;
+		}
+
 		if (Object.keys(initParams).length !== 0) {
 			setSearchParams(initParams, { replace: true });
 		}
@@ -116,6 +121,7 @@ const TablePanel = (props: Props) => {
 	const search = createMemo(() => searchParams[SEARCH_PARAM]);
 
 	const archived = createMemo(() => searchParams[ARCHIVED_PARAM]);
+	const revoked = createMemo(() => searchParams[REVOKED_PARAM]);
 
 	const searchQuery = createMemo(() => {
 		return {
@@ -125,6 +131,7 @@ const TablePanel = (props: Props) => {
 			end_time: end_time(),
 			search: search(),
 			archived: archived(),
+			revoked: revoked(),
 		};
 	});
 
@@ -147,6 +154,7 @@ const TablePanel = (props: Props) => {
 			end_time: undefined | string;
 			search: undefined | string;
 			archived: undefined | boolean;
+			revoked: undefined | boolean;
 		};
 		token: string;
 	}) => {
@@ -223,6 +231,16 @@ const TablePanel = (props: Props) => {
 		);
 	};
 
+	const handleRevoked = () => {
+		setSearchParams(
+			{
+				[PAGE_PARAM]: DEFAULT_PAGE,
+				[REVOKED_PARAM]: !(revoked() === "true"),
+			},
+			{ scroll: true },
+		);
+	};
+
 	return (
 		<>
 			<TableHeader
@@ -233,11 +251,13 @@ const TablePanel = (props: Props) => {
 				end_date={end_date}
 				search={search}
 				archived={archived}
+				revoked={revoked}
 				handleRefresh={refetch}
 				handleStartTime={handleStartTime}
 				handleEndTime={handleEndTime}
 				handleSearch={handleSearch}
 				handleArchived={handleArchived}
+				handleRevoked={handleRevoked}
 			/>
 			<Table
 				config={config()?.table}

--- a/services/console/src/config/types.tsx
+++ b/services/console/src/config/types.tsx
@@ -108,6 +108,7 @@ export enum Button {
 	SEARCH = "search",
 	DATE_TIME = "date_time",
 	ARCHIVED = "archived",
+	REVOKED = "revoked",
 	DISMISS_ALL = "dismiss_all",
 }
 
@@ -119,6 +120,7 @@ export enum ActionButton {
 	MODEL_REPLACED = "model_replaced",
 	RAW = "raw",
 	DELETE = "delete",
+	REVOKE = "revoke",
 }
 
 export enum Row {

--- a/services/console/src/config/types.tsx
+++ b/services/console/src/config/types.tsx
@@ -121,6 +121,7 @@ export enum ActionButton {
 	RAW = "raw",
 	DELETE = "delete",
 	REVOKE = "revoke",
+	REVOKED = "revoked",
 }
 
 export enum Row {

--- a/services/console/src/config/user/tokens.tsx
+++ b/services/console/src/config/user/tokens.tsx
@@ -3,8 +3,17 @@ import IconTitle from "../../components/site/IconTitle";
 import { getUserRaw } from "../../util/auth";
 import type { Params } from "../../util/url";
 import { validResourceName, validU32 } from "../../util/valid";
-import { Button, Card, Display, Operation } from "../types";
+import { ActionButton, Button, Card, Display, Operation } from "../types";
 import { addPath, createdUuidPath, parentPath, viewUuidPath } from "../util";
+
+const isAllowedTokenRevoke = async (_apiUrl: string, params: Params) => {
+	const user = getUserRaw();
+	return (
+		user.user.uuid === params?.user ||
+		user.user.slug === params?.user ||
+		user.user.admin
+	);
+};
 
 export const TOKEN_ICON = "fas fa-stroopwafel";
 
@@ -46,6 +55,7 @@ const tokensConfig = {
 						);
 					},
 				},
+				{ kind: Button.REVOKED },
 				{ kind: Button.REFRESH },
 			],
 		},
@@ -120,6 +130,15 @@ const tokensConfig = {
 		deck: {
 			url: (params: Params) =>
 				`/v0/users/${params?.user}/tokens/${params?.token}`,
+			top_buttons: [
+				{
+					kind: ActionButton.REVOKE,
+					subtitle: "API Token",
+					path: (params: Params) =>
+						`/v0/users/${params?.user}/tokens/${params?.token}`,
+					is_allowed: isAllowedTokenRevoke,
+				},
+			],
 			cards: [
 				{
 					kind: Card.FIELD,
@@ -163,6 +182,12 @@ const tokensConfig = {
 					kind: Card.FIELD,
 					label: "API Token Expiration",
 					key: "expiration",
+					display: Display.RAW,
+				},
+				{
+					kind: Card.FIELD,
+					label: "API Token Revocation",
+					key: "revoked",
 					display: Display.RAW,
 				},
 			],

--- a/services/console/src/config/user/tokens.tsx
+++ b/services/console/src/config/user/tokens.tsx
@@ -123,11 +123,8 @@ const tokensConfig = {
 				`/v0/users/${params?.user}/tokens/${params?.token}`,
 			top_buttons: [
 				{
-					kind: ActionButton.REVOKE,
+					kind: ActionButton.REVOKED,
 					subtitle: "API Token",
-					path: (params: Params) =>
-						`/v0/users/${params?.user}/tokens/${params?.token}`,
-					is_allowed: isSameUser,
 				},
 			],
 			cards: [
@@ -180,6 +177,15 @@ const tokensConfig = {
 					label: "API Token Revocation",
 					key: "revoked",
 					display: Display.RAW,
+				},
+			],
+			buttons: [
+				{
+					kind: ActionButton.REVOKE,
+					subtitle: "API Token",
+					path: (params: Params) =>
+						`/v0/users/${params?.user}/tokens/${params?.token}`,
+					is_allowed: isSameUser,
 				},
 			],
 		},

--- a/services/console/src/config/user/tokens.tsx
+++ b/services/console/src/config/user/tokens.tsx
@@ -1,19 +1,10 @@
 import FieldKind from "../../components/field/kind";
 import IconTitle from "../../components/site/IconTitle";
-import { getUserRaw } from "../../util/auth";
+import { getUserRaw, isSameUser } from "../../util/auth";
 import type { Params } from "../../util/url";
 import { validResourceName, validU32 } from "../../util/valid";
 import { ActionButton, Button, Card, Display, Operation } from "../types";
 import { addPath, createdUuidPath, parentPath, viewUuidPath } from "../util";
-
-const isAllowedTokenRevoke = async (_apiUrl: string, params: Params) => {
-	const user = getUserRaw();
-	return (
-		user.user.uuid === params?.user ||
-		user.user.slug === params?.user ||
-		user.user.admin
-	);
-};
 
 export const TOKEN_ICON = "fas fa-stroopwafel";
 
@@ -136,7 +127,7 @@ const tokensConfig = {
 					subtitle: "API Token",
 					path: (params: Params) =>
 						`/v0/users/${params?.user}/tokens/${params?.token}`,
-					is_allowed: isAllowedTokenRevoke,
+					is_allowed: isSameUser,
 				},
 			],
 			cards: [

--- a/services/console/src/types/bencher.ts
+++ b/services/console/src/types/bencher.ts
@@ -985,6 +985,7 @@ export interface JsonToken {
 	token: Jwt;
 	creation: string;
 	expiration: string;
+	revoked?: string;
 }
 
 export enum UpdateAlertStatus {

--- a/services/console/src/types/bencher.ts
+++ b/services/console/src/types/bencher.ts
@@ -985,6 +985,10 @@ export interface JsonToken {
 	token: Jwt;
 	creation: string;
 	expiration: string;
+	/**
+	 * The time at which the token was revoked, if any.
+	 * `None` means the token is active.
+	 */
 	revoked?: string;
 }
 

--- a/tasks/test_api/src/task/test/seed_test.rs
+++ b/tasks/test_api/src/task/test/seed_test.rs
@@ -2348,6 +2348,7 @@ impl SeedTest {
     }
 
     #[cfg(feature = "plus")]
+    #[expect(clippy::too_many_lines)]
     fn bencher_self_hosted_exec(&self) -> anyhow::Result<()> {
         let host = self.url.as_ref();
         let admin_token = self.admin_token.as_ref();
@@ -2392,6 +2393,144 @@ impl SeedTest {
         let json: bencher_json::JsonSsos =
             serde_json::from_slice(&assert.get_output().stdout).unwrap();
         assert_eq!(json.0.len(), 0);
+
+        // Exercise the API token revocation lifecycle via the CLI.
+        // cargo run -- token create --host http://localhost:61016 --token $BENCHER_API_TOKEN --name "seed-revoke" muriel-bagge
+        let mut cmd = Command::cargo_bin(BENCHER_CMD)?;
+        cmd.args([
+            "token",
+            "create",
+            HOST_ARG,
+            host,
+            TOKEN_ARG,
+            token,
+            "--name",
+            "seed-revoke",
+            ORG_SLUG,
+        ])
+        .current_dir(CLI_DIR);
+        let assert = cmd.assert().success();
+        let created: bencher_json::JsonToken =
+            serde_json::from_slice(&assert.get_output().stdout).unwrap();
+        assert!(
+            created.revoked.is_none(),
+            "freshly created token must not be revoked: {created:?}"
+        );
+        let created_uuid_str = created.uuid.to_string();
+        let created_jwt_str = created.token.as_ref().to_owned();
+
+        // cargo run -- token list --host http://localhost:61016 --token $BENCHER_API_TOKEN muriel-bagge
+        let mut cmd = Command::cargo_bin(BENCHER_CMD)?;
+        cmd.args(["token", "list", HOST_ARG, host, TOKEN_ARG, token, ORG_SLUG])
+            .current_dir(CLI_DIR);
+        let assert = cmd.assert().success();
+        let tokens: bencher_json::JsonTokens =
+            serde_json::from_slice(&assert.get_output().stdout).unwrap();
+        assert!(
+            tokens.0.iter().any(|t| t.uuid == created.uuid),
+            "freshly created token should be in default list: {tokens:?}"
+        );
+
+        // Prove the new token can authenticate: cargo run -- user view using the newly minted JWT.
+        let mut cmd = Command::cargo_bin(BENCHER_CMD)?;
+        cmd.args([
+            "user",
+            "view",
+            HOST_ARG,
+            host,
+            TOKEN_ARG,
+            created_jwt_str.as_str(),
+            ORG_SLUG,
+        ])
+        .current_dir(CLI_DIR);
+        cmd.assert().success();
+
+        // cargo run -- token revoke --host http://localhost:61016 --token $BENCHER_API_TOKEN muriel-bagge <uuid>
+        let mut cmd = Command::cargo_bin(BENCHER_CMD)?;
+        cmd.args([
+            "token",
+            "revoke",
+            HOST_ARG,
+            host,
+            TOKEN_ARG,
+            token,
+            ORG_SLUG,
+            created_uuid_str.as_str(),
+        ])
+        .current_dir(CLI_DIR);
+        cmd.assert().success();
+
+        // The revoked JWT must no longer authenticate.
+        let mut cmd = Command::cargo_bin(BENCHER_CMD)?;
+        cmd.args([
+            "user",
+            "view",
+            HOST_ARG,
+            host,
+            TOKEN_ARG,
+            created_jwt_str.as_str(),
+            ORG_SLUG,
+        ])
+        .current_dir(CLI_DIR);
+        let assert = cmd.assert().failure();
+        let output = assert.get_output();
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("Status: 401"),
+            "revoked token should 401: {output:?}"
+        );
+
+        // Default list must hide the revoked token.
+        let mut cmd = Command::cargo_bin(BENCHER_CMD)?;
+        cmd.args(["token", "list", HOST_ARG, host, TOKEN_ARG, token, ORG_SLUG])
+            .current_dir(CLI_DIR);
+        let assert = cmd.assert().success();
+        let tokens: bencher_json::JsonTokens =
+            serde_json::from_slice(&assert.get_output().stdout).unwrap();
+        assert!(
+            tokens.0.iter().all(|t| t.uuid != created.uuid),
+            "default list should hide revoked tokens: {tokens:?}"
+        );
+
+        // --revoked flag must surface the revoked token with a non-null `revoked` timestamp.
+        let mut cmd = Command::cargo_bin(BENCHER_CMD)?;
+        cmd.args([
+            "token",
+            "list",
+            "--revoked",
+            HOST_ARG,
+            host,
+            TOKEN_ARG,
+            token,
+            ORG_SLUG,
+        ])
+        .current_dir(CLI_DIR);
+        let assert = cmd.assert().success();
+        let tokens: bencher_json::JsonTokens =
+            serde_json::from_slice(&assert.get_output().stdout).unwrap();
+        let revoked_entry = tokens
+            .0
+            .iter()
+            .find(|t| t.uuid == created.uuid)
+            .expect("revoked token should appear when --revoked is set");
+        assert!(
+            revoked_entry.revoked.is_some(),
+            "revoked token must carry a revoked timestamp: {revoked_entry:?}"
+        );
+
+        // Revoking the same token again is a 4xx (already revoked).
+        let mut cmd = Command::cargo_bin(BENCHER_CMD)?;
+        cmd.args([
+            "token",
+            "revoke",
+            HOST_ARG,
+            host,
+            TOKEN_ARG,
+            token,
+            ORG_SLUG,
+            created_uuid_str.as_str(),
+        ])
+        .current_dir(CLI_DIR);
+        cmd.assert().failure();
 
         Ok(())
     }


### PR DESCRIPTION
Add first-class revocation for API tokens, distinct from expiration.
A revoked token is rejected at the authentication boundary, so a leaked
JWT stops working immediately rather than waiting for its TTL.

- New migration `token_revoked` adds a nullable `revoked` BIGINT column
  (mirroring the soft-delete pattern on organization/project) with a
  partial `WHERE revoked IS NULL` index for the hot path.
- `AuthUser::from_token` now looks up API-key JWTs in the token table
  and rejects any whose `revoked` column is set (client-audience JWTs
  for browser sessions are not persisted and skip the check).
- New `DELETE /v0/users/{user}/tokens/{token}` endpoint guarded by
  `same_user!`; token list hides revoked entries by default with a
  `?revoked=true` opt-in for audit.
- CLI: `bencher token revoke` and `bencher token list --revoked`.
- Console: Revoke button on the token detail page (terminal - no
  unrevoke) and a Revoked toggle on the list, mirroring the archived
  dimension UX. Revoked tokens show a warning notification with the
  revocation date.
- Integration tests cover revoke-hides-from-list, direct-GET-still-
  visible, auth-breaks-after-revoke, forbidden-for-other-user, and
  double-revoke-rejected. Seed test exercises the end-to-end CLI
  lifecycle.