### PR TITLE
Improve Bencher download page

### DIFF
--- a/services/console/src/pages/download/index.astro
+++ b/services/console/src/pages/download/index.astro
@@ -22,9 +22,10 @@ const RunnerBins = RunnerBinaries.Content;
 <LegalLayout
   title="Download"
   description="Download Bencher software"
-  heading={`Bencher v${BENCHER_VERSION} Download`}
+  heading="Download Bencher"
 >
-    <Fragment slot="heading">Bencher <code>v{BENCHER_VERSION}</code> Download</Fragment>
+    <p class="subtitle is-5">Latest Version: <code>v{BENCHER_VERSION}</code></p>
+    <p><a href="https://github.com/bencherdev/bencher/releases">View past releases</a></p>
     <h2 id="cli" class="title is-2">Bencher CLI <LinkFragment fragment="cli"/></h2>
     <h3 id="cli-bins" class="title is-3">Pre-Built Binaries <LinkFragment fragment="cli-bins"/></h3>
     <PreBuiltBins />


### PR DESCRIPTION
This changeset improves the [Download Bencher](https://bencher.dev/download/) page by moving back to a consistent H1 and including a link to past releases.