### PR TITLE
Improve deployment workflow

### DIFF
--- a/.github/workflows/rebase_cloud.yml
+++ b/.github/workflows/rebase_cloud.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
 
 jobs:
@@ -23,3 +24,7 @@ jobs:
           git checkout cloud
           git rebase origin/devel
           git push
+      - name: Trigger CI
+        run: gh workflow run ci.yml --ref cloud
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/services/runner/CLAUDE.md
+++ b/services/runner/CLAUDE.md
@@ -14,6 +14,10 @@ please alert the developer working with you and indicate that this is the case b
 
 See [services/runner/DESIGN.md](services/runner/DESIGN.md) for design documentation.
 
+## Operations
+
+See [`tasks/runner_ops/CLAUDE.md`](../../tasks/runner_ops/CLAUDE.md) for deploying and managing runner servers.
+
 ## Testing
 
 See [services/runner/TEST.md](services/runner/TEST.md) for testing instructions and common failure patterns.

--- a/tasks/runner_ops/CLAUDE.md
+++ b/tasks/runner_ops/CLAUDE.md
@@ -1,0 +1,45 @@
+# Runner Ops
+
+Operational tooling for managing bare metal runner servers. Invoked via `cargo ops` (alias for `cargo runner-ops`).
+
+## Server Configuration
+
+Servers are configured in `tasks/runner_ops/runners.json`. Each entry maps a runner name to its SSH connection details and runner key. The runner name is used as the first positional argument in all commands.
+
+## Common Operations
+
+### Deploy a tagged release
+
+To deploy a specific release version, find the CI run ID for the tag and pass it via `--run-id`:
+
+```bash
+gh run list --repo bencherdev/bencher --branch v0.X.Y --workflow ci.yml --status success --json databaseId -L 1
+cargo ops deploy <runner> --run-id <run_id>
+```
+
+### Deploy latest from devel
+
+```bash
+cargo ops deploy <runner>
+```
+
+### Start/stop/logs
+
+```bash
+cargo ops start <runner>
+cargo ops stop <runner>
+cargo ops logs <runner>
+cargo ops logs <runner> --follow
+```
+
+### Full provisioning (new server)
+
+```bash
+cargo ops provision <runner>
+```
+
+## How It Works
+
+1. `deploy` downloads the runner binary from a GitHub Actions CI artifact, SSHes into the server, stops the existing service, copies the new binary, configures systemd, and starts the service.
+2. Server SSH details, runner key, and host URL are resolved by merging `runners.json` with any CLI flags. CLI flags override the JSON file.
+3. The runner key and host are written to a systemd drop-in at `/etc/systemd/system/bencher-runner.service.d/credentials.conf`.


### PR DESCRIPTION
This changeset improves the deployment workflow by having the `workflow_dispatch` for the `cloud` branch rebase trigger the CI workflow, instead of requiring a second `workflow_dispatch` on the CI workflow manually.

New documentation for Claude was also added for Runner deploys.