### PR TITLE
Fix Download Bencher page version check

### DIFF
--- a/tasks/test_netlify/src/task/test_netlify.rs
+++ b/tasks/test_netlify/src/task/test_netlify.rs
@@ -117,9 +117,9 @@ async fn test_ui_version(console_url: &str, user_agent: Option<&str>) -> anyhow:
     let url = format!("{console_url}/download");
     println!("Testing UI deploy is version {API_VERSION} at {url}");
 
-    let heading = format!("Bencher <code>v{API_VERSION}</code> Download");
+    let version = format!("Latest Version: <code>v{API_VERSION}</code>");
 
-    fetch_and_check(&url, user_agent, &heading).await
+    fetch_and_check(&url, user_agent, &version).await
 }
 
 async fn fetch_and_check(


### PR DESCRIPTION
Fix the [Download Bencher](https://bencher.dev/download/) page version check.

