### PR TITLE
Skip building API docker image on pushes to `cloud`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
       wasm-pack-version: "0.12.1"
       litestream-version: "0.5.10"
       build-action: ${{ needs.changes.outputs.action == 'true' || github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/cloud' || startsWith(github.ref, 'refs/tags/') }}
-      build-docker: ${{ !startsWith(github.ref, 'refs/tags/') && (needs.changes.outputs.docker == 'true' || github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/cloud' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy'))) }}
+      build-docker: ${{ !startsWith(github.ref, 'refs/tags/') && (needs.changes.outputs.docker == 'true' || github.ref == 'refs/heads/devel' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy'))) }}
       deploy-only: ${{ github.ref == 'refs/heads/cloud' }}
 
   docker:


### PR DESCRIPTION
The `cloud` Docker build wastes ~15 min rebuilding the API image from scratch because BuildKit's registry cache export drops layers that were cache hits (not freshly built). Since `cloud` is always reset to `devel` before pushing (same commit SHA), the image already exists in GHCR from the `devel` build.