### PR TITLE
Fix unclaimed OCI push race condition

### DIFF
--- a/lib/bencher_schema/src/model/organization/mod.rs
+++ b/lib/bencher_schema/src/model/organization/mod.rs
@@ -137,7 +137,7 @@ impl QueryOrganization {
         let insert_organization =
             InsertOrganization::new(project_name.clone(), project_slug.clone().into());
 
-        let (existing, inserted_id) = write_transaction!(context, |conn| {
+        let result = write_transaction!(context, |conn| {
             let existing = schema::organization::table
                 .filter(schema::organization::slug.eq(&insert_organization.slug))
                 .filter(schema::organization::deleted.is_null())
@@ -146,24 +146,24 @@ impl QueryOrganization {
 
             if let Some(existing) = existing {
                 if !Self::is_claimed_inner(conn, existing.id)? {
-                    return diesel::QueryResult::Ok((Some(existing), None));
+                    return diesel::QueryResult::Ok(GetOrCreateOrg::Unclaimed(existing));
                 }
-                return diesel::QueryResult::Ok((None, None));
+                return diesel::QueryResult::Ok(GetOrCreateOrg::Claimed);
             }
 
             let id = Self::insert(conn, &insert_organization)?;
-            diesel::QueryResult::Ok((None, Some(id)))
+            diesel::QueryResult::Ok(GetOrCreateOrg::Inserted(id))
         })
         .map_err(resource_conflict_err!(Organization, &insert_organization))?;
 
-        match (existing, inserted_id) {
-            (Some(org), _) => Ok(org),
-            (None, Some(id)) => {
+        match result {
+            GetOrCreateOrg::Unclaimed(org) => Ok(org),
+            GetOrCreateOrg::Inserted(id) => {
                 #[cfg(feature = "otel")]
                 bencher_otel::ApiMeter::increment(bencher_otel::ApiCounter::OrganizationCreate);
                 Ok(insert_organization.into_query(id))
             },
-            (None, None) => Err(unauthorized_error(format!(
+            GetOrCreateOrg::Claimed => Err(unauthorized_error(format!(
                 "This project ({project_slug}) has already been claimed. Provide a valid API token (`--token`) to authenticate."
             ))),
         }
@@ -582,6 +582,12 @@ impl QueryOrganization {
             claimed,
         }
     }
+}
+
+enum GetOrCreateOrg {
+    Unclaimed(QueryOrganization),
+    Inserted(OrganizationId),
+    Claimed,
 }
 
 #[derive(Debug, diesel::Insertable)]

--- a/lib/bencher_schema/src/model/organization/mod.rs
+++ b/lib/bencher_schema/src/model/organization/mod.rs
@@ -145,10 +145,13 @@ impl QueryOrganization {
                 .optional()?;
 
             if let Some(existing) = existing {
-                if !Self::is_claimed_inner(conn, existing.id)? {
-                    return diesel::QueryResult::Ok(GetOrCreateOrg::Unclaimed(existing));
-                }
-                return diesel::QueryResult::Ok(GetOrCreateOrg::Claimed);
+                return diesel::QueryResult::Ok(
+                    if QueryOrganizationRole::count_query(conn, existing.id)? == 0 {
+                        GetOrCreateOrg::Unclaimed(existing)
+                    } else {
+                        GetOrCreateOrg::Claimed
+                    },
+                );
             }
 
             let id = Self::insert(conn, &insert_organization)?;
@@ -300,20 +303,8 @@ impl QueryOrganization {
             .map_err(forbidden_error)
     }
 
-    fn is_claimed_inner(
-        conn: &mut DbConnection,
-        organization_id: OrganizationId,
-    ) -> diesel::QueryResult<bool> {
-        let member_count: i64 = schema::organization_role::table
-            .filter(schema::organization_role::organization_id.eq(organization_id))
-            .count()
-            .get_result(conn)?;
-        Ok(member_count > 0)
-    }
-
     pub fn is_claimed(&self, conn: &mut DbConnection) -> Result<bool, HttpError> {
-        Self::is_claimed_inner(conn, self.id)
-            .map_err(resource_not_found_err!(OrganizationRole, self.id))
+        Ok(QueryOrganizationRole::count(conn, self.id)? > 0)
     }
 
     pub fn claimed_at(&self, conn: &mut DbConnection) -> Result<DateTime, HttpError> {

--- a/lib/bencher_schema/src/model/organization/mod.rs
+++ b/lib/bencher_schema/src/model/organization/mod.rs
@@ -133,49 +133,37 @@ impl QueryOrganization {
             return Ok(query_organization);
         }
 
-        // Slow path: atomic check-or-insert using only the write connection.
-        // Under concurrent OCI pushes, multiple requests race past the fast path.
-        // By doing check-or-insert inside the write transaction, we avoid pool
-        // exhaustion that occurred when conflict recovery needed a pool connection.
+        // Slow path: atomic check-or-insert using only the write connection
         let insert_organization =
             InsertOrganization::new(project_name.clone(), project_slug.clone().into());
-        let org_slug = OrganizationSlug::from(project_slug.clone());
 
-        let (query_organization, created) = write_transaction!(context, |conn| {
+        let (existing, inserted_id) = write_transaction!(context, |conn| {
             let existing = schema::organization::table
-                .filter(schema::organization::slug.eq(org_slug.as_ref()))
+                .filter(schema::organization::slug.eq(&insert_organization.slug))
                 .filter(schema::organization::deleted.is_null())
                 .first::<Self>(conn)
                 .optional()?;
 
             if let Some(existing) = existing {
-                let member_count: i64 = schema::organization_role::table
-                    .filter(schema::organization_role::organization_id.eq(existing.id))
-                    .count()
-                    .get_result(conn)?;
-                if member_count == 0 {
-                    return Ok((Some(existing), false));
+                if !Self::is_claimed_inner(conn, existing.id)? {
+                    return diesel::QueryResult::Ok((Some(existing), None));
                 }
-                // Claimed — signal via None
-                return Ok((None, false));
+                return diesel::QueryResult::Ok((None, None));
             }
 
             let id = Self::insert(conn, &insert_organization)?;
-            Ok((Some(insert_organization.into_query(id)), true))
+            diesel::QueryResult::Ok((None, Some(id)))
         })
         .map_err(resource_conflict_err!(Organization, &insert_organization))?;
 
-        match query_organization {
-            Some(org) => {
+        match (existing, inserted_id) {
+            (Some(org), _) => Ok(org),
+            (None, Some(id)) => {
                 #[cfg(feature = "otel")]
-                if created {
-                    bencher_otel::ApiMeter::increment(
-                        bencher_otel::ApiCounter::OrganizationCreate,
-                    );
-                }
-                Ok(org)
+                bencher_otel::ApiMeter::increment(bencher_otel::ApiCounter::OrganizationCreate);
+                Ok(insert_organization.into_query(id))
             },
-            None => Err(unauthorized_error(format!(
+            (None, None) => Err(unauthorized_error(format!(
                 "This project ({project_slug}) has already been claimed. Provide a valid API token (`--token`) to authenticate."
             ))),
         }
@@ -237,7 +225,6 @@ impl QueryOrganization {
 
         Ok(query_organization)
     }
-
 
     fn insert(
         conn: &mut DbConnection,
@@ -313,10 +300,20 @@ impl QueryOrganization {
             .map_err(forbidden_error)
     }
 
+    fn is_claimed_inner(
+        conn: &mut DbConnection,
+        organization_id: OrganizationId,
+    ) -> diesel::QueryResult<bool> {
+        let member_count: i64 = schema::organization_role::table
+            .filter(schema::organization_role::organization_id.eq(organization_id))
+            .count()
+            .get_result(conn)?;
+        Ok(member_count > 0)
+    }
+
     pub fn is_claimed(&self, conn: &mut DbConnection) -> Result<bool, HttpError> {
-        let total_members = QueryOrganizationRole::count(conn, self.id)?;
-        // If the organization that has zero members, then it is unclaimed.
-        Ok(total_members > 0)
+        Self::is_claimed_inner(conn, self.id)
+            .map_err(resource_not_found_err!(OrganizationRole, self.id))
     }
 
     pub fn claimed_at(&self, conn: &mut DbConnection) -> Result<DateTime, HttpError> {

--- a/lib/bencher_schema/src/model/organization/mod.rs
+++ b/lib/bencher_schema/src/model/organization/mod.rs
@@ -13,7 +13,9 @@ use bencher_json::{
 use bencher_rbac::{Organization, organization::Permission};
 #[cfg(feature = "plus")]
 use diesel::BelongingToDsl as _;
-use diesel::{ExpressionMethods as _, QueryDsl as _, Queryable, RunQueryDsl as _};
+use diesel::{
+    ExpressionMethods as _, OptionalExtension as _, QueryDsl as _, Queryable, RunQueryDsl as _,
+};
 use dropshot::HttpError;
 use organization_role::{InsertOrganizationRole, QueryOrganizationRole};
 #[cfg(feature = "plus")]
@@ -124,24 +126,58 @@ impl QueryOrganization {
         project_name: &ResourceName,
         project_slug: &ProjectSlug,
     ) -> Result<Self, HttpError> {
-        // The project organization should be created with the project's slug.
+        // Fast path: check if already exists (pool connection, covers common case)
         if let Ok(query_organization) =
             Self::find_unclaimed_project_organization(context, project_slug).await
         {
             return Ok(query_organization);
         }
 
+        // Slow path: atomic check-or-insert using only the write connection.
+        // Under concurrent OCI pushes, multiple requests race past the fast path.
+        // By doing check-or-insert inside the write transaction, we avoid pool
+        // exhaustion that occurred when conflict recovery needed a pool connection.
         let insert_organization =
             InsertOrganization::new(project_name.clone(), project_slug.clone().into());
-        match Self::create_from_project(context, insert_organization).await {
-            Ok(org) => Ok(org),
-            Err(e) if crate::error::is_conflict(&e) => {
-                // Another concurrent request created this org — re-lookup
-                Self::find_unclaimed_project_organization(context, project_slug)
-                    .await
-                    .map_err(|_lookup_err| e)
+        let org_slug = OrganizationSlug::from(project_slug.clone());
+
+        let (query_organization, created) = write_transaction!(context, |conn| {
+            let existing = schema::organization::table
+                .filter(schema::organization::slug.eq(org_slug.as_ref()))
+                .filter(schema::organization::deleted.is_null())
+                .first::<Self>(conn)
+                .optional()?;
+
+            if let Some(existing) = existing {
+                let member_count: i64 = schema::organization_role::table
+                    .filter(schema::organization_role::organization_id.eq(existing.id))
+                    .count()
+                    .get_result(conn)?;
+                if member_count == 0 {
+                    return Ok((Some(existing), false));
+                }
+                // Claimed — signal via None
+                return Ok((None, false));
+            }
+
+            let id = Self::insert(conn, &insert_organization)?;
+            Ok((Some(insert_organization.into_query(id)), true))
+        })
+        .map_err(resource_conflict_err!(Organization, &insert_organization))?;
+
+        match query_organization {
+            Some(org) => {
+                #[cfg(feature = "otel")]
+                if created {
+                    bencher_otel::ApiMeter::increment(
+                        bencher_otel::ApiCounter::OrganizationCreate,
+                    );
+                }
+                Ok(org)
             },
-            Err(e) => Err(e),
+            None => Err(unauthorized_error(format!(
+                "This project ({project_slug}) has already been claimed. Provide a valid API token (`--token`) to authenticate."
+            ))),
         }
     }
 
@@ -202,20 +238,6 @@ impl QueryOrganization {
         Ok(query_organization)
     }
 
-    async fn create_from_project(
-        context: &ApiContext,
-        insert_organization: InsertOrganization,
-    ) -> Result<Self, HttpError> {
-        let query_organization =
-            write_transaction!(context, |conn| Self::insert(conn, &insert_organization))
-                .map_err(resource_conflict_err!(Organization, &insert_organization))
-                .map(|id| insert_organization.into_query(id))?;
-
-        #[cfg(feature = "otel")]
-        bencher_otel::ApiMeter::increment(bencher_otel::ApiCounter::OrganizationCreate);
-
-        Ok(query_organization)
-    }
 
     fn insert(
         conn: &mut DbConnection,

--- a/lib/bencher_schema/src/model/organization/organization_role.rs
+++ b/lib/bencher_schema/src/model/organization/organization_role.rs
@@ -28,14 +28,21 @@ pub struct QueryOrganizationRole {
 }
 
 impl QueryOrganizationRole {
-    pub fn count(
+    pub(crate) fn count_query(
         conn: &mut DbConnection,
         organization_id: OrganizationId,
-    ) -> Result<i64, HttpError> {
+    ) -> diesel::QueryResult<i64> {
         schema::organization_role::table
             .filter(schema::organization_role::organization_id.eq(&organization_id))
             .count()
             .get_result(conn)
+    }
+
+    pub fn count(
+        conn: &mut DbConnection,
+        organization_id: OrganizationId,
+    ) -> Result<i64, HttpError> {
+        Self::count_query(conn, organization_id)
             .map_err(resource_not_found_err!(OrganizationRole, organization_id))
     }
 

--- a/lib/bencher_schema/src/model/project/mod.rs
+++ b/lib/bencher_schema/src/model/project/mod.rs
@@ -32,7 +32,6 @@ use crate::{
         organization::QueryOrganization,
         user::{auth::AuthUser, public::PublicUser},
     },
-    public_conn,
     schema::{self, project as project_table},
     write_conn, write_transaction,
 };
@@ -175,27 +174,29 @@ impl QueryProject {
                 // requests race past the caller's existence check. By doing
                 // check-or-insert inside the write transaction, we avoid pool
                 // exhaustion from conflict-recovery re-lookups.
-                let (query_project, created) = write_transaction!(context, |conn| {
+                let result = write_transaction!(context, |conn| {
                     let existing = schema::project::table
                         .filter(schema::project::slug.eq(&project_slug))
                         .filter(schema::project::deleted.is_null())
                         .first::<Self>(conn)
                         .optional()?;
                     if let Some(existing) = existing {
-                        return Ok((existing, false));
+                        return diesel::QueryResult::Ok(Some(existing));
                     }
-                    let id = Self::insert(conn, &insert_project)?;
-                    Ok((insert_project.into_query(id), true))
+                    Self::insert(conn, &insert_project)?;
+                    diesel::QueryResult::Ok(None)
                 })
                 .map_err(resource_conflict_err!(Project, &insert_project))?;
 
-                if created {
+                if let Some(query_project) = result {
+                    Ok(query_project)
+                } else {
+                    let query_project = Self::from_slug(write_conn!(context), &project_slug)?;
                     slog::debug!(log, "Created project: {query_project:?}");
                     #[cfg(feature = "plus")]
                     context.update_index(log, &query_project).await;
+                    Ok(query_project)
                 }
-
-                Ok(query_project)
             },
             PublicUser::Auth(auth_user) => {
                 let query_organization =
@@ -362,7 +363,6 @@ impl QueryProject {
 
         Ok(query_project)
     }
-
 
     fn insert(
         conn: &mut DbConnection,

--- a/lib/bencher_schema/src/model/project/mod.rs
+++ b/lib/bencher_schema/src/model/project/mod.rs
@@ -7,8 +7,8 @@ use bencher_json::{
 };
 use bencher_rbac::{Organization, Project, project::Permission};
 use diesel::{
-    BoolExpressionMethods as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _,
-    TextExpressionMethods as _,
+    BoolExpressionMethods as _, ExpressionMethods as _, OptionalExtension as _, QueryDsl as _,
+    RunQueryDsl as _, TextExpressionMethods as _,
 };
 use dropshot::HttpError;
 use project_role::InsertProjectRole;
@@ -162,28 +162,40 @@ impl QueryProject {
                     &project_slug,
                 )
                 .await?;
-                // In most cases, there should only ever be one on-the-fly project here,
-                // but check the rate limit just in case.
                 #[cfg(feature = "plus")]
                 InsertProject::rate_limit(context, &query_organization).await?;
-                // Currently, there is no semantic importance to having the organization and project have the same UUID.
-                // However, it seems like a good idea to keep them in sync for now.
-                // It makes identifying on-the-fly unclaimed projects easier, even after they have been claimed.
-                // This is okay since there should never be more than one project in an unclaimed "from project" organization.
+                // The organization and project share the same UUID so that
+                // on-the-fly unclaimed projects are easy to identify after claiming.
                 let insert_project = InsertProject::from_organization(
                     &query_organization,
                     project_name,
                     project_slug.clone(),
                 );
-                match Self::create_inner(log, context, insert_project).await {
-                    Ok(project) => Ok(project),
-                    Err(e) if crate::error::is_conflict(&e) => {
-                        // Another concurrent request created this project — re-lookup
-                        Self::from_slug(public_conn!(context), &project_slug)
-                            .map_err(|_lookup_err| e)
-                    },
-                    Err(e) => Err(e),
+                // Atomic check-or-insert: under concurrent OCI pushes, multiple
+                // requests race past the caller's existence check. By doing
+                // check-or-insert inside the write transaction, we avoid pool
+                // exhaustion from conflict-recovery re-lookups.
+                let (query_project, created) = write_transaction!(context, |conn| {
+                    let existing = schema::project::table
+                        .filter(schema::project::slug.eq(&project_slug))
+                        .filter(schema::project::deleted.is_null())
+                        .first::<Self>(conn)
+                        .optional()?;
+                    if let Some(existing) = existing {
+                        return Ok((existing, false));
+                    }
+                    let id = Self::insert(conn, &insert_project)?;
+                    Ok((insert_project.into_query(id), true))
+                })
+                .map_err(resource_conflict_err!(Project, &insert_project))?;
+
+                if created {
+                    slog::debug!(log, "Created project: {query_project:?}");
+                    #[cfg(feature = "plus")]
+                    context.update_index(log, &query_project).await;
                 }
+
+                Ok(query_project)
             },
             PublicUser::Auth(auth_user) => {
                 let query_organization =
@@ -351,21 +363,6 @@ impl QueryProject {
         Ok(query_project)
     }
 
-    async fn create_inner(
-        log: &Logger,
-        context: &ApiContext,
-        insert_project: InsertProject,
-    ) -> Result<Self, HttpError> {
-        let query_project = write_transaction!(context, |conn| Self::insert(conn, &insert_project))
-            .map_err(resource_conflict_err!(Project, &insert_project))
-            .map(|id| insert_project.into_query(id))?;
-        slog::debug!(log, "Created project: {query_project:?}");
-
-        #[cfg(feature = "plus")]
-        context.update_index(log, &query_project).await;
-
-        Ok(query_project)
-    }
 
     fn insert(
         conn: &mut DbConnection,

--- a/lib/bencher_schema/src/model/project/mod.rs
+++ b/lib/bencher_schema/src/model/project/mod.rs
@@ -170,10 +170,6 @@ impl QueryProject {
                     project_name,
                     project_slug.clone(),
                 );
-                // Atomic check-or-insert: under concurrent OCI pushes, multiple
-                // requests race past the caller's existence check. By doing
-                // check-or-insert inside the write transaction, we avoid pool
-                // exhaustion from conflict-recovery re-lookups.
                 let result = write_transaction!(context, |conn| {
                     let existing = schema::project::table
                         .filter(schema::project::slug.eq(&project_slug))
@@ -181,21 +177,22 @@ impl QueryProject {
                         .first::<Self>(conn)
                         .optional()?;
                     if let Some(existing) = existing {
-                        return diesel::QueryResult::Ok(Some(existing));
+                        return diesel::QueryResult::Ok(GetOrCreateProject::Existing(existing));
                     }
-                    Self::insert(conn, &insert_project)?;
-                    diesel::QueryResult::Ok(None)
+                    let id = Self::insert(conn, &insert_project)?;
+                    diesel::QueryResult::Ok(GetOrCreateProject::Inserted(id))
                 })
                 .map_err(resource_conflict_err!(Project, &insert_project))?;
 
-                if let Some(query_project) = result {
-                    Ok(query_project)
-                } else {
-                    let query_project = Self::from_slug(write_conn!(context), &project_slug)?;
-                    slog::debug!(log, "Created project: {query_project:?}");
-                    #[cfg(feature = "plus")]
-                    context.update_index(log, &query_project).await;
-                    Ok(query_project)
+                match result {
+                    GetOrCreateProject::Existing(query_project) => Ok(query_project),
+                    GetOrCreateProject::Inserted(id) => {
+                        let query_project = insert_project.into_query(id);
+                        slog::debug!(log, "Created project: {query_project:?}");
+                        #[cfg(feature = "plus")]
+                        context.update_index(log, &query_project).await;
+                        Ok(query_project)
+                    },
                 }
             },
             PublicUser::Auth(auth_user) => {
@@ -560,6 +557,11 @@ impl QueryProject {
             claimed,
         }
     }
+}
+
+enum GetOrCreateProject {
+    Existing(QueryProject),
+    Inserted(ProjectId),
 }
 
 #[derive(Debug, diesel::Insertable)]


### PR DESCRIPTION
Fix unclaimed OCI push race condition by replacing pool-based conflict recovery with atomic check-or-insert.