### PR TITLE
Add `--version` flag to `runner`

### DIFF
--- a/plus/bencher_runner/src/up/mod.rs
+++ b/plus/bencher_runner/src/up/mod.rs
@@ -84,7 +84,10 @@ impl Up {
     pub fn run(mut self) -> Result<(), UpError> {
         install_signal_handlers();
 
-        println!("Bencher Runner starting...");
+        println!(
+            "Bencher Runner v{} starting...",
+            bencher_json::BENCHER_API_VERSION
+        );
         println!("  Host: {}", self.config.host);
         println!("  Runner: {}", self.config.runner);
         println!("  Poll timeout: {}s", self.config.poll_timeout_secs);
@@ -142,7 +145,7 @@ fn run_driver(config: &UpConfig, channel_url: &Url, key: &str) -> Result<(), UpE
             .map(|(os, arch)| bencher_json::runner::JsonRunnerMetadata {
                 os,
                 arch,
-                version: env!("CARGO_PKG_VERSION").to_owned(),
+                version: bencher_json::BENCHER_API_VERSION.to_owned(),
             })
     };
     let mut sm = ChannelStateMachine::new(config.poll_timeout_secs, runner_metadata);

--- a/plus/bencher_runner/src/up/state_machine.rs
+++ b/plus/bencher_runner/src/up/state_machine.rs
@@ -647,7 +647,7 @@ mod tests {
             Some(JsonRunnerMetadata {
                 os: OperatingSystem::Linux,
                 arch: Architecture::X86_64,
-                version: env!("CARGO_PKG_VERSION").to_owned(),
+                version: bencher_json::BENCHER_API_VERSION.to_owned(),
             }),
         )
     }
@@ -1244,7 +1244,7 @@ mod tests {
             Some(JsonRunnerMetadata {
                 os: OperatingSystem::Linux,
                 arch: Architecture::X86_64,
-                version: env!("CARGO_PKG_VERSION").to_owned(),
+                version: bencher_json::BENCHER_API_VERSION.to_owned(),
             }),
         );
         let effects = sm.step(Input::Connected);

--- a/services/runner/src/parser/mod.rs
+++ b/services/runner/src/parser/mod.rs
@@ -17,7 +17,7 @@ pub use tuning::CliTuning;
 pub use up::CliUp;
 
 #[derive(Parser, Debug)]
-#[command(name = "runner")]
+#[command(name = "runner", version)]
 #[command(about = "Execute benchmarks in isolated Firecracker microVMs", long_about = None)]
 pub struct CliRunner {
     #[command(subcommand)]


### PR DESCRIPTION
This changeset adds the `--version` flag to the `runner` binary. Further, the version is also printed out at startup. The `runner` and `api` are released in lockstep versions, so the version definition is now shared as well.