### PR TITLE
Add project keys to OCI endpoints

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,26 +95,12 @@ jobs:
         run: |
           echo "## OCI Conformance Test Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Admin Token" >> $GITHUB_STEP_SUMMARY
           if [ -f ./oci-conformance-results/test-output.log ]; then
             echo "<details>" >> $GITHUB_STEP_SUMMARY
             echo "<summary>Test Output</summary>" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             cat ./oci-conformance-results/test-output.log >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "</details>" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "No test output found." >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Project Key" >> $GITHUB_STEP_SUMMARY
-          if [ -f ./oci-conformance-results/project-key/test-output.log ]; then
-            echo "<details>" >> $GITHUB_STEP_SUMMARY
-            echo "<summary>Test Output</summary>" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            cat ./oci-conformance-results/project-key/test-output.log >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "</details>" >> $GITHUB_STEP_SUMMARY
           else

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,12 +95,26 @@ jobs:
         run: |
           echo "## OCI Conformance Test Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Admin Token" >> $GITHUB_STEP_SUMMARY
           if [ -f ./oci-conformance-results/test-output.log ]; then
             echo "<details>" >> $GITHUB_STEP_SUMMARY
             echo "<summary>Test Output</summary>" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             cat ./oci-conformance-results/test-output.log >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "</details>" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "No test output found." >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Project Key" >> $GITHUB_STEP_SUMMARY
+          if [ -f ./oci-conformance-results/project-key/test-output.log ]; then
+            echo "<details>" >> $GITHUB_STEP_SUMMARY
+            echo "<summary>Test Output</summary>" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            cat ./oci-conformance-results/project-key/test-output.log >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "</details>" >> $GITHUB_STEP_SUMMARY
           else

--- a/lib/api_auth/src/oci/mod.rs
+++ b/lib/api_auth/src/oci/mod.rs
@@ -340,12 +340,7 @@ async fn project_key_oci_token(
     let query_project = QueryProject::get(public_conn!(context), query_key.project_id)
         .map_err(|_| unauthorized_with_www_authenticate(rqctx, query.scope.as_deref()))?;
 
-    // Verify the username matches the key's project
-    let username_matches = match project_rid {
-        ProjectResourceId::Slug(slug) => query_project.slug == *slug,
-        ProjectResourceId::Uuid(uuid) => query_project.uuid == *uuid,
-    };
-    if !username_matches {
+    if !query_project.matches_resource_id(project_rid) {
         return Err(unauthorized_with_www_authenticate(
             rqctx,
             query.scope.as_deref(),
@@ -355,21 +350,16 @@ async fn project_key_oci_token(
     // If scope specifies a repository, verify it matches the key's project
     if let Some(repo_name) = &repository
         && let Ok(repo_rid) = repo_name.parse::<ProjectResourceId>()
+        && !query_project.matches_resource_id(&repo_rid)
     {
-        let repo_matches = match &repo_rid {
-            ProjectResourceId::Slug(slug) => query_project.slug == *slug,
-            ProjectResourceId::Uuid(uuid) => query_project.uuid == *uuid,
-        };
-        if !repo_matches {
-            return Err(HttpError::for_client_error(
-                None,
-                ClientErrorStatusCode::FORBIDDEN,
-                oci_error_body(
-                    OCI_ERROR_DENIED,
-                    "Project key is not authorized for the requested repository",
-                ),
-            ));
-        }
+        return Err(HttpError::for_client_error(
+            None,
+            ClientErrorStatusCode::FORBIDDEN,
+            oci_error_body(
+                OCI_ERROR_DENIED,
+                "Project key is not authorized for the requested repository",
+            ),
+        ));
     }
 
     slog::info!(

--- a/lib/api_auth/src/oci/mod.rs
+++ b/lib/api_auth/src/oci/mod.rs
@@ -75,14 +75,10 @@ pub async fn auth_oci_token_options(
 ///
 /// Authenticates via Basic auth and returns a short-lived JWT for OCI operations.
 /// Supports two credential types:
-/// - `email:api-key-jwt` — user authentication
-/// - `project-slug-or-uuid:bencher_run_xxxxx` — project key authentication
+/// - `email:api-key-jwt`: user authentication
+/// - `project-slug-or-uuid:bencher_run_xxxxx`: project key authentication
 ///
 /// If no Basic auth credentials are provided, issues a public (anonymous) OCI token.
-#[expect(
-    clippy::map_err_ignore,
-    reason = "Intentionally discarding credential parse errors for security"
-)]
 #[endpoint {
     method = GET,
     path = "/v0/auth/oci/token",
@@ -104,22 +100,26 @@ pub async fn auth_oci_token_get(
 
     let jwt = match extract_basic_credentials(&rqctx) {
         Ok((username, password)) if password.starts_with(PROJECT_KEY_PREFIX) => {
-            let project_key: ProjectKey = password
-                .parse()
-                .map_err(|_| unauthorized_with_www_authenticate(&rqctx, query.scope.as_deref()))?;
-            let project: ProjectResourceId = username
-                .parse()
-                .map_err(|_| unauthorized_with_www_authenticate(&rqctx, query.scope.as_deref()))?;
-            project_key_oci_token(
-                &rqctx,
-                context,
-                &query,
-                &project,
-                &project_key,
-                repository,
-                actions,
-            )
-            .await?
+            if let (Ok(project), Ok(project_key)) = (
+                username.parse::<ProjectResourceId>(),
+                password.parse::<ProjectKey>(),
+            ) {
+                project_key_oci_token(
+                    &rqctx,
+                    context,
+                    &query,
+                    &project,
+                    &project_key,
+                    repository,
+                    actions,
+                )
+                .await?
+            } else {
+                return Err(unauthorized_with_www_authenticate(
+                    &rqctx,
+                    query.scope.as_deref(),
+                ));
+            }
         },
         Ok((username, password)) => {
             if let (Ok(email), Ok(api_token)) = (username.parse::<Email>(), password.parse::<Jwt>())

--- a/lib/api_auth/src/oci/mod.rs
+++ b/lib/api_auth/src/oci/mod.rs
@@ -362,6 +362,8 @@ async fn project_key_oci_token(
         ));
     }
 
+    context.rate_limiting.project_request(query_project.uuid)?;
+
     slog::info!(
         &rqctx.log,
         "Issuing OCI project token via project key";

--- a/lib/api_auth/src/oci/mod.rs
+++ b/lib/api_auth/src/oci/mod.rs
@@ -98,7 +98,7 @@ pub async fn auth_oci_token_get(
         (None, vec![])
     };
 
-    let jwt = match extract_basic_credentials(&rqctx) {
+    let jwt = match extract_basic_credentials(&rqctx)? {
         Some((username, password)) if password.starts_with(PROJECT_KEY_PREFIX) => {
             if let (Ok(project), Ok(project_key)) = (
                 username.parse::<ProjectResourceId>(),
@@ -379,19 +379,44 @@ async fn project_key_oci_token(
 
 /// Extract raw username and password from Basic auth header.
 ///
-/// Returns `None` if the header is missing or malformed.
-fn extract_basic_credentials(rqctx: &RequestContext<ApiContext>) -> Option<(String, String)> {
+/// Returns `Ok(None)` if no Authorization header or non-Basic scheme (anonymous).
+/// Returns `Ok(Some(...))` if valid Basic credentials were extracted.
+/// Returns `Err(...)` if the header is Basic but the payload is malformed.
+fn extract_basic_credentials(
+    rqctx: &RequestContext<ApiContext>,
+) -> Result<Option<(String, String)>, HttpError> {
     let headers = rqctx.request.headers();
-    let auth_header = headers.get(http::header::AUTHORIZATION)?;
-    let auth_str = auth_header.to_str().ok()?;
-    let (scheme, credentials) = auth_str.split_once(' ')?;
+    let Some(auth_header) = headers.get(http::header::AUTHORIZATION) else {
+        return Ok(None);
+    };
+    let auth_str = auth_header
+        .to_str()
+        .inspect_err(|e| {
+            slog::info!(&rqctx.log, "Invalid Authorization header encoding"; "error" => %e);
+        })
+        .map_err(|_err| unauthorized_with_www_authenticate(rqctx, None))?;
+    let Some((scheme, credentials)) = auth_str.split_once(' ') else {
+        return Ok(None);
+    };
     if !scheme.eq_ignore_ascii_case("Basic") {
-        return None;
+        return Ok(None);
     }
-    let decoded = STANDARD.decode(credentials).ok()?;
-    let decoded_str = String::from_utf8(decoded).ok()?;
-    let (username, password) = decoded_str.split_once(':')?;
-    Some((username.to_owned(), password.to_owned()))
+    let decoded = STANDARD
+        .decode(credentials)
+        .inspect_err(|e| {
+            slog::info!(&rqctx.log, "Invalid base64 in Basic auth"; "error" => %e);
+        })
+        .map_err(|_err| unauthorized_with_www_authenticate(rqctx, None))?;
+    let decoded_str = String::from_utf8(decoded)
+        .inspect_err(|e| {
+            slog::info!(&rqctx.log, "Invalid UTF-8 in Basic auth"; "error" => %e);
+        })
+        .map_err(|_err| unauthorized_with_www_authenticate(rqctx, None))?;
+    let Some((username, password)) = decoded_str.split_once(':') else {
+        slog::info!(&rqctx.log, "Missing colon in Basic auth credentials");
+        return Err(unauthorized_with_www_authenticate(rqctx, None));
+    };
+    Ok(Some((username.to_owned(), password.to_owned())))
 }
 
 /// Parse OCI scope string into repository and actions

--- a/lib/api_auth/src/oci/mod.rs
+++ b/lib/api_auth/src/oci/mod.rs
@@ -16,13 +16,13 @@
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use bencher_endpoint::{CorsResponse, Endpoint, Get};
 use bencher_json::oci::{OCI_ERROR_DENIED, OCI_ERROR_UNAUTHORIZED, oci_error_body};
-use bencher_json::{Email, Jwt, ProjectResourceId};
+use bencher_json::{Email, Jwt, PROJECT_KEY_PREFIX, ProjectKey, ProjectKeyHash, ProjectResourceId};
 use bencher_rbac::project::Permission;
 use bencher_schema::{
     context::ApiContext,
     error::issue_error,
     model::{
-        project::QueryProject,
+        project::{QueryProject, key::QueryProjectKey},
         user::{QueryUser, auth::AuthUser},
     },
     public_conn,
@@ -73,9 +73,16 @@ pub async fn auth_oci_token_options(
 
 /// OCI token endpoint
 ///
-/// Authenticates users via Basic auth (email:bencher-api-token)
-/// and returns a short-lived JWT for OCI operations.
+/// Authenticates via Basic auth and returns a short-lived JWT for OCI operations.
+/// Supports two credential types:
+/// - `email:api-key-jwt` — user authentication
+/// - `project-slug-or-uuid:bencher_run_xxxxx` — project key authentication
+///
 /// If no Basic auth credentials are provided, issues a public (anonymous) OCI token.
+#[expect(
+    clippy::map_err_ignore,
+    reason = "Intentionally discarding credential parse errors for security"
+)]
 #[endpoint {
     method = GET,
     path = "/v0/auth/oci/token",
@@ -95,20 +102,49 @@ pub async fn auth_oci_token_get(
         (None, vec![])
     };
 
-    // Try to extract Basic auth — if absent, issue a public (anonymous) token
-    let jwt = if let Ok((email, api_token)) = extract_basic_auth(&rqctx) {
-        auth_oci_token(
-            &rqctx, context, &query, &email, &api_token, repository, actions,
-        )
-        .await?
-    } else {
-        // Anonymous: issue a public OCI token with no identity or RBAC checks
-        context
+    let jwt = match extract_basic_credentials(&rqctx) {
+        Ok((username, password)) if password.starts_with(PROJECT_KEY_PREFIX) => {
+            let project_key: ProjectKey = password
+                .parse()
+                .map_err(|_| unauthorized_with_www_authenticate(&rqctx, query.scope.as_deref()))?;
+            let project: ProjectResourceId = username
+                .parse()
+                .map_err(|_| unauthorized_with_www_authenticate(&rqctx, query.scope.as_deref()))?;
+            project_key_oci_token(
+                &rqctx,
+                context,
+                &query,
+                &project,
+                &project_key,
+                repository,
+                actions,
+            )
+            .await?
+        },
+        Ok((username, password)) => {
+            if let (Ok(email), Ok(api_token)) = (username.parse::<Email>(), password.parse::<Jwt>())
+            {
+                auth_oci_token(
+                    &rqctx, context, &query, &email, &api_token, repository, actions,
+                )
+                .await?
+            } else {
+                context
+                    .token_key
+                    .new_oci_public(OCI_TOKEN_TTL, repository, actions)
+                    .map_err(|e| {
+                        HttpError::for_internal_error(format!(
+                            "Failed to create public OCI token: {e}"
+                        ))
+                    })?
+            }
+        },
+        Err(_) => context
             .token_key
             .new_oci_public(OCI_TOKEN_TTL, repository, actions)
             .map_err(|e| {
                 HttpError::for_internal_error(format!("Failed to create public OCI token: {e}"))
-            })?
+            })?,
     };
 
     let response = TokenResponse {
@@ -272,12 +308,97 @@ pub fn unauthorized_with_www_authenticate(
     error
 }
 
-/// Extract email and API token from Basic auth header
+/// Issue a project-scoped OCI token after validating a project key.
+#[expect(
+    clippy::map_err_ignore,
+    reason = "Intentionally discarding project key validation errors for security"
+)]
+async fn project_key_oci_token(
+    rqctx: &RequestContext<ApiContext>,
+    context: &ApiContext,
+    query: &TokenQuery,
+    project_rid: &ProjectResourceId,
+    project_key: &ProjectKey,
+    repository: Option<String>,
+    actions: Vec<OciAction>,
+) -> Result<Jwt, HttpError> {
+    // Pull-only requests are not allowed for project key auth.
+    // Only bare metal runners should be pulling, and they use runner tokens.
+    if actions.contains(&OciAction::Pull) && !actions.contains(&OciAction::Push) {
+        return Err(HttpError::for_client_error(
+            None,
+            ClientErrorStatusCode::FORBIDDEN,
+            oci_error_body(
+                OCI_ERROR_DENIED,
+                "Project keys cannot be used for pull-only access. Use a runner token to pull.",
+            ),
+        ));
+    }
+
+    let key_hash = ProjectKeyHash::from(project_key);
+    let now = context.clock.now();
+
+    let query_key = QueryProjectKey::from_hash(public_conn!(context), &key_hash, now)
+        .map_err(|_| unauthorized_with_www_authenticate(rqctx, query.scope.as_deref()))?;
+
+    let query_project = QueryProject::get(public_conn!(context), query_key.project_id)
+        .map_err(|_| unauthorized_with_www_authenticate(rqctx, query.scope.as_deref()))?;
+
+    // Verify the username matches the key's project
+    let username_matches = match project_rid {
+        ProjectResourceId::Slug(slug) => query_project.slug == *slug,
+        ProjectResourceId::Uuid(uuid) => query_project.uuid == *uuid,
+    };
+    if !username_matches {
+        return Err(unauthorized_with_www_authenticate(
+            rqctx,
+            query.scope.as_deref(),
+        ));
+    }
+
+    // If scope specifies a repository, verify it matches the key's project
+    if let Some(repo_name) = &repository
+        && let Ok(repo_rid) = repo_name.parse::<ProjectResourceId>()
+    {
+        let repo_matches = match &repo_rid {
+            ProjectResourceId::Slug(slug) => query_project.slug == *slug,
+            ProjectResourceId::Uuid(uuid) => query_project.uuid == *uuid,
+        };
+        if !repo_matches {
+            return Err(HttpError::for_client_error(
+                None,
+                ClientErrorStatusCode::FORBIDDEN,
+                oci_error_body(
+                    OCI_ERROR_DENIED,
+                    "Project key is not authorized for the requested repository",
+                ),
+            ));
+        }
+    }
+
+    slog::info!(
+        &rqctx.log,
+        "Issuing OCI project token via project key";
+        "project_key_uuid" => %query_key.uuid,
+        "project_uuid" => %query_project.uuid
+    );
+
+    context
+        .token_key
+        .new_oci_project(query_project.uuid, OCI_TOKEN_TTL, repository, actions)
+        .map_err(|e| {
+            HttpError::for_internal_error(format!("Failed to create OCI project token: {e}"))
+        })
+}
+
+/// Extract raw username and password from Basic auth header
 #[expect(
     clippy::map_err_ignore,
     reason = "Intentionally discarding decode errors for security"
 )]
-fn extract_basic_auth(rqctx: &RequestContext<ApiContext>) -> Result<(Email, Jwt), HttpError> {
+fn extract_basic_credentials(
+    rqctx: &RequestContext<ApiContext>,
+) -> Result<(String, String), HttpError> {
     let headers = rqctx.request.headers();
 
     let auth_header = headers
@@ -325,23 +446,7 @@ fn extract_basic_auth(rqctx: &RequestContext<ApiContext>) -> Result<(Email, Jwt)
         )
     })?;
 
-    let email: Email = username.parse().map_err(|_| {
-        HttpError::for_client_error(
-            None,
-            ClientErrorStatusCode::BAD_REQUEST,
-            "Invalid email format in username".to_owned(),
-        )
-    })?;
-
-    let api_token: Jwt = password.parse().map_err(|_| {
-        HttpError::for_client_error(
-            None,
-            ClientErrorStatusCode::BAD_REQUEST,
-            "Invalid API token format in password".to_owned(),
-        )
-    })?;
-
-    Ok((email, api_token))
+    Ok((username.to_owned(), password.to_owned()))
 }
 
 /// Parse OCI scope string into repository and actions

--- a/lib/api_auth/src/oci/mod.rs
+++ b/lib/api_auth/src/oci/mod.rs
@@ -161,10 +161,6 @@ pub async fn auth_oci_token_get(
 }
 
 /// Issue an authenticated OCI token after validating credentials and RBAC.
-#[expect(
-    clippy::map_err_ignore,
-    reason = "Intentionally discarding API key validation error for security"
-)]
 async fn auth_oci_token(
     rqctx: &RequestContext<ApiContext>,
     context: &ApiContext,
@@ -174,18 +170,17 @@ async fn auth_oci_token(
     repository: Option<String>,
     actions: Vec<OciAction>,
 ) -> Result<Jwt, HttpError> {
+    let scope = query.scope.as_deref();
+
     // Validate the API token
     let claims = context
         .token_key
         .validate_api_key(api_token)
-        .map_err(|_| unauthorized_with_www_authenticate(rqctx, query.scope.as_deref()))?;
+        .map_err(|e| log_unauthorized_with_www_authenticate(rqctx, scope, &e))?;
 
     // Verify the email matches the token subject
     if claims.email() != email {
-        return Err(unauthorized_with_www_authenticate(
-            rqctx,
-            query.scope.as_deref(),
-        ));
+        return Err(unauthorized_with_www_authenticate(rqctx, scope));
     }
 
     // Check admin status for pull-only requests
@@ -196,9 +191,9 @@ async fn auth_oci_token(
     if actions.contains(&OciAction::Pull) && !actions.contains(&OciAction::Push) {
         let conn = public_conn!(context);
         let query_user = QueryUser::get_with_email(conn, email)
-            .map_err(|_| unauthorized_with_www_authenticate(rqctx, query.scope.as_deref()))?;
+            .map_err(|e| log_unauthorized_with_www_authenticate(rqctx, scope, &e))?;
         let auth_user = AuthUser::load(conn, query_user)
-            .map_err(|_| unauthorized_with_www_authenticate(rqctx, query.scope.as_deref()))?;
+            .map_err(|e| log_unauthorized_with_www_authenticate(rqctx, scope, &e))?;
 
         if !auth_user.is_admin(&context.rbac) {
             return Err(HttpError::for_client_error(
@@ -218,27 +213,28 @@ async fn auth_oci_token(
         if let Ok(query_project) = QueryProject::from_resource_id(conn, &project_id) {
             let is_claimed = query_project
                 .organization(conn)
-                .map_err(|_| {
-                    HttpError::for_internal_error("Failed to query organization".to_owned())
+                .map_err(|e| {
+                    HttpError::for_internal_error(format!("Failed to query organization: {e}"))
                 })?
                 .is_claimed(conn)
-                .map_err(|_| {
-                    HttpError::for_internal_error(
-                        "Failed to check organization claim status".to_owned(),
-                    )
+                .map_err(|e| {
+                    HttpError::for_internal_error(format!(
+                        "Failed to check organization claim status: {e}"
+                    ))
                 })?;
 
             if is_claimed {
-                let query_user = QueryUser::get_with_email(conn, email).map_err(|_| {
-                    unauthorized_with_www_authenticate(rqctx, query.scope.as_deref())
-                })?;
-                let auth_user = AuthUser::load(conn, query_user).map_err(|_| {
-                    unauthorized_with_www_authenticate(rqctx, query.scope.as_deref())
-                })?;
+                let query_user = QueryUser::get_with_email(conn, email)
+                    .map_err(|e| log_unauthorized_with_www_authenticate(rqctx, scope, &e))?;
+                let auth_user = AuthUser::load(conn, query_user)
+                    .map_err(|e| log_unauthorized_with_www_authenticate(rqctx, scope, &e))?;
 
                 query_project
                     .try_allowed(&context.rbac, &auth_user, Permission::Create)
-                    .map_err(|_| {
+                    .inspect_err(|e| {
+                        slog::info!(&rqctx.log, "OCI RBAC check failed"; "error" => %e);
+                    })
+                    .map_err(|_err| {
                         HttpError::for_client_error(
                             None,
                             ClientErrorStatusCode::FORBIDDEN,
@@ -304,11 +300,16 @@ pub fn unauthorized_with_www_authenticate(
     error
 }
 
+pub fn log_unauthorized_with_www_authenticate(
+    rqctx: &RequestContext<ApiContext>,
+    scope: Option<&str>,
+    error: &dyn std::fmt::Display,
+) -> HttpError {
+    slog::info!(&rqctx.log, "OCI auth failed"; "error" => %error);
+    unauthorized_with_www_authenticate(rqctx, scope)
+}
+
 /// Issue a project-scoped OCI token after validating a project key.
-#[expect(
-    clippy::map_err_ignore,
-    reason = "Intentionally discarding project key validation errors for security"
-)]
 async fn project_key_oci_token(
     rqctx: &RequestContext<ApiContext>,
     context: &ApiContext,
@@ -318,6 +319,8 @@ async fn project_key_oci_token(
     repository: Option<String>,
     actions: Vec<OciAction>,
 ) -> Result<Jwt, HttpError> {
+    let scope = query.scope.as_deref();
+
     // Pull-only requests are not allowed for project key auth.
     // Only bare metal runners should be pulling, and they use runner tokens.
     if actions.contains(&OciAction::Pull) && !actions.contains(&OciAction::Push) {
@@ -335,16 +338,13 @@ async fn project_key_oci_token(
     let now = context.clock.now();
 
     let query_key = QueryProjectKey::from_hash(public_conn!(context), &key_hash, now)
-        .map_err(|_| unauthorized_with_www_authenticate(rqctx, query.scope.as_deref()))?;
+        .map_err(|e| log_unauthorized_with_www_authenticate(rqctx, scope, &e))?;
 
     let query_project = QueryProject::get(public_conn!(context), query_key.project_id)
-        .map_err(|_| unauthorized_with_www_authenticate(rqctx, query.scope.as_deref()))?;
+        .map_err(|e| log_unauthorized_with_www_authenticate(rqctx, scope, &e))?;
 
     if !query_project.matches_resource_id(project_rid) {
-        return Err(unauthorized_with_www_authenticate(
-            rqctx,
-            query.scope.as_deref(),
-        ));
+        return Err(unauthorized_with_www_authenticate(rqctx, scope));
     }
 
     // If scope specifies a repository, verify it matches the key's project

--- a/lib/api_auth/src/oci/mod.rs
+++ b/lib/api_auth/src/oci/mod.rs
@@ -129,14 +129,10 @@ pub async fn auth_oci_token_get(
                 )
                 .await?
             } else {
-                context
-                    .token_key
-                    .new_oci_public(OCI_TOKEN_TTL, repository, actions)
-                    .map_err(|e| {
-                        HttpError::for_internal_error(format!(
-                            "Failed to create public OCI token: {e}"
-                        ))
-                    })?
+                return Err(unauthorized_with_www_authenticate(
+                    &rqctx,
+                    query.scope.as_deref(),
+                ));
             }
         },
         Err(_) => context

--- a/lib/api_auth/src/oci/mod.rs
+++ b/lib/api_auth/src/oci/mod.rs
@@ -99,7 +99,7 @@ pub async fn auth_oci_token_get(
     };
 
     let jwt = match extract_basic_credentials(&rqctx) {
-        Ok((username, password)) if password.starts_with(PROJECT_KEY_PREFIX) => {
+        Some((username, password)) if password.starts_with(PROJECT_KEY_PREFIX) => {
             if let (Ok(project), Ok(project_key)) = (
                 username.parse::<ProjectResourceId>(),
                 password.parse::<ProjectKey>(),
@@ -121,7 +121,7 @@ pub async fn auth_oci_token_get(
                 ));
             }
         },
-        Ok((username, password)) => {
+        Some((username, password)) => {
             if let (Ok(email), Ok(api_token)) = (username.parse::<Email>(), password.parse::<Jwt>())
             {
                 auth_oci_token(
@@ -135,7 +135,7 @@ pub async fn auth_oci_token_get(
                 ));
             }
         },
-        Err(_) => context
+        None => context
             .token_key
             .new_oci_public(OCI_TOKEN_TTL, repository, actions)
             .map_err(|e| {
@@ -377,62 +377,21 @@ async fn project_key_oci_token(
         })
 }
 
-/// Extract raw username and password from Basic auth header
-#[expect(
-    clippy::map_err_ignore,
-    reason = "Intentionally discarding decode errors for security"
-)]
-fn extract_basic_credentials(
-    rqctx: &RequestContext<ApiContext>,
-) -> Result<(String, String), HttpError> {
+/// Extract raw username and password from Basic auth header.
+///
+/// Returns `None` if the header is missing or malformed.
+fn extract_basic_credentials(rqctx: &RequestContext<ApiContext>) -> Option<(String, String)> {
     let headers = rqctx.request.headers();
-
-    let auth_header = headers
-        .get(http::header::AUTHORIZATION)
-        .ok_or_else(|| unauthorized_with_www_authenticate(rqctx, None))?;
-
-    let auth_str = auth_header.to_str().map_err(|_| {
-        HttpError::for_client_error(
-            None,
-            ClientErrorStatusCode::BAD_REQUEST,
-            "Invalid Authorization header encoding".to_owned(),
-        )
-    })?;
-
-    let (scheme, credentials) = auth_str
-        .split_once(' ')
-        .ok_or_else(|| unauthorized_with_www_authenticate(rqctx, None))?;
-
+    let auth_header = headers.get(http::header::AUTHORIZATION)?;
+    let auth_str = auth_header.to_str().ok()?;
+    let (scheme, credentials) = auth_str.split_once(' ')?;
     if !scheme.eq_ignore_ascii_case("Basic") {
-        return Err(unauthorized_with_www_authenticate(rqctx, None));
+        return None;
     }
-
-    // Decode base64 credentials
-    let decoded = STANDARD.decode(credentials).map_err(|_| {
-        HttpError::for_client_error(
-            None,
-            ClientErrorStatusCode::BAD_REQUEST,
-            "Invalid base64 encoding in Authorization header".to_owned(),
-        )
-    })?;
-
-    let decoded_str = String::from_utf8(decoded).map_err(|_| {
-        HttpError::for_client_error(
-            None,
-            ClientErrorStatusCode::BAD_REQUEST,
-            "Invalid UTF-8 in Authorization credentials".to_owned(),
-        )
-    })?;
-
-    let (username, password) = decoded_str.split_once(':').ok_or_else(|| {
-        HttpError::for_client_error(
-            None,
-            ClientErrorStatusCode::BAD_REQUEST,
-            "Invalid Basic auth format (expected username:password)".to_owned(),
-        )
-    })?;
-
-    Ok((username.to_owned(), password.to_owned()))
+    let decoded = STANDARD.decode(credentials).ok()?;
+    let decoded_str = String::from_utf8(decoded).ok()?;
+    let (username, password) = decoded_str.split_once(':')?;
+    Some((username.to_owned(), password.to_owned()))
 }
 
 /// Parse OCI scope string into repository and actions

--- a/lib/bencher_json/src/system/config/plus/rate_limiting.rs
+++ b/lib/bencher_json/src/system/config/plus/rate_limiting.rs
@@ -37,6 +37,7 @@ pub struct JsonUserRateLimiter {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct JsonProjectRateLimiter {
+    pub requests: Option<JsonRateLimits>,
     pub runs: Option<JsonRateLimits>,
 }
 

--- a/lib/bencher_schema/src/context/rate_limiting/mod.rs
+++ b/lib/bencher_schema/src/context/rate_limiting/mod.rs
@@ -102,6 +102,8 @@ pub enum RateLimitingError {
         limit_gib: u64,
     },
 
+    #[error("Too many requests for project. Please, try again later.")]
+    ProjectRequests,
     #[error("Too many runs for project. Please, try again later.")]
     ProjectRuns,
 
@@ -328,6 +330,10 @@ impl RateLimiting {
 
     pub fn claimed_run(&self, user_uuid: UserUuid) -> Result<(), HttpError> {
         self.user.check_run(user_uuid)
+    }
+
+    pub fn project_request(&self, project_uuid: ProjectUuid) -> Result<(), HttpError> {
+        self.project.check_request(project_uuid)
     }
 
     pub fn project_run(&self, project_uuid: ProjectUuid) -> Result<(), HttpError> {

--- a/lib/bencher_schema/src/context/rate_limiting/project.rs
+++ b/lib/bencher_schema/src/context/rate_limiting/project.rs
@@ -5,29 +5,47 @@ use crate::context::{
     rate_limiting::{RateLimiter, RateLimits, extract_rate_limits},
 };
 
+const DEFAULT_REQUESTS_PER_MINUTE_LIMIT: usize = 1 << 11;
+const DEFAULT_REQUESTS_PER_HOUR_LIMIT: usize = 1 << 13;
+const DEFAULT_REQUESTS_PER_DAY_LIMIT: usize = 1 << 14;
+
 const DEFAULT_RUNS_PER_MINUTE_LIMIT: usize = 1 << 6;
 const DEFAULT_RUNS_PER_HOUR_LIMIT: usize = 1 << 10;
 const DEFAULT_RUNS_PER_DAY_LIMIT: usize = 1 << 12;
 
 pub(super) struct ProjectRateLimiter {
+    requests: RateLimiter<ProjectUuid>,
     runs: RateLimiter<ProjectUuid>,
 }
 
 impl Default for ProjectRateLimiter {
     fn default() -> Self {
+        let requests = RateLimits {
+            minute: DEFAULT_REQUESTS_PER_MINUTE_LIMIT,
+            hour: DEFAULT_REQUESTS_PER_HOUR_LIMIT,
+            day: DEFAULT_REQUESTS_PER_DAY_LIMIT,
+        };
+
         let runs = RateLimits {
             minute: DEFAULT_RUNS_PER_MINUTE_LIMIT,
             hour: DEFAULT_RUNS_PER_HOUR_LIMIT,
             day: DEFAULT_RUNS_PER_DAY_LIMIT,
         };
 
-        Self::new(runs)
+        Self::new(requests, runs)
     }
 }
 
 impl From<JsonProjectRateLimiter> for ProjectRateLimiter {
     fn from(json: JsonProjectRateLimiter) -> Self {
-        let JsonProjectRateLimiter { runs } = json;
+        let JsonProjectRateLimiter { requests, runs } = json;
+
+        let requests = extract_rate_limits!(
+            requests,
+            DEFAULT_REQUESTS_PER_MINUTE_LIMIT,
+            DEFAULT_REQUESTS_PER_HOUR_LIMIT,
+            DEFAULT_REQUESTS_PER_DAY_LIMIT
+        );
 
         let runs = extract_rate_limits!(
             runs,
@@ -36,12 +54,27 @@ impl From<JsonProjectRateLimiter> for ProjectRateLimiter {
             DEFAULT_RUNS_PER_DAY_LIMIT
         );
 
-        Self::new(runs)
+        Self::new(requests, runs)
     }
 }
 
 impl ProjectRateLimiter {
-    pub fn new(runs: RateLimits) -> Self {
+    pub fn new(requests: RateLimits, runs: RateLimits) -> Self {
+        let RateLimits { minute, hour, day } = requests;
+        let requests = RateLimiter::new(
+            minute,
+            hour,
+            day,
+            #[cfg(feature = "otel")]
+            &|interval| {
+                bencher_otel::ApiCounter::RequestMax(
+                    interval,
+                    bencher_otel::AuthorizationKind::Project,
+                )
+            },
+            RateLimitingError::ProjectRequests,
+        );
+
         let RateLimits { minute, hour, day } = runs;
         let runs = RateLimiter::new(
             minute,
@@ -57,17 +90,27 @@ impl ProjectRateLimiter {
             RateLimitingError::ProjectRuns,
         );
 
-        Self { runs }
+        Self { requests, runs }
     }
 
     pub fn max() -> Self {
+        let requests = RateLimits {
+            minute: usize::MAX,
+            hour: usize::MAX,
+            day: usize::MAX,
+        };
+
         let runs = RateLimits {
             minute: usize::MAX,
             hour: usize::MAX,
             day: usize::MAX,
         };
 
-        Self::new(runs)
+        Self::new(requests, runs)
+    }
+
+    pub fn check_request(&self, project_uuid: ProjectUuid) -> Result<(), dropshot::HttpError> {
+        self.requests.check(project_uuid)
     }
 
     pub fn check_run(&self, project_uuid: ProjectUuid) -> Result<(), dropshot::HttpError> {

--- a/lib/bencher_schema/src/model/project/mod.rs
+++ b/lib/bencher_schema/src/model/project/mod.rs
@@ -79,6 +79,13 @@ impl QueryProject {
     fn_eq_resource_id!(project, ProjectResourceId);
     fn_from_resource_id!(project, Project, ProjectResourceId, not_deleted);
 
+    pub fn matches_resource_id(&self, resource_id: &ProjectResourceId) -> bool {
+        match resource_id {
+            ProjectResourceId::Slug(slug) => self.slug == *slug,
+            ProjectResourceId::Uuid(uuid) => self.uuid == *uuid,
+        }
+    }
+
     fn_get!(project, ProjectId, not_deleted);
     fn_get_uuid!(project, ProjectId, ProjectUuid, not_deleted);
     fn_from_uuid!(

--- a/lib/bencher_token/src/audience.rs
+++ b/lib/bencher_token/src/audience.rs
@@ -7,6 +7,7 @@ const AUDIENCE_INVITE: &str = "invite";
 const AUDIENCE_OAUTH: &str = "oauth";
 const AUDIENCE_OCI_PUBLIC: &str = "oci_public";
 const AUDIENCE_OCI_AUTH: &str = "oci_auth";
+const AUDIENCE_OCI_PROJECT: &str = "oci_project";
 const AUDIENCE_OCI_RUNNER: &str = "oci_runner";
 
 #[derive(Debug, Copy, Clone)]
@@ -18,6 +19,7 @@ pub enum Audience {
     OAuth,
     OciPublic,
     OciAuth,
+    OciProject,
     OciRunner,
 }
 
@@ -31,6 +33,7 @@ impl Audience {
             Self::OAuth => AUDIENCE_OAUTH,
             Self::OciPublic => AUDIENCE_OCI_PUBLIC,
             Self::OciAuth => AUDIENCE_OCI_AUTH,
+            Self::OciProject => AUDIENCE_OCI_PROJECT,
             Self::OciRunner => AUDIENCE_OCI_RUNNER,
         }
     }

--- a/lib/bencher_token/src/claims.rs
+++ b/lib/bencher_token/src/claims.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "plus")]
 use bencher_json::PlanLevel;
 #[cfg(feature = "plus")]
+use bencher_json::ProjectUuid;
+#[cfg(feature = "plus")]
 use bencher_json::RunnerUuid;
 use bencher_json::{
     DateTime, Email, Jwt, OrganizationUuid, organization::member::OrganizationRole,
@@ -292,6 +294,56 @@ impl TryFrom<RunnerOciTokenClaims> for RunnerOciClaims {
 #[cfg(feature = "plus")]
 impl RunnerOciClaims {
     pub fn runner_uuid(&self) -> RunnerUuid {
+        self.sub
+    }
+}
+
+#[cfg(feature = "plus")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ProjectOciTokenClaims {
+    pub aud: String,
+    pub exp: i64,
+    pub iat: i64,
+    pub iss: String,
+    pub sub: ProjectUuid,
+    pub oci: Option<OciScopeClaims>,
+}
+
+#[cfg(feature = "plus")]
+#[derive(Debug, Clone)]
+pub struct ProjectOciClaims {
+    pub aud: String,
+    pub exp: i64,
+    pub iat: i64,
+    pub iss: String,
+    pub sub: ProjectUuid,
+    pub oci: OciScopeClaims,
+}
+
+#[cfg(feature = "plus")]
+impl TryFrom<ProjectOciTokenClaims> for ProjectOciClaims {
+    type Error = TokenError;
+
+    fn try_from(claims: ProjectOciTokenClaims) -> Result<Self, Self::Error> {
+        match claims.oci {
+            Some(oci) => Ok(Self {
+                aud: claims.aud,
+                exp: claims.exp,
+                iat: claims.iat,
+                iss: claims.iss,
+                sub: claims.sub,
+                oci,
+            }),
+            None => Err(TokenError::OciProject {
+                error: JsonWebTokenErrorKind::MissingRequiredClaim("oci".into()).into(),
+            }),
+        }
+    }
+}
+
+#[cfg(feature = "plus")]
+impl ProjectOciClaims {
+    pub fn project_uuid(&self) -> ProjectUuid {
         self.sub
     }
 }

--- a/lib/bencher_token/src/error.rs
+++ b/lib/bencher_token/src/error.rs
@@ -22,4 +22,6 @@ pub enum TokenError {
     OciAuth { error: jsonwebtoken::errors::Error },
     #[error("Invalid runner OCI token: {error}")]
     OciRunner { error: jsonwebtoken::errors::Error },
+    #[error("Invalid project OCI token: {error}")]
+    OciProject { error: jsonwebtoken::errors::Error },
 }

--- a/lib/bencher_token/src/key.rs
+++ b/lib/bencher_token/src/key.rs
@@ -9,10 +9,16 @@ use jsonwebtoken::{
 };
 
 #[cfg(feature = "plus")]
+use bencher_json::ProjectUuid;
+#[cfg(feature = "plus")]
 use bencher_json::RunnerUuid;
 
 #[cfg(feature = "plus")]
+use crate::ProjectOciClaims;
+#[cfg(feature = "plus")]
 use crate::RunnerOciClaims;
+#[cfg(feature = "plus")]
+use crate::claims::ProjectOciTokenClaims;
 use crate::claims::PublicOciTokenClaims;
 #[cfg(feature = "plus")]
 use crate::claims::RunnerOciTokenClaims;
@@ -125,6 +131,33 @@ impl TokenKey {
     }
 
     #[cfg(feature = "plus")]
+    pub fn new_oci_project(
+        &self,
+        project_uuid: ProjectUuid,
+        ttl: u32,
+        repository: Option<String>,
+        actions: Vec<OciAction>,
+    ) -> Result<Jwt, TokenError> {
+        let now = Utc::now().timestamp();
+        let claims = ProjectOciTokenClaims {
+            aud: Audience::OciProject.into(),
+            exp: now.checked_add(i64::from(ttl)).unwrap_or(now),
+            iat: now,
+            iss: self.issuer.clone(),
+            sub: project_uuid,
+            oci: Some(OciScopeClaims {
+                repository,
+                actions,
+            }),
+        };
+        Jwt::from_str(
+            &encode(&HEADER, &claims, &self.encoding)
+                .map_err(|e| TokenError::Encode { error: e })?,
+        )
+        .map_err(TokenError::Parse)
+    }
+
+    #[cfg(feature = "plus")]
     pub fn new_oci_runner(
         &self,
         runner_uuid: RunnerUuid,
@@ -225,6 +258,29 @@ impl TokenKey {
         self.validate(token, &[Audience::OciAuth])?
             .claims
             .try_into()
+    }
+
+    #[cfg(feature = "plus")]
+    pub fn validate_oci_project(&self, token: &Jwt) -> Result<ProjectOciClaims, TokenError> {
+        let mut validation = Validation::new(ALGORITHM);
+        validation.set_audience(&[Audience::OciProject]);
+        validation.set_issuer(&[self.issuer.as_str()]);
+        validation.set_required_spec_claims(&["aud", "exp", "iss", "sub"]);
+
+        let token_data: TokenData<ProjectOciTokenClaims> =
+            decode(token.as_ref(), &self.decoding, &validation)
+                .map_err(|error| TokenError::Decode { error })?;
+        let exp = token_data.claims.exp;
+        let now = Utc::now().timestamp();
+        if exp < now {
+            Err(TokenError::Expired {
+                exp,
+                now,
+                error: JsonWebTokenErrorKind::ExpiredSignature.into(),
+            })
+        } else {
+            token_data.claims.try_into()
+        }
     }
 
     #[cfg(feature = "plus")]
@@ -474,6 +530,58 @@ mod tests {
         assert!(claims.oci.repository.is_none());
     }
 
+    // --- OCI Project tokens ---
+
+    #[cfg(feature = "plus")]
+    #[test]
+    fn jwt_oci_project_round_trip() {
+        let secret_key = TokenKey::new(BENCHER_DOT_DEV_ISSUER.to_owned(), &DEFAULT_SECRET_KEY);
+
+        let project_uuid = bencher_json::ProjectUuid::new();
+        let repository = Some("test-org/test-project".to_owned());
+        let actions = vec![OciAction::Pull, OciAction::Push];
+
+        let token = secret_key
+            .new_oci_project(project_uuid, TTL, repository.clone(), actions.clone())
+            .unwrap();
+
+        let claims = secret_key.validate_oci_project(&token).unwrap();
+
+        assert_eq!(claims.aud, Audience::OciProject.to_string());
+        assert_eq!(claims.iss, BENCHER_DOT_DEV_ISSUER.to_owned());
+        assert_eq!(claims.iat, claims.exp - i64::from(TTL));
+        assert_eq!(claims.sub, project_uuid);
+        assert_eq!(claims.project_uuid(), project_uuid);
+        assert_eq!(claims.oci.repository, repository);
+        assert_eq!(claims.oci.actions, actions);
+    }
+
+    #[cfg(feature = "plus")]
+    #[test]
+    fn jwt_oci_project_expired() {
+        let secret_key = TokenKey::new(BENCHER_DOT_DEV_ISSUER.to_owned(), &DEFAULT_SECRET_KEY);
+
+        let project_uuid = bencher_json::ProjectUuid::new();
+        let now = chrono::Utc::now().timestamp();
+        let claims = crate::claims::ProjectOciTokenClaims {
+            aud: Audience::OciProject.to_string(),
+            exp: now - 100,
+            iat: now - 200,
+            iss: BENCHER_DOT_DEV_ISSUER.to_owned(),
+            sub: project_uuid,
+            oci: Some(OciScopeClaims {
+                repository: None,
+                actions: vec![OciAction::Push],
+            }),
+        };
+        let token = Jwt::from_str(
+            &jsonwebtoken::encode(&super::HEADER, &claims, &secret_key.encoding).unwrap(),
+        )
+        .unwrap();
+
+        assert!(secret_key.validate_oci_project(&token).is_err());
+    }
+
     // --- OCI Runner tokens ---
 
     #[cfg(feature = "plus")]
@@ -526,7 +634,7 @@ mod tests {
         assert!(secret_key.validate_oci_runner(&token).is_err());
     }
 
-    // --- Cross-type rejection: each OCI token type rejected by the other two ---
+    // --- Cross-type rejection: each OCI token type rejected by the other ---
 
     #[test]
     fn jwt_auth_token_rejected_as_oci_auth() {
@@ -598,5 +706,69 @@ mod tests {
             .new_oci_runner(runner_uuid, TTL, None, vec![OciAction::Pull])
             .unwrap();
         assert!(secret_key.validate_oci_auth(&token).is_err());
+    }
+
+    // --- Cross-type rejection: OCI Project tokens ---
+
+    #[cfg(feature = "plus")]
+    #[test]
+    fn jwt_oci_public_rejected_as_oci_project() {
+        let secret_key = TokenKey::new(BENCHER_DOT_DEV_ISSUER.to_owned(), &DEFAULT_SECRET_KEY);
+        let token = secret_key.new_oci_public(TTL, None, vec![]).unwrap();
+        assert!(secret_key.validate_oci_project(&token).is_err());
+    }
+
+    #[cfg(feature = "plus")]
+    #[test]
+    fn jwt_oci_project_rejected_as_oci_public() {
+        let secret_key = TokenKey::new(BENCHER_DOT_DEV_ISSUER.to_owned(), &DEFAULT_SECRET_KEY);
+        let project_uuid = bencher_json::ProjectUuid::new();
+        let token = secret_key
+            .new_oci_project(project_uuid, TTL, None, vec![OciAction::Push])
+            .unwrap();
+        assert!(secret_key.validate_oci_public(&token).is_err());
+    }
+
+    #[cfg(feature = "plus")]
+    #[test]
+    fn jwt_oci_auth_rejected_as_oci_project() {
+        let secret_key = TokenKey::new(BENCHER_DOT_DEV_ISSUER.to_owned(), &DEFAULT_SECRET_KEY);
+        let token = secret_key
+            .new_oci_auth(EMAIL.clone(), TTL, None, vec![OciAction::Pull])
+            .unwrap();
+        assert!(secret_key.validate_oci_project(&token).is_err());
+    }
+
+    #[cfg(feature = "plus")]
+    #[test]
+    fn jwt_oci_project_rejected_as_oci_auth() {
+        let secret_key = TokenKey::new(BENCHER_DOT_DEV_ISSUER.to_owned(), &DEFAULT_SECRET_KEY);
+        let project_uuid = bencher_json::ProjectUuid::new();
+        let token = secret_key
+            .new_oci_project(project_uuid, TTL, None, vec![OciAction::Push])
+            .unwrap();
+        assert!(secret_key.validate_oci_auth(&token).is_err());
+    }
+
+    #[cfg(feature = "plus")]
+    #[test]
+    fn jwt_oci_runner_rejected_as_oci_project() {
+        let secret_key = TokenKey::new(BENCHER_DOT_DEV_ISSUER.to_owned(), &DEFAULT_SECRET_KEY);
+        let runner_uuid = bencher_json::RunnerUuid::new();
+        let token = secret_key
+            .new_oci_runner(runner_uuid, TTL, None, vec![OciAction::Pull])
+            .unwrap();
+        assert!(secret_key.validate_oci_project(&token).is_err());
+    }
+
+    #[cfg(feature = "plus")]
+    #[test]
+    fn jwt_oci_project_rejected_as_oci_runner() {
+        let secret_key = TokenKey::new(BENCHER_DOT_DEV_ISSUER.to_owned(), &DEFAULT_SECRET_KEY);
+        let project_uuid = bencher_json::ProjectUuid::new();
+        let token = secret_key
+            .new_oci_project(project_uuid, TTL, None, vec![OciAction::Push])
+            .unwrap();
+        assert!(secret_key.validate_oci_runner(&token).is_err());
     }
 }

--- a/lib/bencher_token/src/lib.rs
+++ b/lib/bencher_token/src/lib.rs
@@ -11,12 +11,12 @@ mod error;
 mod key;
 
 pub use audience::Audience;
-#[cfg(feature = "plus")]
-pub use claims::RunnerOciClaims;
 pub use claims::{
     AuthOciClaims, Claims, InviteClaims, OAuthClaims, OciAction, OciScopeClaims, OrgClaims,
     PublicOciClaims, StateClaims,
 };
+#[cfg(feature = "plus")]
+pub use claims::{ProjectOciClaims, RunnerOciClaims};
 pub use error::TokenError;
 pub use key::TokenKey;
 

--- a/plus/api_oci/src/auth.rs
+++ b/plus/api_oci/src/auth.rs
@@ -185,16 +185,7 @@ pub async fn validate_pull_access(
     // Project tokens can pull from their own project regardless of claimed status
     if let OciPullIdentity::Project(pk_claims) = &identity {
         let project = resolve_project(context, repository).await?;
-        if project.uuid != pk_claims.project_uuid() {
-            return Err(HttpError::for_client_error(
-                None,
-                ClientErrorStatusCode::FORBIDDEN,
-                oci_error_body(
-                    OCI_ERROR_DENIED,
-                    "Project token not authorized for this repository",
-                ),
-            ));
-        }
+        verify_project_token(&project, pk_claims)?;
         context.rate_limiting.project_request(project.uuid)?;
         return Ok(project);
     }
@@ -260,16 +251,7 @@ pub async fn require_push_access(
                 )
             })?;
         let project = resolve_project(context, &repo_rid).await?;
-        if project.uuid != pk_claims.project_uuid() {
-            return Err(HttpError::for_client_error(
-                None,
-                ClientErrorStatusCode::FORBIDDEN,
-                oci_error_body(
-                    OCI_ERROR_DENIED,
-                    "Project token not authorized for this repository",
-                ),
-            ));
-        }
+        verify_project_token(&project, &pk_claims)?;
         context.rate_limiting.project_request(project.uuid)?;
         return Ok(());
     }
@@ -328,16 +310,7 @@ pub async fn validate_push_access(
     if let Ok(pk_claims) = context.token_key.validate_oci_project(&token) {
         validate_oci_scope(&pk_claims.oci, &repository_str, &OciAction::Push)?;
         let project = resolve_project(context, repository).await?;
-        if project.uuid != pk_claims.project_uuid() {
-            return Err(HttpError::for_client_error(
-                None,
-                ClientErrorStatusCode::FORBIDDEN,
-                oci_error_body(
-                    OCI_ERROR_DENIED,
-                    "Project token not authorized for this repository",
-                ),
-            ));
-        }
+        verify_project_token(&project, &pk_claims)?;
         slog::info!(
             log,
             "OCI push with project token";
@@ -617,6 +590,23 @@ pub fn apply_public_rate_limit(
         context.rate_limiting.public_request(remote_ip)?;
     }
     Ok(())
+}
+
+fn verify_project_token(
+    project: &QueryProject,
+    claims: &ProjectOciClaims,
+) -> Result<(), HttpError> {
+    if project.uuid == claims.project_uuid() {
+        return Ok(());
+    }
+    Err(HttpError::for_client_error(
+        None,
+        ClientErrorStatusCode::FORBIDDEN,
+        oci_error_body(
+            OCI_ERROR_DENIED,
+            "Project token not authorized for this repository",
+        ),
+    ))
 }
 
 /// Resolve a `ProjectResourceId` (UUID or slug) to a `QueryProject`

--- a/plus/api_oci/src/auth.rs
+++ b/plus/api_oci/src/auth.rs
@@ -39,7 +39,9 @@ pub enum OciPullIdentity {
 }
 
 // Re-export from api_auth
-pub use api_auth::oci::unauthorized_with_www_authenticate;
+pub use api_auth::oci::{
+    log_unauthorized_with_www_authenticate, unauthorized_with_www_authenticate,
+};
 
 /// Extract OCI bearer token from Authorization header
 ///
@@ -168,10 +170,6 @@ fn validate_pull_identity(
 /// to unclaimed projects; runner and auth tokens have normal pull access.
 ///
 /// Use this for read operations during push flows (e.g. HEAD blob checks).
-#[expect(
-    clippy::map_err_ignore,
-    reason = "Intentionally discarding auth errors for security"
-)]
 pub async fn validate_pull_access(
     rqctx: &RequestContext<ApiContext>,
     repository: &ProjectResourceId,
@@ -181,7 +179,7 @@ pub async fn validate_pull_access(
     let scope = format!("repository:{repository_str}:pull");
 
     let token = extract_oci_bearer_token(rqctx)
-        .map_err(|_| unauthorized_with_www_authenticate(rqctx, Some(&scope)))?;
+        .map_err(|e| log_unauthorized_with_www_authenticate(rqctx, Some(&scope), &e))?;
     let identity = validate_pull_identity(context, &token, &repository_str)?;
 
     // Project tokens can pull from their own project regardless of claimed status
@@ -232,10 +230,6 @@ pub async fn validate_pull_access(
 /// Validates the bearer token as an authenticated user OCI token and checks push scope.
 /// Use this for simple write operations that don't need the full project creation flow.
 /// For operations that may create projects, use `validate_push_access` instead.
-#[expect(
-    clippy::map_err_ignore,
-    reason = "Intentionally discarding auth and parse errors for security"
-)]
 pub async fn require_push_access(
     rqctx: &RequestContext<ApiContext>,
     repository: &str,
@@ -243,7 +237,7 @@ pub async fn require_push_access(
     let context = rqctx.context();
     let scope = format!("repository:{repository}:push");
     let token = extract_oci_bearer_token(rqctx)
-        .map_err(|_| unauthorized_with_www_authenticate(rqctx, Some(&scope)))?;
+        .map_err(|e| log_unauthorized_with_www_authenticate(rqctx, Some(&scope), &e))?;
 
     // Try project token first
     if let Ok(pk_claims) = context.token_key.validate_oci_project(&token) {
@@ -258,7 +252,7 @@ pub async fn require_push_access(
                     "error" => %e
                 );
             })
-            .map_err(|_| {
+            .map_err(|_err| {
                 HttpError::for_client_error(
                     None,
                     ClientErrorStatusCode::FORBIDDEN,
@@ -317,10 +311,6 @@ pub struct PushAccess {
 ///
 /// Requires a Bearer token (auth or public). Returns the project and optional claims,
 /// or an error if access is denied.
-#[expect(
-    clippy::map_err_ignore,
-    reason = "Intentionally discarding auth errors for security"
-)]
 pub async fn validate_push_access(
     log: &Logger,
     rqctx: &RequestContext<ApiContext>,
@@ -332,7 +322,7 @@ pub async fn validate_push_access(
 
     // Bearer token is required (Docker obtains one from the token endpoint)
     let token = extract_oci_bearer_token(rqctx)
-        .map_err(|_| unauthorized_with_www_authenticate(rqctx, Some(&scope)))?;
+        .map_err(|e| log_unauthorized_with_www_authenticate(rqctx, Some(&scope), &e))?;
 
     // Project tokens bypass the standard auth flow — the key is the authorization
     if let Ok(pk_claims) = context.token_key.validate_oci_project(&token) {
@@ -434,10 +424,6 @@ async fn handle_existing_project(
 }
 
 /// Handle push to a claimed project (requires authentication and RBAC permission)
-#[expect(
-    clippy::map_err_ignore,
-    reason = "Intentionally discarding RBAC error details for security"
-)]
 fn handle_claimed_project(
     log: &Logger,
     rqctx: &RequestContext<ApiContext>,
@@ -465,7 +451,10 @@ fn handle_claimed_project(
     // Verify RBAC permission
     project
         .try_allowed(&context.rbac, auth_user, Permission::Create)
-        .map_err(|_| {
+        .inspect_err(|e| {
+            slog::info!(log, "OCI RBAC check failed"; "error" => %e);
+        })
+        .map_err(|_err| {
             HttpError::for_client_error(
                 None,
                 ClientErrorStatusCode::FORBIDDEN,

--- a/plus/api_oci/src/auth.rs
+++ b/plus/api_oci/src/auth.rs
@@ -234,7 +234,7 @@ pub async fn validate_pull_access(
 /// For operations that may create projects, use `validate_push_access` instead.
 #[expect(
     clippy::map_err_ignore,
-    reason = "Intentionally discarding auth errors for security"
+    reason = "Intentionally discarding auth and parse errors for security"
 )]
 pub async fn require_push_access(
     rqctx: &RequestContext<ApiContext>,
@@ -248,20 +248,35 @@ pub async fn require_push_access(
     // Try project token first
     if let Ok(pk_claims) = context.token_key.validate_oci_project(&token) {
         validate_oci_scope(&pk_claims.oci, repository, &OciAction::Push)?;
-        if let Ok(repo_rid) = repository.parse::<ProjectResourceId>() {
-            let project = resolve_project(context, &repo_rid).await?;
-            if project.uuid != pk_claims.project_uuid() {
-                return Err(HttpError::for_client_error(
+        let repo_rid: ProjectResourceId = repository
+            .parse()
+            .inspect_err(|e| {
+                slog::error!(
+                    &rqctx.log,
+                    "Failed to parse repository as ProjectResourceId";
+                    "repository" => repository,
+                    "error" => %e
+                );
+            })
+            .map_err(|_| {
+                HttpError::for_client_error(
                     None,
                     ClientErrorStatusCode::FORBIDDEN,
-                    oci_error_body(
-                        OCI_ERROR_DENIED,
-                        "Project token not authorized for this repository",
-                    ),
-                ));
-            }
-            context.rate_limiting.project_request(project.uuid)?;
+                    oci_error_body(OCI_ERROR_DENIED, "Invalid repository for project token"),
+                )
+            })?;
+        let project = resolve_project(context, &repo_rid).await?;
+        if project.uuid != pk_claims.project_uuid() {
+            return Err(HttpError::for_client_error(
+                None,
+                ClientErrorStatusCode::FORBIDDEN,
+                oci_error_body(
+                    OCI_ERROR_DENIED,
+                    "Project token not authorized for this repository",
+                ),
+            ));
         }
+        context.rate_limiting.project_request(project.uuid)?;
         return Ok(());
     }
 

--- a/plus/api_oci/src/auth.rs
+++ b/plus/api_oci/src/auth.rs
@@ -22,18 +22,20 @@ use bencher_schema::{
     },
     public_conn,
 };
-use bencher_token::{AuthOciClaims, OciAction, OciScopeClaims, RunnerOciClaims};
+use bencher_token::{AuthOciClaims, OciAction, OciScopeClaims, ProjectOciClaims, RunnerOciClaims};
 use dropshot::{ClientErrorStatusCode, HttpError, RequestContext};
 use slog::Logger;
 
 /// Identity that can pull from the OCI registry.
 ///
 /// Pull endpoints accept public OCI tokens (anonymous),
-/// user OCI tokens (sub: `Email`), and runner OCI tokens (sub: `RunnerUuid`).
+/// user OCI tokens (sub: `Email`), runner OCI tokens (sub: `RunnerUuid`),
+/// and project OCI tokens (sub: `ProjectUuid`).
 pub enum OciPullIdentity {
     Public,
     Auth(AuthOciClaims),
     Runner(RunnerOciClaims),
+    Project(ProjectOciClaims),
 }
 
 // Re-export from api_auth
@@ -135,6 +137,12 @@ fn validate_pull_identity(
         return Ok(OciPullIdentity::Runner(runner_claims));
     }
 
+    // Try project token
+    if let Ok(project_claims) = context.token_key.validate_oci_project(token) {
+        validate_oci_scope(&project_claims.oci, repository, &OciAction::Pull)?;
+        return Ok(OciPullIdentity::Project(project_claims));
+    }
+
     // Try user token
     if let Ok(user_claims) = context.token_key.validate_oci_auth(token) {
         validate_oci_scope(&user_claims.oci, repository, &OciAction::Pull)?;
@@ -176,6 +184,23 @@ pub async fn validate_pull_access(
         .map_err(|_| unauthorized_with_www_authenticate(rqctx, Some(&scope)))?;
     let identity = validate_pull_identity(context, &token, &repository_str)?;
 
+    // Project tokens can pull from their own project regardless of claimed status
+    if let OciPullIdentity::Project(pk_claims) = &identity {
+        let project = resolve_project(context, repository).await?;
+        if project.uuid != pk_claims.project_uuid() {
+            return Err(HttpError::for_client_error(
+                None,
+                ClientErrorStatusCode::FORBIDDEN,
+                oci_error_body(
+                    OCI_ERROR_DENIED,
+                    "Project token not authorized for this repository",
+                ),
+            ));
+        }
+        context.rate_limiting.project_request(project.uuid)?;
+        return Ok(project);
+    }
+
     // Public tokens can only pull from unclaimed projects
     if matches!(identity, OciPullIdentity::Public) {
         let conn = public_conn!(context);
@@ -197,7 +222,9 @@ pub async fn validate_pull_access(
 
     apply_pull_rate_limit(rqctx, &identity).await?;
 
-    resolve_project(context, repository).await
+    let project = resolve_project(context, repository).await?;
+    context.rate_limiting.project_request(project.uuid)?;
+    Ok(project)
 }
 
 /// Require push access for an OCI operation (simple ops like delete, not project creation).
@@ -217,6 +244,16 @@ pub async fn require_push_access(
     let scope = format!("repository:{repository}:push");
     let token = extract_oci_bearer_token(rqctx)
         .map_err(|_| unauthorized_with_www_authenticate(rqctx, Some(&scope)))?;
+
+    // Try project token first
+    if let Ok(pk_claims) = context.token_key.validate_oci_project(&token) {
+        validate_oci_scope(&pk_claims.oci, repository, &OciAction::Push)?;
+        context
+            .rate_limiting
+            .project_request(pk_claims.project_uuid())?;
+        return Ok(());
+    }
+
     let claims = context
         .token_key
         .validate_oci_auth(&token)
@@ -270,6 +307,33 @@ pub async fn validate_push_access(
     // Bearer token is required (Docker obtains one from the token endpoint)
     let token = extract_oci_bearer_token(rqctx)
         .map_err(|_| unauthorized_with_www_authenticate(rqctx, Some(&scope)))?;
+
+    // Project tokens bypass the standard auth flow — the key is the authorization
+    if let Ok(pk_claims) = context.token_key.validate_oci_project(&token) {
+        validate_oci_scope(&pk_claims.oci, &repository_str, &OciAction::Push)?;
+        let project = resolve_project(context, repository).await?;
+        if project.uuid != pk_claims.project_uuid() {
+            return Err(HttpError::for_client_error(
+                None,
+                ClientErrorStatusCode::FORBIDDEN,
+                oci_error_body(
+                    OCI_ERROR_DENIED,
+                    "Project token not authorized for this repository",
+                ),
+            ));
+        }
+        slog::info!(
+            log,
+            "OCI push with project token";
+            "project_uuid" => %project.uuid
+        );
+        context.rate_limiting.project_request(project.uuid)?;
+        return Ok(PushAccess {
+            project,
+            claims: None,
+        });
+    }
+
     let (public_user, claims) =
         build_public_user(log, context, rqctx, token, &repository_str).await?;
 
@@ -278,12 +342,16 @@ pub async fn validate_push_access(
 
     // Try to find existing project, or create if using a slug
     let conn = public_conn!(context);
-    match QueryProject::from_resource_id(conn, repository) {
+    let push_access = match QueryProject::from_resource_id(conn, repository) {
         Ok(project) => {
             handle_existing_project(log, rqctx, context, project, &public_user, claims).await
         },
         Err(_) => handle_nonexistent_project(log, context, repository, &public_user, claims).await,
-    }
+    }?;
+    context
+        .rate_limiting
+        .project_request(push_access.project.uuid)?;
+    Ok(push_access)
 }
 
 /// Apply rate limiting for push operations based on authentication status.
@@ -489,6 +557,10 @@ async fn apply_pull_rate_limit(
         OciPullIdentity::Auth(claims) => apply_user_rate_limit(log, context, claims).await,
         OciPullIdentity::Runner(claims) => {
             slog::debug!(log, "Skipping rate limit for runner OCI pull"; "runner_uuid" => %claims.sub);
+            Ok(())
+        },
+        OciPullIdentity::Project(_) => {
+            // Project rate limit is applied after project resolution in validate_pull_access
             Ok(())
         },
     }

--- a/plus/api_oci/src/auth.rs
+++ b/plus/api_oci/src/auth.rs
@@ -248,9 +248,20 @@ pub async fn require_push_access(
     // Try project token first
     if let Ok(pk_claims) = context.token_key.validate_oci_project(&token) {
         validate_oci_scope(&pk_claims.oci, repository, &OciAction::Push)?;
-        context
-            .rate_limiting
-            .project_request(pk_claims.project_uuid())?;
+        if let Ok(repo_rid) = repository.parse::<ProjectResourceId>() {
+            let project = resolve_project(context, &repo_rid).await?;
+            if project.uuid != pk_claims.project_uuid() {
+                return Err(HttpError::for_client_error(
+                    None,
+                    ClientErrorStatusCode::FORBIDDEN,
+                    oci_error_body(
+                        OCI_ERROR_DENIED,
+                        "Project token not authorized for this repository",
+                    ),
+                ));
+            }
+            context.rate_limiting.project_request(project.uuid)?;
+        }
         return Ok(());
     }
 

--- a/plus/api_oci/src/auth.rs
+++ b/plus/api_oci/src/auth.rs
@@ -259,16 +259,15 @@ pub async fn require_push_access(
     let claims = context
         .token_key
         .validate_oci_auth(&token)
-        .map_err(|_err| {
-            HttpError::for_client_error(
-                None,
-                ClientErrorStatusCode::UNAUTHORIZED,
-                oci_error_body(OCI_ERROR_UNAUTHORIZED, "Invalid or expired token"),
-            )
-        })?;
+        .map_err(|e| log_unauthorized_with_www_authenticate(rqctx, Some(&scope), &e))?;
     validate_oci_scope(&claims.oci, repository, &OciAction::Push)?;
 
     apply_user_rate_limit(&rqctx.log, context, &claims).await?;
+
+    if let Ok(repo_rid) = repository.parse::<ProjectResourceId>() {
+        let project = resolve_project(context, &repo_rid).await?;
+        context.rate_limiting.project_request(project.uuid)?;
+    }
 
     Ok(())
 }

--- a/plus/api_oci/src/base.rs
+++ b/plus/api_oci/src/base.rs
@@ -52,9 +52,13 @@ pub async fn oci_base(rqctx: RequestContext<ApiContext>) -> Result<Response<Body
     let token = extract_oci_bearer_token(&rqctx)
         .map_err(|_| unauthorized_with_www_authenticate(&rqctx, None))?;
 
-    // Auth tokens (most common — authenticated Docker users), then public tokens
+    // Auth tokens (most common — authenticated Docker users), then project, then public tokens
     if let Ok(claims) = context.token_key.validate_oci_auth(&token) {
         apply_user_rate_limit(&rqctx.log, context, &claims).await?;
+    } else if let Ok(pk_claims) = context.token_key.validate_oci_project(&token) {
+        context
+            .rate_limiting
+            .project_request(pk_claims.project_uuid())?;
     } else if context.token_key.validate_oci_public(&token).is_ok() {
         apply_public_rate_limit(&rqctx.log, context, &rqctx)?;
     } else {

--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -695,7 +695,7 @@
           "oci"
         ],
         "summary": "OCI token endpoint",
-        "description": "Authenticates via Basic auth and returns a short-lived JWT for OCI operations. Supports two credential types: - `email:api-key-jwt` — user authentication - `project-slug-or-uuid:bencher_run_xxxxx` — project key authentication\n\nIf no Basic auth credentials are provided, issues a public (anonymous) OCI token.",
+        "description": "Authenticates via Basic auth and returns a short-lived JWT for OCI operations. Supports two credential types: - `email:api-key-jwt`: user authentication - `project-slug-or-uuid:bencher_run_xxxxx`: project key authentication\n\nIf no Basic auth credentials are provided, issues a public (anonymous) OCI token.",
         "operationId": "auth_oci_token_get",
         "parameters": [
           {

--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -695,7 +695,7 @@
           "oci"
         ],
         "summary": "OCI token endpoint",
-        "description": "Authenticates users via Basic auth (email:bencher-api-token) and returns a short-lived JWT for OCI operations. If no Basic auth credentials are provided, issues a public (anonymous) OCI token.",
+        "description": "Authenticates via Basic auth and returns a short-lived JWT for OCI operations. Supports two credential types: - `email:api-key-jwt` — user authentication - `project-slug-or-uuid:bencher_run_xxxxx` — project key authentication\n\nIf no Basic auth credentials are provided, issues a public (anonymous) OCI token.",
         "operationId": "auth_oci_token_get",
         "parameters": [
           {
@@ -14794,6 +14794,14 @@
       "JsonProjectRateLimiter": {
         "type": "object",
         "properties": {
+          "requests": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonRateLimits"
+              }
+            ]
+          },
           "runs": {
             "nullable": true,
             "allOf": [

--- a/tasks/test_api/src/task/plus/oci.rs
+++ b/tasks/test_api/src/task/plus/oci.rs
@@ -6,12 +6,12 @@ use std::process::{Command, Stdio};
 use std::thread;
 use std::time::Duration;
 
-use bencher_json::Jwt;
-use bencher_json::Url;
+use assert_cmd::cargo::CommandCargoExt as _;
+use bencher_json::{JsonProjectKeyCreated, Jwt, Url};
 
 use crate::parser::TaskOci;
 use crate::task::is_dev;
-use crate::task::test::seed_test::ADMIN_EMAIL;
+use crate::task::test::seed_test::{ADMIN_EMAIL, BENCHER_CMD, CLI_DIR, HOST_ARG, TOKEN_ARG};
 use crate::task::unwrap_admin_token;
 use crate::task::unwrap_url;
 
@@ -122,7 +122,101 @@ impl Oci {
             println!("Open {} to view the detailed report", report_path.display());
         }
 
-        result
+        result?;
+
+        // Run conformance tests again with a project key
+        self.run_project_key_conformance_tests()
+    }
+
+    fn run_project_key_conformance_tests(&self) -> anyhow::Result<()> {
+        println!();
+        println!("=== OCI Conformance Tests (Project Key) ===");
+
+        // Create a project key for the namespace project
+        let host = self.url.as_ref();
+        println!("Creating project key for namespace: {}", self.namespace);
+        let mut cmd = Command::cargo_bin(BENCHER_CMD)?;
+        cmd.args([
+            "project",
+            "key",
+            "create",
+            HOST_ARG,
+            host,
+            TOKEN_ARG,
+            self.password.as_ref(),
+            "--name",
+            "oci-conformance-key",
+            &self.namespace,
+        ])
+        .current_dir(CLI_DIR);
+        let output = cmd.output()?;
+        anyhow::ensure!(
+            output.status.success(),
+            "Failed to create project key for OCI conformance:\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let project_key_created: JsonProjectKeyCreated = serde_json::from_slice(&output.stdout)?;
+        let project_key = project_key_created.key;
+
+        println!(
+            "Running conformance tests with project key (username: {})...",
+            self.namespace
+        );
+        println!("Test categories enabled:");
+        println!("  - Pull: 0 (project keys reject pull-only scope)");
+        println!("  - Push: 1");
+        println!("  - Content Discovery: 1");
+        println!("  - Content Management: 1");
+        println!();
+
+        let conformance_dir = self.spec_dir.join("conformance");
+        let conformance_binary = self.conformance_binary_path();
+        let project_key_output_dir = self.output_dir.join("project-key");
+        fs::create_dir_all(&project_key_output_dir)?;
+
+        let output_file = project_key_output_dir.join("test-output.log");
+
+        let mut cmd = Command::new(&conformance_binary);
+        cmd.args(["-test.v"])
+            .current_dir(&conformance_dir)
+            .env("OCI_ROOT_URL", host)
+            .env("OCI_NAMESPACE", &self.namespace)
+            .env("OCI_CROSSMOUNT_NAMESPACE", &self.crossmount_namespace)
+            .env("OCI_DEBUG", if self.debug { "1" } else { "0" })
+            .env("OCI_REPORT_DIR", &project_key_output_dir)
+            .env("OCI_USERNAME", &self.namespace)
+            .env("OCI_PASSWORD", project_key.as_ref())
+            .env("OCI_AUTOMATIC_CROSSMOUNT", "0")
+            .env("OCI_TEST_PULL", "0")
+            .env("OCI_TEST_PUSH", "1")
+            .env("OCI_TEST_CONTENT_DISCOVERY", "1")
+            .env("OCI_TEST_CONTENT_MANAGEMENT", "1");
+
+        let output = cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).output()?;
+
+        let combined_output = format!(
+            "STDOUT:\n{}\n\nSTDERR:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        fs::write(&output_file, &combined_output)?;
+
+        print!("{}", String::from_utf8_lossy(&output.stdout));
+        eprint!("{}", String::from_utf8_lossy(&output.stderr));
+
+        println!();
+        println!("=== OCI Conformance Tests (Project Key) Complete ===");
+        println!("Results saved to: {}", project_key_output_dir.display());
+
+        if output.status.success() {
+            Ok(())
+        } else {
+            anyhow::bail!(
+                "OCI conformance tests (project key) failed with exit code: {:?}",
+                output.status.code()
+            )
+        }
     }
 
     fn check_api_connectivity(&self) -> anyhow::Result<()> {

--- a/tasks/test_api/src/task/plus/oci.rs
+++ b/tasks/test_api/src/task/plus/oci.rs
@@ -6,12 +6,11 @@ use std::process::{Command, Stdio};
 use std::thread;
 use std::time::Duration;
 
-use assert_cmd::cargo::CommandCargoExt as _;
-use bencher_json::{JsonProjectKeyCreated, Jwt, Url};
+use bencher_json::{Jwt, Url};
 
 use crate::parser::TaskOci;
 use crate::task::is_dev;
-use crate::task::test::seed_test::{ADMIN_EMAIL, BENCHER_CMD, CLI_DIR, HOST_ARG, TOKEN_ARG};
+use crate::task::test::seed_test::ADMIN_EMAIL;
 use crate::task::unwrap_admin_token;
 use crate::task::unwrap_url;
 
@@ -122,101 +121,7 @@ impl Oci {
             println!("Open {} to view the detailed report", report_path.display());
         }
 
-        result?;
-
-        // Run conformance tests again with a project key
-        self.run_project_key_conformance_tests()
-    }
-
-    fn run_project_key_conformance_tests(&self) -> anyhow::Result<()> {
-        println!();
-        println!("=== OCI Conformance Tests (Project Key) ===");
-
-        // Create a project key for the namespace project
-        let host = self.url.as_ref();
-        println!("Creating project key for namespace: {}", self.namespace);
-        let mut cmd = Command::cargo_bin(BENCHER_CMD)?;
-        cmd.args([
-            "project",
-            "key",
-            "create",
-            HOST_ARG,
-            host,
-            TOKEN_ARG,
-            self.password.as_ref(),
-            "--name",
-            "oci-conformance-key",
-            &self.namespace,
-        ])
-        .current_dir(CLI_DIR);
-        let output = cmd.output()?;
-        anyhow::ensure!(
-            output.status.success(),
-            "Failed to create project key for OCI conformance:\nstdout: {}\nstderr: {}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-        let project_key_created: JsonProjectKeyCreated = serde_json::from_slice(&output.stdout)?;
-        let project_key = project_key_created.key;
-
-        println!(
-            "Running conformance tests with project key (username: {})...",
-            self.namespace
-        );
-        println!("Test categories enabled:");
-        println!("  - Pull: 0 (project keys reject pull-only scope)");
-        println!("  - Push: 1");
-        println!("  - Content Discovery: 1");
-        println!("  - Content Management: 1");
-        println!();
-
-        let conformance_dir = self.spec_dir.join("conformance");
-        let conformance_binary = self.conformance_binary_path();
-        let project_key_output_dir = self.output_dir.join("project-key");
-        fs::create_dir_all(&project_key_output_dir)?;
-
-        let output_file = project_key_output_dir.join("test-output.log");
-
-        let mut cmd = Command::new(&conformance_binary);
-        cmd.args(["-test.v"])
-            .current_dir(&conformance_dir)
-            .env("OCI_ROOT_URL", host)
-            .env("OCI_NAMESPACE", &self.namespace)
-            .env("OCI_CROSSMOUNT_NAMESPACE", &self.crossmount_namespace)
-            .env("OCI_DEBUG", if self.debug { "1" } else { "0" })
-            .env("OCI_REPORT_DIR", &project_key_output_dir)
-            .env("OCI_USERNAME", &self.namespace)
-            .env("OCI_PASSWORD", project_key.as_ref())
-            .env("OCI_AUTOMATIC_CROSSMOUNT", "0")
-            .env("OCI_TEST_PULL", "0")
-            .env("OCI_TEST_PUSH", "1")
-            .env("OCI_TEST_CONTENT_DISCOVERY", "1")
-            .env("OCI_TEST_CONTENT_MANAGEMENT", "1");
-
-        let output = cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).output()?;
-
-        let combined_output = format!(
-            "STDOUT:\n{}\n\nSTDERR:\n{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-        fs::write(&output_file, &combined_output)?;
-
-        print!("{}", String::from_utf8_lossy(&output.stdout));
-        eprint!("{}", String::from_utf8_lossy(&output.stderr));
-
-        println!();
-        println!("=== OCI Conformance Tests (Project Key) Complete ===");
-        println!("Results saved to: {}", project_key_output_dir.display());
-
-        if output.status.success() {
-            Ok(())
-        } else {
-            anyhow::bail!(
-                "OCI conformance tests (project key) failed with exit code: {:?}",
-                output.status.code()
-            )
-        }
+        result
     }
 
     fn check_api_connectivity(&self) -> anyhow::Result<()> {

--- a/tasks/test_api/src/task/plus/runner.rs
+++ b/tasks/test_api/src/task/plus/runner.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 use assert_cmd::cargo::CommandCargoExt as _;
-use bencher_json::{Jwt, Url};
+use bencher_json::{JsonProjectKeyCreated, Jwt, Url};
 use pretty_assertions::assert_eq;
 
 use crate::parser::TaskRunner;
@@ -10,6 +10,7 @@ use crate::task::test::seed_test::{
 };
 use crate::task::{is_dev, unwrap_admin_token, unwrap_url, unwrap_user_token};
 
+const KEY_ARG: &str = "--key";
 const DOCKER_IMAGE: &str = "ghcr.io/bencherdev/bencher:latest";
 const IMAGE_TAG: &str = "runner-test";
 
@@ -66,7 +67,8 @@ impl RunnerTest {
             } else {
                 "no-sandbox-spec"
             };
-            run_runner_test(&self.url, &self.username, &self.token, spec)
+            run_runner_test(&self.url, &self.username, &self.token, spec)?;
+            run_project_key_runner_test(&self.url, &self.admin_token, spec)
         }
     }
 
@@ -250,6 +252,13 @@ impl RunnerTest {
             Ok(())
         };
 
+        // Run a test using a project key for authentication
+        let project_key_result = if detach_result.is_ok() {
+            run_project_key_runner_test(&self.url, &self.admin_token, spec)
+        } else {
+            Ok(())
+        };
+
         // Always kill runner daemons, even if the test failed
         if let Some((mut runner_child, reader_handle)) = runner_child_and_handle {
             let _kill = runner_child.kill();
@@ -264,6 +273,7 @@ impl RunnerTest {
         result?;
         no_sandbox_result?;
         detach_result?;
+        project_key_result?;
         println!("=== Runner Daemon Test Passed ===");
         Ok(())
     }
@@ -539,6 +549,112 @@ fn run_detach_runner_test(url: &Url, token: &Jwt) -> anyhow::Result<()> {
     }
 
     println!("Detach runner smoke test passed!");
+    Ok(())
+}
+
+/// Run the runner smoke test with project key authentication.
+///
+/// Creates a project key, logs into Docker with the project slug as username
+/// and the key as password, pushes the image, and submits a job via `bencher run --key`.
+fn run_project_key_runner_test(url: &Url, admin_token: &Jwt, spec: &str) -> anyhow::Result<()> {
+    let host = url.as_ref();
+
+    println!("Running project key runner smoke test against: {host}");
+
+    // Step 1: Create a project key
+    println!("Step 1: Creating project key...");
+    let mut cmd = Command::cargo_bin(BENCHER_CMD)?;
+    cmd.args([
+        "project",
+        "key",
+        "create",
+        HOST_ARG,
+        host,
+        TOKEN_ARG,
+        admin_token.as_ref(),
+        "--name",
+        "runner-test-key",
+        PROJECT_SLUG,
+    ])
+    .current_dir(CLI_DIR);
+    let output = cmd.output()?;
+    anyhow::ensure!(
+        output.status.success(),
+        "Failed to create project key:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let project_key_created: JsonProjectKeyCreated = serde_json::from_slice(&output.stdout)?;
+    let project_key = project_key_created.key;
+
+    // Step 2: Docker login with project slug as username and project key as password
+    let registry = if cfg!(target_os = "macos") {
+        let port = registry_host(host)?
+            .rsplit_once(':')
+            .and_then(|(_, p)| p.parse::<u16>().ok())
+            .unwrap_or(bencher_json::BENCHER_API_PORT);
+        format!("host.docker.internal:{port}")
+    } else {
+        registry_for_api(host)?
+    };
+    println!("Step 2: Docker login with project key to {registry}...");
+    docker_login(&registry, PROJECT_SLUG, project_key.as_ref())?;
+
+    // Step 3: Push the image (already tagged from the previous test)
+    let local_ref = format!("{registry}/{PROJECT_SLUG}:{IMAGE_TAG}");
+    println!("Step 3: Pushing image with project key auth...");
+    docker_push(&local_ref)?;
+
+    // Step 4: Submit a job via `bencher run --key`
+    println!("Step 4: Submitting job via bencher run --key...");
+    let mut cmd = Command::cargo_bin(BENCHER_CMD)?;
+    let image_ref = format!("{PROJECT_SLUG}:{IMAGE_TAG}");
+    cmd.args([
+        "run",
+        HOST_ARG,
+        host,
+        KEY_ARG,
+        project_key.as_ref(),
+        "--project",
+        PROJECT_SLUG,
+        "--branch",
+        "master",
+        "--testbed",
+        "base",
+        "--image",
+        &image_ref,
+        "--spec",
+        spec,
+        "--format",
+        "json",
+        "--quiet",
+        "--job-timeout",
+        "120",
+        "--job-poll-interval",
+        "1",
+        "--exec",
+        "mock",
+    ])
+    .current_dir(CLI_DIR);
+    let output = cmd.output()?;
+    anyhow::ensure!(
+        output.status.success(),
+        "bencher run --key failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Step 5: Verify the results
+    println!("Step 5: Verifying results...");
+    let json: bencher_json::JsonReport = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(json.project.slug.to_string(), PROJECT_SLUG);
+    #[cfg(feature = "plus")]
+    assert!(
+        json.job.is_some(),
+        "Expected job UUID in project key report: {json:?}"
+    );
+
+    println!("Project key runner smoke test passed!");
     Ok(())
 }
 


### PR DESCRIPTION
This changeset adds accepting project keys (https://github.com/bencherdev/bencher/pull/823) to the OCI endpoints.
The `docker login` will now take a project slug or UUID and a `bencher_run` token for OCI authentication.