### PR TITLE
Add `update-sandbox` task for automated Firecracker and kernel updates  

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,6 +13,7 @@ test-netlify = "run --manifest-path ./tasks/test_netlify/Cargo.toml --"
 test-runner = "run --manifest-path ./tasks/test_runner/Cargo.toml --"
 runner-ops = "run --manifest-path ./tasks/runner_ops/Cargo.toml --"
 ops = "run --manifest-path ./tasks/runner_ops/Cargo.toml --"
+update-sandbox = "run --manifest-path ./tasks/update_sandbox/Cargo.toml --"
 
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
               - 'plus/bencher_runner/**'
               - 'services/runner/**'
               - 'tasks/test_runner/**'
+              - 'tasks/update_sandbox/**'
             nix:
               - 'flake.nix'
               - 'flake.lock'

--- a/.github/workflows/update_sandbox.yml
+++ b/.github/workflows/update_sandbox.yml
@@ -18,6 +18,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Update sandbox dependencies
         id: update
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           output=$(cargo update-sandbox)
           echo "$output"
@@ -36,6 +38,7 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          SUMMARY: ${{ steps.update.outputs.summary }}
         run: |
           git config user.name "Bencher"
           git config user.email "git@bencher.dev"
@@ -43,7 +46,7 @@ jobs:
           branch="update/sandbox"
           git checkout -B "$branch"
           git add plus/bencher_runner/build.rs
-          git commit -m "${{ steps.update.outputs.summary }}"
+          git commit -m "$SUMMARY"
           git push -u origin "$branch" --force
 
           existing=$(gh pr list --head "$branch" --base devel --json number -q '.[0].number')
@@ -51,7 +54,8 @@ jobs:
             gh pr create \
               --base devel \
               --head "$branch" \
-              --title "${{ steps.update.outputs.summary }}" \
+              --title "$SUMMARY" \
               --body "Automated update of bundled Firecracker and/or kernel in the runner sandbox." \
-              --label "dependencies"
+              --label "dependencies" \
+              --label "deploy"
           fi

--- a/.github/workflows/update_sandbox.yml
+++ b/.github/workflows/update_sandbox.yml
@@ -1,0 +1,57 @@
+name: Update Sandbox
+
+on:
+  schedule:
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: devel
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Update sandbox dependencies
+        id: update
+        run: |
+          output=$(cargo update-sandbox)
+          echo "$output"
+          echo "summary<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$output" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create or update PR
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name "Bencher"
+          git config user.email "git@bencher.dev"
+
+          branch="update/sandbox"
+          git checkout -B "$branch"
+          git add plus/bencher_runner/build.rs
+          git commit -m "${{ steps.update.outputs.summary }}"
+          git push -u origin "$branch" --force
+
+          existing=$(gh pr list --head "$branch" --base devel --json number -q '.[0].number')
+          if [ -z "$existing" ]; then
+            gh pr create \
+              --base devel \
+              --head "$branch" \
+              --title "${{ steps.update.outputs.summary }}" \
+              --body "Automated update of bundled Firecracker and/or kernel in the runner sandbox." \
+              --label "dependencies"
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9171,6 +9171,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "update_sandbox"
+version = "0.6.4"
+dependencies = [
+ "anyhow",
+ "camino",
+ "clap",
+ "serde",
+ "serde_json",
+ "sha2",
+ "ureq",
+]
+
+[[package]]
 name = "ureq"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/docker/bench.Dockerfile
+++ b/docker/bench.Dockerfile
@@ -73,6 +73,7 @@ RUN cargo init --bin test_api
 RUN cargo init --bin test_netlify
 RUN cargo init --bin test_runner
 RUN cargo init --bin runner_ops
+RUN cargo init --bin update_sandbox
 
 WORKDIR /usr/src/bencher
 COPY Cargo.toml Cargo.toml

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -83,6 +83,7 @@ RUN cargo init --bin test_api
 RUN cargo init --bin test_netlify
 RUN cargo init --bin test_runner
 RUN cargo init --bin runner_ops
+RUN cargo init --bin update_sandbox
 
 WORKDIR /usr/src/bencher
 COPY Cargo.toml Cargo.toml

--- a/services/cli/Dockerfile
+++ b/services/cli/Dockerfile
@@ -73,6 +73,7 @@ RUN cargo init --bin test_api
 RUN cargo init --bin test_netlify
 RUN cargo init --bin test_runner
 RUN cargo init --bin runner_ops
+RUN cargo init --bin update_sandbox
 
 WORKDIR /usr/src/bencher
 COPY Cargo.toml Cargo.toml

--- a/services/console/Dockerfile
+++ b/services/console/Dockerfile
@@ -57,6 +57,7 @@ RUN cargo init --bin test_api
 RUN cargo init --bin test_netlify
 RUN cargo init --bin test_runner
 RUN cargo init --bin runner_ops
+RUN cargo init --bin update_sandbox
 
 WORKDIR /usr/src/bencher
 COPY Cargo.toml Cargo.toml

--- a/tasks/update_sandbox/Cargo.toml
+++ b/tasks/update_sandbox/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "update_sandbox"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license-file.workspace = true
+publish = false
+
+[dependencies]
+anyhow.workspace = true
+camino.workspace = true
+clap.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+ureq.workspace = true
+
+[lints]
+workspace = true

--- a/tasks/update_sandbox/src/main.rs
+++ b/tasks/update_sandbox/src/main.rs
@@ -1,0 +1,11 @@
+#![expect(clippy::print_stdout)]
+
+mod parser;
+mod task;
+
+use task::Task;
+
+fn main() -> anyhow::Result<()> {
+    let task = Task::new()?;
+    task.exec()
+}

--- a/tasks/update_sandbox/src/parser.rs
+++ b/tasks/update_sandbox/src/parser.rs
@@ -1,0 +1,21 @@
+use camino::Utf8PathBuf;
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+pub struct TaskUpdateSandbox {
+    /// Print what would change without modifying files
+    #[clap(long)]
+    pub dry_run: bool,
+
+    /// Path to the runner build.rs file
+    #[clap(long)]
+    pub build_rs: Option<Utf8PathBuf>,
+
+    /// Firecracker major.minor version to pin (e.g. "1.15")
+    #[clap(long, default_value = "1.15")]
+    pub firecracker_version: String,
+
+    /// Linux kernel major.minor version to pin (e.g. "6.1")
+    #[clap(long, default_value = "6.1")]
+    pub kernel_version: String,
+}

--- a/tasks/update_sandbox/src/task/build_rs.rs
+++ b/tasks/update_sandbox/src/task/build_rs.rs
@@ -55,20 +55,48 @@ pub fn apply_updates(
     let content = fs::read_to_string(build_rs_path)
         .with_context(|| format!("failed to read {build_rs_path}"))?;
 
-    let updated = content
-        .replace(&old.firecracker_version, &new.firecracker_version)
-        .replace(
+    let replacements = [
+        (
+            "DEFAULT_FIRECRACKER_VERSION",
+            &old.firecracker_version,
+            &new.firecracker_version,
+        ),
+        (
+            "FIRECRACKER_TGZ_SHA256_X86_64",
             &old.firecracker_sha256_x86_64,
             &new.firecracker_sha256_x86_64,
-        )
-        .replace(
+        ),
+        (
+            "FIRECRACKER_TGZ_SHA256_AARCH64",
             &old.firecracker_sha256_aarch64,
             &new.firecracker_sha256_aarch64,
-        )
-        .replace(&old.kernel_url_x86_64, &new.kernel_url_x86_64)
-        .replace(&old.kernel_url_aarch64, &new.kernel_url_aarch64)
-        .replace(&old.kernel_sha256_x86_64, &new.kernel_sha256_x86_64)
-        .replace(&old.kernel_sha256_aarch64, &new.kernel_sha256_aarch64);
+        ),
+        (
+            "DEFAULT_KERNEL_URL_X86_64",
+            &old.kernel_url_x86_64,
+            &new.kernel_url_x86_64,
+        ),
+        (
+            "DEFAULT_KERNEL_URL_AARCH64",
+            &old.kernel_url_aarch64,
+            &new.kernel_url_aarch64,
+        ),
+        (
+            "KERNEL_SHA256_X86_64",
+            &old.kernel_sha256_x86_64,
+            &new.kernel_sha256_x86_64,
+        ),
+        (
+            "KERNEL_SHA256_AARCH64",
+            &old.kernel_sha256_aarch64,
+            &new.kernel_sha256_aarch64,
+        ),
+    ];
+
+    let mut updated = content.clone();
+    for (name, old_val, new_val) in replacements {
+        updated = replace_const(&updated, name, old_val, new_val)?;
+    }
 
     if updated == content {
         return Ok(false);
@@ -78,6 +106,50 @@ pub fn apply_updates(
         .with_context(|| format!("failed to write {build_rs_path}"))?;
 
     Ok(true)
+}
+
+fn replace_const(
+    content: &str,
+    name: &str,
+    old_value: &str,
+    new_value: &str,
+) -> anyhow::Result<String> {
+    let prefix = format!("const {name}: &str =");
+    let mut result = String::with_capacity(content.len());
+    let mut lines = content.lines().peekable();
+    let mut found = false;
+
+    while let Some(line) = lines.next() {
+        if !found && line.trim().starts_with(&prefix) {
+            found = true;
+            if line.contains(old_value) {
+                result.push_str(&line.replacen(old_value, new_value, 1));
+                result.push('\n');
+            } else {
+                result.push_str(line);
+                result.push('\n');
+                // Value is on the next line
+                if let Some(next_line) = lines.next() {
+                    result.push_str(&next_line.replacen(old_value, new_value, 1));
+                    result.push('\n');
+                }
+            }
+        } else {
+            result.push_str(line);
+            result.push('\n');
+        }
+    }
+
+    if !found {
+        anyhow::bail!("constant {name} not found in build.rs");
+    }
+
+    // Preserve original trailing newline behavior
+    if !content.ends_with('\n') {
+        result.pop();
+    }
+
+    Ok(result)
 }
 
 pub fn read_current(build_rs_path: &Utf8Path) -> anyhow::Result<BuildRsValues> {

--- a/tasks/update_sandbox/src/task/build_rs.rs
+++ b/tasks/update_sandbox/src/task/build_rs.rs
@@ -1,0 +1,96 @@
+use std::fs;
+
+use anyhow::Context as _;
+use camino::Utf8Path;
+
+pub struct BuildRsValues {
+    pub firecracker_version: String,
+    pub firecracker_sha256_x86_64: String,
+    pub firecracker_sha256_aarch64: String,
+    pub kernel_url_x86_64: String,
+    pub kernel_url_aarch64: String,
+    pub kernel_sha256_x86_64: String,
+    pub kernel_sha256_aarch64: String,
+}
+
+pub fn extract_const(content: &str, name: &str) -> anyhow::Result<String> {
+    let prefix = format!("const {name}: &str =");
+    let mut lines = content.lines();
+    while let Some(line) = lines.next() {
+        let trimmed = line.trim();
+        if !trimmed.starts_with(&prefix) {
+            continue;
+        }
+        // Single-line: const X: &str = "value";
+        if trimmed.contains('"') {
+            return extract_quoted_value(trimmed);
+        }
+        // Multi-line: the value is on the next line
+        if let Some(next_line) = lines.next() {
+            return extract_quoted_value(next_line.trim());
+        }
+    }
+    anyhow::bail!("constant {name} not found in build.rs");
+}
+
+fn extract_quoted_value(s: &str) -> anyhow::Result<String> {
+    let start = s
+        .find('"')
+        .with_context(|| format!("no opening quote in: {s}"))?;
+    let after_quote = s.get(start + 1..).context("unexpected end of string")?;
+    let end = after_quote
+        .find('"')
+        .with_context(|| format!("no closing quote in: {s}"))?;
+    Ok(after_quote
+        .get(..end)
+        .context("unexpected end of string")?
+        .to_owned())
+}
+
+pub fn apply_updates(
+    build_rs_path: &Utf8Path,
+    old: &BuildRsValues,
+    new: &BuildRsValues,
+) -> anyhow::Result<bool> {
+    let content = fs::read_to_string(build_rs_path)
+        .with_context(|| format!("failed to read {build_rs_path}"))?;
+
+    let updated = content
+        .replace(&old.firecracker_version, &new.firecracker_version)
+        .replace(
+            &old.firecracker_sha256_x86_64,
+            &new.firecracker_sha256_x86_64,
+        )
+        .replace(
+            &old.firecracker_sha256_aarch64,
+            &new.firecracker_sha256_aarch64,
+        )
+        .replace(&old.kernel_url_x86_64, &new.kernel_url_x86_64)
+        .replace(&old.kernel_url_aarch64, &new.kernel_url_aarch64)
+        .replace(&old.kernel_sha256_x86_64, &new.kernel_sha256_x86_64)
+        .replace(&old.kernel_sha256_aarch64, &new.kernel_sha256_aarch64);
+
+    if updated == content {
+        return Ok(false);
+    }
+
+    fs::write(build_rs_path, &updated)
+        .with_context(|| format!("failed to write {build_rs_path}"))?;
+
+    Ok(true)
+}
+
+pub fn read_current(build_rs_path: &Utf8Path) -> anyhow::Result<BuildRsValues> {
+    let content = fs::read_to_string(build_rs_path)
+        .with_context(|| format!("failed to read {build_rs_path}"))?;
+
+    Ok(BuildRsValues {
+        firecracker_version: extract_const(&content, "DEFAULT_FIRECRACKER_VERSION")?,
+        firecracker_sha256_x86_64: extract_const(&content, "FIRECRACKER_TGZ_SHA256_X86_64")?,
+        firecracker_sha256_aarch64: extract_const(&content, "FIRECRACKER_TGZ_SHA256_AARCH64")?,
+        kernel_url_x86_64: extract_const(&content, "DEFAULT_KERNEL_URL_X86_64")?,
+        kernel_url_aarch64: extract_const(&content, "DEFAULT_KERNEL_URL_AARCH64")?,
+        kernel_sha256_x86_64: extract_const(&content, "KERNEL_SHA256_X86_64")?,
+        kernel_sha256_aarch64: extract_const(&content, "KERNEL_SHA256_AARCH64")?,
+    })
+}

--- a/tasks/update_sandbox/src/task/build_rs.rs
+++ b/tasks/update_sandbox/src/task/build_rs.rs
@@ -116,7 +116,7 @@ fn replace_const(
 ) -> anyhow::Result<String> {
     let prefix = format!("const {name}: &str =");
     let mut result = String::with_capacity(content.len());
-    let mut lines = content.lines().peekable();
+    let mut lines = content.lines();
     let mut found = false;
 
     while let Some(line) = lines.next() {

--- a/tasks/update_sandbox/src/task/firecracker.rs
+++ b/tasks/update_sandbox/src/task/firecracker.rs
@@ -15,9 +15,17 @@ pub struct FirecrackerRelease {
 pub fn find_latest(pinned_minor: &str) -> anyhow::Result<FirecrackerRelease> {
     let prefix = format!("v{pinned_minor}.");
 
-    let body = ureq::get("https://api.github.com/repos/firecracker-microvm/firecracker/releases")
-        .header("Accept", "application/vnd.github+json")
-        .header("User-Agent", "bencher-update-sandbox")
+    let mut request = ureq::get(
+        "https://api.github.com/repos/firecracker-microvm/firecracker/releases?per_page=100",
+    )
+    .header("Accept", "application/vnd.github+json")
+    .header("User-Agent", "bencher-update-sandbox");
+
+    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+        request = request.header("Authorization", &format!("Bearer {token}"));
+    }
+
+    let body = request
         .call()
         .context("failed to fetch Firecracker releases")?
         .body_mut()

--- a/tasks/update_sandbox/src/task/firecracker.rs
+++ b/tasks/update_sandbox/src/task/firecracker.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 #[derive(Deserialize)]
 struct Release {
     tag_name: String,
+    prerelease: bool,
 }
 
 pub struct FirecrackerRelease {
@@ -37,7 +38,7 @@ pub fn find_latest(pinned_minor: &str) -> anyhow::Result<FirecrackerRelease> {
 
     let best = releases
         .iter()
-        .filter(|r| r.tag_name.starts_with(&prefix))
+        .filter(|r| !r.prerelease && r.tag_name.starts_with(&prefix))
         .max_by(|a, b| compare_tags(&a.tag_name, &b.tag_name))
         .with_context(|| format!("no Firecracker release found matching v{pinned_minor}.x"))?;
 

--- a/tasks/update_sandbox/src/task/firecracker.rs
+++ b/tasks/update_sandbox/src/task/firecracker.rs
@@ -1,0 +1,82 @@
+use anyhow::Context as _;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Release {
+    tag_name: String,
+}
+
+pub struct FirecrackerRelease {
+    pub tag: String,
+    pub sha256_x86_64: String,
+    pub sha256_aarch64: String,
+}
+
+pub fn find_latest(pinned_minor: &str) -> anyhow::Result<FirecrackerRelease> {
+    let prefix = format!("v{pinned_minor}.");
+
+    let body = ureq::get("https://api.github.com/repos/firecracker-microvm/firecracker/releases")
+        .header("Accept", "application/vnd.github+json")
+        .header("User-Agent", "bencher-update-sandbox")
+        .call()
+        .context("failed to fetch Firecracker releases")?
+        .body_mut()
+        .read_to_string()
+        .context("failed to read releases body")?;
+
+    let releases: Vec<Release> =
+        serde_json::from_str(&body).context("failed to parse releases JSON")?;
+
+    let best = releases
+        .iter()
+        .filter(|r| r.tag_name.starts_with(&prefix))
+        .max_by(|a, b| compare_tags(&a.tag_name, &b.tag_name))
+        .with_context(|| format!("no Firecracker release found matching v{pinned_minor}.x"))?;
+
+    let tag = best.tag_name.clone();
+
+    let sha256_x86_64 = download_sha256(&tag, "x86_64")?;
+    let sha256_aarch64 = download_sha256(&tag, "aarch64")?;
+
+    Ok(FirecrackerRelease {
+        tag,
+        sha256_x86_64,
+        sha256_aarch64,
+    })
+}
+
+fn download_sha256(tag: &str, arch: &str) -> anyhow::Result<String> {
+    let url = format!(
+        "https://github.com/firecracker-microvm/firecracker/releases/download/{tag}/firecracker-{tag}-{arch}.tgz.sha256.txt"
+    );
+
+    let body = ureq::get(&url)
+        .header("User-Agent", "bencher-update-sandbox")
+        .call()
+        .with_context(|| format!("failed to download SHA256 for {tag} {arch}"))?
+        .body_mut()
+        .read_to_string()
+        .with_context(|| format!("failed to read SHA256 body for {tag} {arch}"))?;
+
+    // Format: "{hash}  {filename}\n"
+    let hash = body
+        .split_whitespace()
+        .next()
+        .with_context(|| format!("empty SHA256 file for {tag} {arch}"))?;
+
+    if hash.len() != 64 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+        anyhow::bail!("invalid SHA256 hash for {tag} {arch}: {hash}");
+    }
+
+    Ok(hash.to_owned())
+}
+
+fn compare_tags(a: &str, b: &str) -> std::cmp::Ordering {
+    let parse = |tag: &str| -> Vec<u64> {
+        tag.trim_start_matches('v')
+            .split('.')
+            .filter_map(|s| s.parse().ok())
+            .collect()
+    };
+    parse(a).cmp(&parse(b))
+}

--- a/tasks/update_sandbox/src/task/kernel.rs
+++ b/tasks/update_sandbox/src/task/kernel.rs
@@ -1,0 +1,160 @@
+use std::io::Read as _;
+
+use anyhow::Context as _;
+use sha2::{Digest as _, Sha256};
+
+const S3_BUCKET_URL: &str = "https://s3.amazonaws.com/spec.ccfc.min";
+
+pub struct KernelArtifacts {
+    pub url_x86_64: String,
+    pub url_aarch64: String,
+    pub sha256_x86_64: String,
+    pub sha256_aarch64: String,
+    pub version: String,
+}
+
+pub fn find_latest(pinned_minor: &str) -> anyhow::Result<KernelArtifacts> {
+    let build_id = find_newest_ci_build()?;
+
+    let version_x86_64 = find_kernel_version(&build_id, "x86_64", pinned_minor)?;
+    let version_aarch64 = find_kernel_version(&build_id, "aarch64", pinned_minor)?;
+
+    anyhow::ensure!(
+        version_x86_64 == version_aarch64,
+        "kernel version mismatch: x86_64 has {version_x86_64} but aarch64 has {version_aarch64}"
+    );
+
+    let version = version_x86_64;
+
+    let url_x86_64 = format!("{S3_BUCKET_URL}/firecracker-ci/{build_id}/x86_64/vmlinux-{version}");
+    let url_aarch64 =
+        format!("{S3_BUCKET_URL}/firecracker-ci/{build_id}/aarch64/vmlinux-{version}");
+
+    let sha256_x86_64 = download_and_hash(&url_x86_64).context("failed to hash x86_64 kernel")?;
+    let sha256_aarch64 =
+        download_and_hash(&url_aarch64).context("failed to hash aarch64 kernel")?;
+
+    Ok(KernelArtifacts {
+        url_x86_64,
+        url_aarch64,
+        sha256_x86_64,
+        sha256_aarch64,
+        version,
+    })
+}
+
+fn find_newest_ci_build() -> anyhow::Result<String> {
+    let url = format!("{S3_BUCKET_URL}?list-type=2&prefix=firecracker-ci/&delimiter=/");
+
+    let xml = ureq::get(&url)
+        .call()
+        .context("failed to list S3 CI builds")?
+        .body_mut()
+        .read_to_string()
+        .context("failed to read S3 listing")?;
+
+    let prefixes = extract_xml_values(&xml, "Prefix");
+
+    // Filter to date-based directories: firecracker-ci/YYYYMMDD-{hash}-{n}/
+    // The name must start with exactly 8 digits (a date) followed by a hyphen.
+    let mut date_dirs: Vec<&str> = prefixes
+        .iter()
+        .filter_map(|p| {
+            let name = p.strip_prefix("firecracker-ci/")?.strip_suffix('/')?;
+            let is_date_dir = name.len() > 9
+                && name.as_bytes().iter().take(8).all(u8::is_ascii_digit)
+                && name.as_bytes().get(8) == Some(&b'-');
+            is_date_dir.then_some(name)
+        })
+        .collect();
+
+    date_dirs.sort_unstable();
+
+    let newest = date_dirs
+        .last()
+        .context("no date-based CI build directories found in S3")?;
+
+    Ok((*newest).to_owned())
+}
+
+fn find_kernel_version(build_id: &str, arch: &str, pinned_minor: &str) -> anyhow::Result<String> {
+    let prefix = format!("firecracker-ci/{build_id}/{arch}/vmlinux-");
+    let url = format!("{S3_BUCKET_URL}?list-type=2&prefix={prefix}");
+
+    let xml = ureq::get(&url)
+        .call()
+        .with_context(|| format!("failed to list kernels for {arch}"))?
+        .body_mut()
+        .read_to_string()
+        .with_context(|| format!("failed to read kernel listing for {arch}"))?;
+
+    let keys = extract_xml_values(&xml, "Key");
+    let version_prefix = format!("{pinned_minor}.");
+
+    let best_version = keys
+        .iter()
+        .filter_map(|key| {
+            let filename = key.rsplit('/').next()?;
+            // Skip .config and -no-acpi variants
+            if filename.contains(".config") || filename.contains("-no-acpi") {
+                return None;
+            }
+            let version = filename.strip_prefix("vmlinux-")?;
+            version
+                .starts_with(&version_prefix)
+                .then(|| version.to_owned())
+        })
+        .max_by(|a, b| compare_versions(a, b))
+        .with_context(|| {
+            format!("no kernel matching {pinned_minor}.x found in {build_id}/{arch}")
+        })?;
+
+    Ok(best_version)
+}
+
+fn download_and_hash(url: &str) -> anyhow::Result<String> {
+    let mut reader = ureq::get(url)
+        .call()
+        .with_context(|| format!("failed to download {url}"))?
+        .into_body()
+        .into_reader();
+
+    let mut hasher = Sha256::new();
+    let mut buf = vec![0u8; 64 * 1024];
+    loop {
+        let n = reader
+            .read(&mut buf)
+            .context("failed to read kernel body")?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(buf.get(..n).context("buffer slice out of bounds")?);
+    }
+
+    let hash = hasher.finalize();
+    Ok(format!("{hash:x}"))
+}
+
+fn extract_xml_values(xml: &str, tag: &str) -> Vec<String> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let mut values = Vec::new();
+    let mut remaining = xml;
+    while let Some(start) = remaining.find(&open) {
+        let after_open = start + open.len();
+        let value_str = remaining.get(after_open..).unwrap_or_default();
+        if let Some(end) = value_str.find(&close) {
+            let value = value_str.get(..end).unwrap_or_default();
+            values.push(value.to_owned());
+            remaining = value_str.get(end + close.len()..).unwrap_or_default();
+        } else {
+            break;
+        }
+    }
+    values
+}
+
+fn compare_versions(a: &str, b: &str) -> std::cmp::Ordering {
+    let parse = |v: &str| -> Vec<u64> { v.split('.').filter_map(|s| s.parse().ok()).collect() };
+    parse(a).cmp(&parse(b))
+}

--- a/tasks/update_sandbox/src/task/mod.rs
+++ b/tasks/update_sandbox/src/task/mod.rs
@@ -1,0 +1,131 @@
+use camino::Utf8PathBuf;
+use clap::Parser as _;
+
+use crate::parser::TaskUpdateSandbox;
+
+mod build_rs;
+mod firecracker;
+mod kernel;
+
+use build_rs::BuildRsValues;
+
+#[derive(Debug)]
+pub struct Task {
+    dry_run: bool,
+    build_rs_path: Utf8PathBuf,
+    firecracker_version: String,
+    kernel_version: String,
+}
+
+impl TryFrom<TaskUpdateSandbox> for Task {
+    type Error = anyhow::Error;
+
+    fn try_from(parser: TaskUpdateSandbox) -> Result<Self, Self::Error> {
+        let TaskUpdateSandbox {
+            dry_run,
+            build_rs,
+            firecracker_version,
+            kernel_version,
+        } = parser;
+
+        let build_rs_path = match build_rs {
+            Some(path) => path,
+            None => default_build_rs_path(),
+        };
+
+        Ok(Self {
+            dry_run,
+            build_rs_path,
+            firecracker_version,
+            kernel_version,
+        })
+    }
+}
+
+impl Task {
+    pub fn new() -> anyhow::Result<Self> {
+        TaskUpdateSandbox::parse().try_into()
+    }
+
+    pub fn exec(&self) -> anyhow::Result<()> {
+        let current = build_rs::read_current(&self.build_rs_path)?;
+
+        let fc = firecracker::find_latest(&self.firecracker_version)?;
+        let kern = kernel::find_latest(&self.kernel_version)?;
+
+        let new = BuildRsValues {
+            firecracker_version: fc.tag.clone(),
+            firecracker_sha256_x86_64: fc.sha256_x86_64,
+            firecracker_sha256_aarch64: fc.sha256_aarch64,
+            kernel_url_x86_64: kern.url_x86_64,
+            kernel_url_aarch64: kern.url_aarch64,
+            kernel_sha256_x86_64: kern.sha256_x86_64,
+            kernel_sha256_aarch64: kern.sha256_aarch64,
+        };
+
+        let fc_changed = current.firecracker_version != new.firecracker_version;
+        let kern_changed = current.kernel_url_x86_64 != new.kernel_url_x86_64;
+
+        if !fc_changed && !kern_changed {
+            println!("Already up to date");
+            return Ok(());
+        }
+
+        let summary = format_summary(&current, &new, &kern.version, fc_changed, kern_changed);
+
+        if self.dry_run {
+            println!("[dry run] {summary}");
+            return Ok(());
+        }
+
+        build_rs::apply_updates(&self.build_rs_path, &current, &new)?;
+        println!("{summary}");
+
+        Ok(())
+    }
+}
+
+fn format_summary(
+    current: &BuildRsValues,
+    new: &BuildRsValues,
+    new_kernel_version: &str,
+    fc_changed: bool,
+    kern_changed: bool,
+) -> String {
+    let mut parts = Vec::new();
+
+    if fc_changed {
+        parts.push(format!(
+            "Firecracker {} -> {}",
+            current.firecracker_version, new.firecracker_version
+        ));
+    }
+
+    if kern_changed {
+        let current_kernel = current
+            .kernel_url_x86_64
+            .rsplit('/')
+            .next()
+            .and_then(|f| f.strip_prefix("vmlinux-"))
+            .unwrap_or("unknown");
+        parts.push(format!("kernel {current_kernel} -> {new_kernel_version}"));
+    }
+
+    format!("Update {}", parts.join(", "))
+}
+
+fn default_build_rs_path() -> Utf8PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_owned());
+    let manifest_path = Utf8PathBuf::from(manifest_dir);
+
+    // Walk up to find the workspace root (contains Cargo.lock)
+    let mut workspace_root = manifest_path.clone();
+    while let Some(parent) = workspace_root.parent() {
+        if workspace_root.join("Cargo.lock").exists() {
+            break;
+        }
+        workspace_root = parent.to_path_buf();
+    }
+
+    workspace_root.join("plus/bencher_runner/build.rs")
+}


### PR DESCRIPTION
- Add update_sandbox task crate that detects newer Firecracker releases and Linux kernel builds, then updates `plus/bencher_runner/build.rs` with new versions and SHA256 hashes
- Add nightly GitHub Actions workflow (`.github/workflows/update_sandbox.yml`) that runs the task and creates/updates a PR against `devel`                                                            
                                                                                                                                                                      
The task pins to a major.minor series (default: Firecracker `1.15`, kernel `6.1`) and only auto-bumps patch versions. Override with` --firecracker-version` and `--kernel-version`. Use `--dry-run` to preview changes without writing.   