### PR TITLE
Add project keys to GET endpoints

### DIFF
--- a/lib/api_projects/src/alerts.rs
+++ b/lib/api_projects/src/alerts.rs
@@ -75,7 +75,8 @@ pub async fn proj_alerts_options(
 ///
 /// List all alerts for a project.
 /// If the project is public, then the user does not need to be authenticated.
-/// If the project is private, then the user must be authenticated and have `view` permissions for the project.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
 /// By default, the alerts are sorted by status (active then dismissed) and modification date time in reverse chronological order.
 /// The HTTP response header `X-Total-Count` contains the total number of alerts.
 #[endpoint {
@@ -314,7 +315,8 @@ pub async fn proj_alert_options(
 ///
 /// View an alert for a project.
 /// If the project is public, then the user does not need to be authenticated.
-/// If the project is private, then the user must be authenticated and have `view` permissions for the project.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
 #[endpoint {
     method = GET,
     path =  "/v0/projects/{project}/alerts/{alert}",

--- a/lib/api_projects/src/alerts.rs
+++ b/lib/api_projects/src/alerts.rs
@@ -5,7 +5,7 @@ use bencher_json::{
 };
 use bencher_rbac::project::Permission;
 use bencher_schema::{
-    auth_conn,
+    actor_conn, auth_conn,
     context::ApiContext,
     error::{resource_conflict_err, resource_not_found_err},
     model::{
@@ -14,11 +14,11 @@ use bencher_schema::{
             threshold::alert::{QueryAlert, UpdateAlert},
         },
         user::{
+            actor::{ApiActor, PubProjectBearerToken},
             auth::{AuthUser, BearerToken},
-            public::{PubBearerToken, PublicUser},
         },
     },
-    public_conn, schema, write_conn,
+    schema, write_conn,
 };
 use diesel::{
     BoolExpressionMethods as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _,
@@ -89,10 +89,10 @@ pub async fn proj_alerts_get(
     pagination_params: Query<ProjAlertsPagination>,
     query_params: Query<ProjAlertsQuery>,
 ) -> Result<ResponseOk<JsonAlerts>, HttpError> {
-    let public_user = PublicUser::new(&rqctx).await?;
+    let api_actor = ApiActor::new(&rqctx).await?;
     let (json, total_count) = get_ls_inner(
         rqctx.context(),
-        &public_user,
+        &api_actor,
         path_params.into_inner(),
         pagination_params.into_inner(),
         query_params.into_inner(),
@@ -100,29 +100,29 @@ pub async fn proj_alerts_get(
     .await?;
     Ok(Get::response_ok_with_total_count(
         json,
-        public_user.is_auth(),
+        api_actor.is_auth(),
         total_count,
     ))
 }
 
 async fn get_ls_inner(
     context: &ApiContext,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
     path_params: ProjAlertsParams,
     pagination_params: ProjAlertsPagination,
     query_params: ProjAlertsQuery,
 ) -> Result<(JsonAlerts, TotalCount), HttpError> {
-    let query_project = QueryProject::is_allowed_public(
-        public_conn!(context, public_user),
+    let query_project = QueryProject::is_allowed_actor(
+        actor_conn!(context, api_actor),
         &context.rbac,
         &path_params.project,
-        public_user,
+        api_actor,
     )?;
 
     let alerts = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
         .limit(pagination_params.limit())
-        .load(public_conn!(context, public_user))
+        .load(actor_conn!(context, api_actor))
         .map_err(resource_not_found_err!(
             Alert,
             (&query_project, &pagination_params, &query_params)
@@ -131,7 +131,7 @@ async fn get_ls_inner(
     // Drop connection lock before iterating
     let json_alerts = alerts
         .into_iter()
-        .map(|alert| async { alert.into_json(public_conn!(context, public_user)) })
+        .map(|alert| async { alert.into_json(actor_conn!(context, api_actor)) })
         .collect::<FuturesOrdered<_>>()
         .collect::<Vec<_>>()
         .await
@@ -149,7 +149,7 @@ async fn get_ls_inner(
 
     let total_count = get_ls_query(&query_project, &pagination_params, &query_params)
         .count()
-        .get_result::<i64>(public_conn!(context, public_user))
+        .get_result::<i64>(actor_conn!(context, api_actor))
         .map_err(resource_not_found_err!(
             Alert,
             (&query_project, &pagination_params, &query_params)
@@ -322,10 +322,10 @@ pub async fn proj_alert_options(
 }]
 pub async fn proj_alert_get(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: PubBearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjAlertParams>,
 ) -> Result<ResponseOk<JsonAlert>, HttpError> {
-    let public_user = PublicUser::from_token(
+    let api_actor = ApiActor::from_token(
         &rqctx.log,
         rqctx.context(),
         #[cfg(feature = "plus")]
@@ -333,23 +333,23 @@ pub async fn proj_alert_get(
         bearer_token,
     )
     .await?;
-    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &public_user).await?;
-    Ok(Get::response_ok(json, public_user.is_auth()))
+    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &api_actor).await?;
+    Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 
 async fn get_one_inner(
     context: &ApiContext,
     path_params: ProjAlertParams,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
 ) -> Result<JsonAlert, HttpError> {
-    let query_project = QueryProject::is_allowed_public(
-        public_conn!(context, public_user),
+    let query_project = QueryProject::is_allowed_actor(
+        actor_conn!(context, api_actor),
         &context.rbac,
         &path_params.project,
-        public_user,
+        api_actor,
     )?;
 
-    public_conn!(context, public_user, |conn| {
+    actor_conn!(context, api_actor, |conn| {
         QueryAlert::from_uuid(conn, query_project.id, path_params.alert)?.into_json(conn)
     })
 }

--- a/lib/api_projects/src/benchmarks.rs
+++ b/lib/api_projects/src/benchmarks.rs
@@ -77,7 +77,8 @@ pub async fn proj_benchmarks_options(
 ///
 /// List all benchmarks for a project.
 /// If the project is public, then the user does not need to be authenticated.
-/// If the project is private, then the user must be authenticated and have `view` permissions for the project.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
 /// By default, the benchmarks are sorted in alphabetical order by name.
 /// The HTTP response header `X-Total-Count` contains the total number of benchmarks.
 #[endpoint {
@@ -251,7 +252,8 @@ pub async fn proj_benchmark_options(
 ///
 /// View a benchmark for a project.
 /// If the project is public, then the user does not need to be authenticated.
-/// If the project is private, then the user must be authenticated and have `view` permissions for the project.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
 #[endpoint {
     method = GET,
     path =  "/v0/projects/{project}/benchmarks/{benchmark}",
@@ -279,21 +281,19 @@ async fn get_one_inner(
     path_params: ProjBenchmarkParams,
     api_actor: &ApiActor,
 ) -> Result<JsonBenchmark, HttpError> {
-    let query_project = QueryProject::is_allowed_actor(
-        actor_conn!(context, api_actor),
-        &context.rbac,
-        &path_params.project,
-        api_actor,
-    )?;
+    actor_conn!(context, api_actor, |conn| {
+        let query_project =
+            QueryProject::is_allowed_actor(conn, &context.rbac, &path_params.project, api_actor)?;
 
-    QueryBenchmark::belonging_to(&query_project)
-        .filter(QueryBenchmark::eq_resource_id(&path_params.benchmark))
-        .first::<QueryBenchmark>(actor_conn!(context, api_actor))
-        .map(|benchmark| benchmark.into_json_for_project(&query_project))
-        .map_err(resource_not_found_err!(
-            Benchmark,
-            (&query_project, path_params.benchmark)
-        ))
+        QueryBenchmark::belonging_to(&query_project)
+            .filter(QueryBenchmark::eq_resource_id(&path_params.benchmark))
+            .first::<QueryBenchmark>(conn)
+            .map(|benchmark| benchmark.into_json_for_project(&query_project))
+            .map_err(resource_not_found_err!(
+                Benchmark,
+                (&query_project, path_params.benchmark)
+            ))
+    })
 }
 
 /// Update a benchmark

--- a/lib/api_projects/src/benchmarks.rs
+++ b/lib/api_projects/src/benchmarks.rs
@@ -9,7 +9,7 @@ use bencher_json::{
 };
 use bencher_rbac::project::Permission;
 use bencher_schema::{
-    auth_conn,
+    actor_conn, auth_conn,
     context::ApiContext,
     error::{resource_conflict_err, resource_not_found_err},
     model::{
@@ -18,11 +18,11 @@ use bencher_schema::{
             benchmark::{QueryBenchmark, UpdateBenchmark},
         },
         user::{
+            actor::{ApiActor, PubProjectBearerToken},
             auth::{AuthUser, BearerToken},
-            public::{PubBearerToken, PublicUser},
         },
     },
-    public_conn, schema, write_conn,
+    schema, write_conn,
 };
 use diesel::{
     BelongingToDsl as _, BoolExpressionMethods as _, ExpressionMethods as _, QueryDsl as _,
@@ -91,10 +91,10 @@ pub async fn proj_benchmarks_get(
     pagination_params: Query<ProjBenchmarksPagination>,
     query_params: Query<ProjBenchmarksQuery>,
 ) -> Result<ResponseOk<JsonBenchmarks>, HttpError> {
-    let public_user = PublicUser::new(&rqctx).await?;
+    let api_actor = ApiActor::new(&rqctx).await?;
     let (json, total_count) = get_ls_inner(
         rqctx.context(),
-        &public_user,
+        &api_actor,
         path_params.into_inner(),
         pagination_params.into_inner(),
         query_params.into_inner(),
@@ -102,29 +102,29 @@ pub async fn proj_benchmarks_get(
     .await?;
     Ok(Get::response_ok_with_total_count(
         json,
-        public_user.is_auth(),
+        api_actor.is_auth(),
         total_count,
     ))
 }
 
 async fn get_ls_inner(
     context: &ApiContext,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
     path_params: ProjBenchmarksParams,
     pagination_params: ProjBenchmarksPagination,
     query_params: ProjBenchmarksQuery,
 ) -> Result<(JsonBenchmarks, TotalCount), HttpError> {
-    let query_project = QueryProject::is_allowed_public(
-        public_conn!(context, public_user),
+    let query_project = QueryProject::is_allowed_actor(
+        actor_conn!(context, api_actor),
         &context.rbac,
         &path_params.project,
-        public_user,
+        api_actor,
     )?;
 
     let benchmarks = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
         .limit(pagination_params.limit())
-        .load::<QueryBenchmark>(public_conn!(context, public_user))
+        .load::<QueryBenchmark>(actor_conn!(context, api_actor))
         .map_err(resource_not_found_err!(
             Benchmark,
             (&query_project, &pagination_params, &query_params)
@@ -138,7 +138,7 @@ async fn get_ls_inner(
 
     let total_count = get_ls_query(&query_project, &pagination_params, &query_params)
         .count()
-        .get_result::<i64>(public_conn!(context, public_user))
+        .get_result::<i64>(actor_conn!(context, api_actor))
         .map_err(resource_not_found_err!(
             Plot,
             (&query_project, &pagination_params, &query_params)
@@ -259,10 +259,10 @@ pub async fn proj_benchmark_options(
 }]
 pub async fn proj_benchmark_get(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: PubBearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjBenchmarkParams>,
 ) -> Result<ResponseOk<JsonBenchmark>, HttpError> {
-    let public_user = PublicUser::from_token(
+    let api_actor = ApiActor::from_token(
         &rqctx.log,
         rqctx.context(),
         #[cfg(feature = "plus")]
@@ -270,25 +270,25 @@ pub async fn proj_benchmark_get(
         bearer_token,
     )
     .await?;
-    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &public_user).await?;
-    Ok(Get::response_ok(json, public_user.is_auth()))
+    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &api_actor).await?;
+    Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 
 async fn get_one_inner(
     context: &ApiContext,
     path_params: ProjBenchmarkParams,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
 ) -> Result<JsonBenchmark, HttpError> {
-    let query_project = QueryProject::is_allowed_public(
-        public_conn!(context, public_user),
+    let query_project = QueryProject::is_allowed_actor(
+        actor_conn!(context, api_actor),
         &context.rbac,
         &path_params.project,
-        public_user,
+        api_actor,
     )?;
 
     QueryBenchmark::belonging_to(&query_project)
         .filter(QueryBenchmark::eq_resource_id(&path_params.benchmark))
-        .first::<QueryBenchmark>(public_conn!(context, public_user))
+        .first::<QueryBenchmark>(actor_conn!(context, api_actor))
         .map(|benchmark| benchmark.into_json_for_project(&query_project))
         .map_err(resource_not_found_err!(
             Benchmark,

--- a/lib/api_projects/src/branches.rs
+++ b/lib/api_projects/src/branches.rs
@@ -80,7 +80,8 @@ pub async fn proj_branches_options(
 ///
 /// List all branches for a project.
 /// If the project is public, then the user does not need to be authenticated.
-/// If the project is private, then the user must be authenticated and have `view` permissions for the project.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
 /// By default, the branches are sorted in alphabetical order by name.
 /// The HTTP response header `X-Total-Count` contains the total number of branches.
 #[endpoint {
@@ -281,7 +282,8 @@ pub async fn proj_branch_options(
 ///
 /// View a branch for a project.
 /// If the project is public, then the user does not need to be authenticated.
-/// If the project is private, then the user must be authenticated and have `view` permissions for the project.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
 #[endpoint {
     method = GET,
     path =  "/v0/projects/{project}/branches/{branch}",

--- a/lib/api_projects/src/branches.rs
+++ b/lib/api_projects/src/branches.rs
@@ -8,7 +8,7 @@ use bencher_json::{
 };
 use bencher_rbac::project::Permission;
 use bencher_schema::{
-    auth_conn,
+    actor_conn, auth_conn,
     context::ApiContext,
     error::{
         BencherResource, resource_conflict_err, resource_not_found_err, resource_not_found_error,
@@ -19,11 +19,11 @@ use bencher_schema::{
             branch::{QueryBranch, UpdateBranch, head::QueryHead},
         },
         user::{
+            actor::{ApiActor, PubProjectBearerToken},
             auth::{AuthUser, BearerToken},
-            public::{PubBearerToken, PublicUser},
         },
     },
-    public_conn, schema, write_conn,
+    schema, write_conn,
 };
 use diesel::{
     BelongingToDsl as _, BoolExpressionMethods as _, ExpressionMethods as _, QueryDsl as _,
@@ -94,10 +94,10 @@ pub async fn proj_branches_get(
     pagination_params: Query<ProjBranchesPagination>,
     query_params: Query<ProjBranchesQuery>,
 ) -> Result<ResponseOk<JsonBranches>, HttpError> {
-    let public_user = PublicUser::new(&rqctx).await?;
+    let api_actor = ApiActor::new(&rqctx).await?;
     let (json, total_count) = get_ls_inner(
         rqctx.context(),
-        &public_user,
+        &api_actor,
         path_params.into_inner(),
         pagination_params.into_inner(),
         query_params.into_inner(),
@@ -105,29 +105,29 @@ pub async fn proj_branches_get(
     .await?;
     Ok(Get::response_ok_with_total_count(
         json,
-        public_user.is_auth(),
+        api_actor.is_auth(),
         total_count,
     ))
 }
 
 async fn get_ls_inner(
     context: &ApiContext,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
     path_params: ProjBranchesParams,
     pagination_params: ProjBranchesPagination,
     query_params: ProjBranchesQuery,
 ) -> Result<(JsonBranches, TotalCount), HttpError> {
-    let query_project = QueryProject::is_allowed_public(
-        public_conn!(context, public_user),
+    let query_project = QueryProject::is_allowed_actor(
+        actor_conn!(context, api_actor),
         &context.rbac,
         &path_params.project,
-        public_user,
+        api_actor,
     )?;
 
     let branches = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
         .limit(pagination_params.limit())
-        .load::<QueryBranch>(public_conn!(context, public_user))
+        .load::<QueryBranch>(actor_conn!(context, api_actor))
         .map_err(resource_not_found_err!(
             Branch,
             (&query_project, &pagination_params, &query_params)
@@ -137,7 +137,7 @@ async fn get_ls_inner(
     let json_branches = branches
         .into_iter()
         .map(|branch| async {
-            branch.into_json_for_project(public_conn!(context, public_user), &query_project)
+            branch.into_json_for_project(actor_conn!(context, api_actor), &query_project)
         })
         .collect::<FuturesOrdered<_>>()
         .collect::<Vec<_>>()
@@ -156,7 +156,7 @@ async fn get_ls_inner(
 
     let total_count = get_ls_query(&query_project, &pagination_params, &query_params)
         .count()
-        .get_result::<i64>(public_conn!(context, public_user))
+        .get_result::<i64>(actor_conn!(context, api_actor))
         .map_err(resource_not_found_err!(
             Branch,
             (&query_project, &pagination_params, &query_params)
@@ -289,11 +289,11 @@ pub async fn proj_branch_options(
 }]
 pub async fn proj_branch_get(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: PubBearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjBranchParams>,
     query_params: Query<ProjBranchQuery>,
 ) -> Result<ResponseOk<JsonBranch>, HttpError> {
-    let public_user = PublicUser::from_token(
+    let api_actor = ApiActor::from_token(
         &rqctx.log,
         rqctx.context(),
         #[cfg(feature = "plus")]
@@ -305,58 +305,47 @@ pub async fn proj_branch_get(
         rqctx.context(),
         path_params.into_inner(),
         query_params.into_inner(),
-        &public_user,
+        &api_actor,
     )
     .await?;
-    Ok(Get::response_ok(json, public_user.is_auth()))
+    Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 
 async fn get_one_inner(
     context: &ApiContext,
     path_params: ProjBranchParams,
     query_params: ProjBranchQuery,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
 ) -> Result<JsonBranch, HttpError> {
-    let query_project = QueryProject::is_allowed_public(
-        public_conn!(context, public_user),
-        &context.rbac,
-        &path_params.project,
-        public_user,
-    )?;
+    actor_conn!(context, api_actor, |conn| {
+        let query_project =
+            QueryProject::is_allowed_actor(conn, &context.rbac, &path_params.project, api_actor)?;
 
-    let query_branch = QueryBranch::belonging_to(&query_project)
-        .filter(QueryBranch::eq_resource_id(&path_params.branch))
-        .first::<QueryBranch>(public_conn!(context, public_user))
-        .map_err(resource_not_found_err!(
-            Branch,
-            (&query_project, &path_params.branch)
-        ))?;
+        let query_branch = QueryBranch::belonging_to(&query_project)
+            .filter(QueryBranch::eq_resource_id(&path_params.branch))
+            .first::<QueryBranch>(conn)
+            .map_err(resource_not_found_err!(
+                Branch,
+                (&query_project, &path_params.branch)
+            ))?;
 
-    if let Some(head_uuid) = query_params.head {
-        let query_head = QueryHead::from_uuid(
-            public_conn!(context, public_user),
-            query_project.id,
-            head_uuid,
-        )?;
-        if query_head.branch_id != query_branch.id {
-            return Err(resource_not_found_error(
-                BencherResource::Head,
-                head_uuid,
-                format!(
-                    "Specified head {head_uuid} does not belong to branch {branch_uuid}",
-                    branch_uuid = query_branch.uuid
-                ),
-            ));
+        if let Some(head_uuid) = query_params.head {
+            let query_head = QueryHead::from_uuid(conn, query_project.id, head_uuid)?;
+            if query_head.branch_id != query_branch.id {
+                return Err(resource_not_found_error(
+                    BencherResource::Head,
+                    head_uuid,
+                    format!(
+                        "Specified head {head_uuid} does not belong to branch {branch_uuid}",
+                        branch_uuid = query_branch.uuid
+                    ),
+                ));
+            }
+            query_branch.into_json_for_head(conn, &query_project, &query_head, None)
+        } else {
+            query_branch.into_json_for_project(conn, &query_project)
         }
-        query_branch.into_json_for_head(
-            public_conn!(context, public_user),
-            &query_project,
-            &query_head,
-            None,
-        )
-    } else {
-        query_branch.into_json_for_project(public_conn!(context, public_user), &query_project)
-    }
+    })
 }
 
 /// Update a branch

--- a/lib/api_projects/src/jobs.rs
+++ b/lib/api_projects/src/jobs.rs
@@ -57,7 +57,8 @@ pub async fn proj_jobs_options(
 /// ➕ Bencher Plus: List all jobs for a project.
 /// The job output is not included in the list response.
 /// If the project is public, then the user does not need to be authenticated.
-/// If the project is private, then the user must be authenticated and have `view` permissions for the project.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
 /// By default, the jobs are sorted by creation date time in reverse chronological order.
 /// The HTTP response header `X-Total-Count` contains the total number of jobs.
 #[endpoint {
@@ -189,7 +190,8 @@ pub async fn proj_job_options(
 ///
 /// ➕ Bencher Plus: View a job for a project.
 /// If the project is public, then the user does not need to be authenticated.
-/// If the project is private, then the user must be authenticated and have `view` permissions for the project.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
 /// The job output is only included in the response for terminal (completed, failed, or canceled) jobs
 /// when the user is authenticated and has `view` permissions for the project.
 #[endpoint {

--- a/lib/api_projects/src/jobs.rs
+++ b/lib/api_projects/src/jobs.rs
@@ -5,10 +5,11 @@ use bencher_json::{
     JobStatus, JobUuid, JsonDirection, JsonJob, JsonPagination, ProjectResourceId, runner::JsonJobs,
 };
 use bencher_schema::{
+    actor_conn,
     context::ApiContext,
     error::resource_not_found_err,
-    model::{project::QueryProject, runner::QueryJob, user::public::PublicUser},
-    public_conn, schema,
+    model::{project::QueryProject, runner::QueryJob, user::actor::ApiActor},
+    schema,
 };
 use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _, SelectableHelper as _};
 use dropshot::{HttpError, Path, Query, RequestContext, endpoint};
@@ -70,18 +71,18 @@ pub async fn proj_jobs_get(
     pagination_params: Query<ProjJobsPagination>,
     query_params: Query<ProjJobsQuery>,
 ) -> Result<ResponseOk<JsonJobs>, HttpError> {
-    let public_user = PublicUser::new(&rqctx).await?;
+    let api_actor = ApiActor::new(&rqctx).await?;
     let (json, total_count) = get_ls_inner(
         rqctx.context(),
         path_params.into_inner(),
         pagination_params.into_inner(),
         query_params.into_inner(),
-        &public_user,
+        &api_actor,
     )
     .await?;
     Ok(Get::response_ok_with_total_count(
         json,
-        public_user.is_auth(),
+        api_actor.is_auth(),
         total_count,
     ))
 }
@@ -95,25 +96,25 @@ async fn get_ls_inner(
     path_params: ProjJobsParams,
     pagination_params: ProjJobsPagination,
     query_params: ProjJobsQuery,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
 ) -> Result<(JsonJobs, TotalCount), HttpError> {
-    let query_project = QueryProject::is_allowed_public(
-        public_conn!(context, public_user),
+    let query_project = QueryProject::is_allowed_actor(
+        actor_conn!(context, api_actor),
         &context.rbac,
         &path_params.project,
-        public_user,
+        api_actor,
     )?;
 
     let jobs = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
         .limit(pagination_params.limit())
-        .load::<QueryJob>(public_conn!(context, public_user))
+        .load::<QueryJob>(actor_conn!(context, api_actor))
         .map_err(resource_not_found_err!(
             Job,
             (&query_project, &pagination_params, &query_params)
         ))?;
 
-    let json_jobs = public_conn!(context, public_user, |conn| {
+    let json_jobs = actor_conn!(context, api_actor, |conn| {
         jobs.into_iter()
             .map(|job| job.into_json(conn))
             .collect::<Result<Vec<_>, _>>()?
@@ -121,7 +122,7 @@ async fn get_ls_inner(
 
     let total_count = get_ls_query(&query_project, &pagination_params, &query_params)
         .count()
-        .get_result::<i64>(public_conn!(context, public_user))
+        .get_result::<i64>(actor_conn!(context, api_actor))
         .map_err(resource_not_found_err!(
             Job,
             (&query_project, &pagination_params, &query_params)
@@ -200,28 +201,28 @@ pub async fn proj_job_get(
     rqctx: RequestContext<ApiContext>,
     path_params: Path<ProjJobParams>,
 ) -> Result<ResponseOk<JsonJob>, HttpError> {
-    let public_user = PublicUser::new(&rqctx).await?;
+    let api_actor = ApiActor::new(&rqctx).await?;
     let json = get_one_inner(
         rqctx.context(),
         path_params.into_inner(),
-        &public_user,
+        &api_actor,
         &rqctx.log,
     )
     .await?;
-    Ok(Get::response_ok(json, public_user.is_auth()))
+    Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 
 async fn get_one_inner(
     context: &ApiContext,
     path_params: ProjJobParams,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
     log: &slog::Logger,
 ) -> Result<JsonJob, HttpError> {
-    let query_project = QueryProject::is_allowed_public(
-        public_conn!(context, public_user),
+    let query_project = QueryProject::is_allowed_actor(
+        actor_conn!(context, api_actor),
         &context.rbac,
         &path_params.project,
-        public_user,
+        api_actor,
     )?;
 
     let job_uuid = path_params.job;
@@ -231,14 +232,14 @@ async fn get_one_inner(
         .filter(schema::report::project_id.eq(query_project.id))
         .filter(schema::job::uuid.eq(job_uuid))
         .select(QueryJob::as_select())
-        .first(public_conn!(context, public_user))
+        .first(actor_conn!(context, api_actor))
         .map_err(resource_not_found_err!(Job, (&query_project, job_uuid)))?;
 
     let has_run = query_job.status.has_run();
-    let mut job = query_job.into_json(public_conn!(context, public_user))?;
+    let mut job = query_job.into_json(actor_conn!(context, api_actor))?;
 
     // Fetch output from blob storage for terminal jobs only when authenticated
-    if has_run && public_user.is_auth() {
+    if has_run && api_actor.is_auth() {
         job.output = match context
             .oci_storage()
             .job_output()

--- a/lib/api_projects/src/measures.rs
+++ b/lib/api_projects/src/measures.rs
@@ -8,7 +8,7 @@ use bencher_json::{
 };
 use bencher_rbac::project::Permission;
 use bencher_schema::{
-    auth_conn,
+    actor_conn, auth_conn,
     context::ApiContext,
     error::{resource_conflict_err, resource_not_found_err},
     model::{
@@ -17,11 +17,11 @@ use bencher_schema::{
             measure::{QueryMeasure, UpdateMeasure},
         },
         user::{
+            actor::{ApiActor, PubProjectBearerToken},
             auth::{AuthUser, BearerToken},
-            public::{PubBearerToken, PublicUser},
         },
     },
-    public_conn, schema, write_conn,
+    schema, write_conn,
 };
 use diesel::{
     BelongingToDsl as _, BoolExpressionMethods as _, ExpressionMethods as _, QueryDsl as _,
@@ -90,10 +90,10 @@ pub async fn proj_measures_get(
     pagination_params: Query<ProjMeasuresPagination>,
     query_params: Query<ProjMeasuresQuery>,
 ) -> Result<ResponseOk<JsonMeasures>, HttpError> {
-    let public_user = PublicUser::new(&rqctx).await?;
+    let api_actor = ApiActor::new(&rqctx).await?;
     let (json, total_count) = get_ls_inner(
         rqctx.context(),
-        &public_user,
+        &api_actor,
         path_params.into_inner(),
         pagination_params.into_inner(),
         query_params.into_inner(),
@@ -101,29 +101,29 @@ pub async fn proj_measures_get(
     .await?;
     Ok(Get::response_ok_with_total_count(
         json,
-        public_user.is_auth(),
+        api_actor.is_auth(),
         total_count,
     ))
 }
 
 async fn get_ls_inner(
     context: &ApiContext,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
     path_params: ProjMeasuresParams,
     pagination_params: ProjMeasuresPagination,
     query_params: ProjMeasuresQuery,
 ) -> Result<(JsonMeasures, TotalCount), HttpError> {
-    let query_project = QueryProject::is_allowed_public(
-        public_conn!(context, public_user),
+    let query_project = QueryProject::is_allowed_actor(
+        actor_conn!(context, api_actor),
         &context.rbac,
         &path_params.project,
-        public_user,
+        api_actor,
     )?;
 
     let measures = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
         .limit(pagination_params.limit())
-        .load::<QueryMeasure>(public_conn!(context, public_user))
+        .load::<QueryMeasure>(actor_conn!(context, api_actor))
         .map_err(resource_not_found_err!(
             Measure,
             (&query_project, &pagination_params, &query_params)
@@ -137,7 +137,7 @@ async fn get_ls_inner(
 
     let total_count = get_ls_query(&query_project, &pagination_params, &query_params)
         .count()
-        .get_result::<i64>(public_conn!(context, public_user))
+        .get_result::<i64>(actor_conn!(context, api_actor))
         .map_err(resource_not_found_err!(
             Measure,
             (&query_project, &pagination_params, &query_params)
@@ -258,10 +258,10 @@ pub async fn proj_measure_options(
 }]
 pub async fn proj_measure_get(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: PubBearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjMeasureParams>,
 ) -> Result<ResponseOk<JsonMeasure>, HttpError> {
-    let public_user = PublicUser::from_token(
+    let api_actor = ApiActor::from_token(
         &rqctx.log,
         rqctx.context(),
         #[cfg(feature = "plus")]
@@ -269,25 +269,25 @@ pub async fn proj_measure_get(
         bearer_token,
     )
     .await?;
-    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &public_user).await?;
-    Ok(Get::response_ok(json, public_user.is_auth()))
+    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &api_actor).await?;
+    Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 
 async fn get_one_inner(
     context: &ApiContext,
     path_params: ProjMeasureParams,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
 ) -> Result<JsonMeasure, HttpError> {
-    let query_project = QueryProject::is_allowed_public(
-        public_conn!(context, public_user),
+    let query_project = QueryProject::is_allowed_actor(
+        actor_conn!(context, api_actor),
         &context.rbac,
         &path_params.project,
-        public_user,
+        api_actor,
     )?;
 
     QueryMeasure::belonging_to(&query_project)
         .filter(QueryMeasure::eq_resource_id(&path_params.measure))
-        .first::<QueryMeasure>(public_conn!(context, public_user))
+        .first::<QueryMeasure>(actor_conn!(context, api_actor))
         .map(|measure| measure.into_json_for_project(&query_project))
         .map_err(resource_not_found_err!(
             Measure,

--- a/lib/api_projects/src/measures.rs
+++ b/lib/api_projects/src/measures.rs
@@ -76,7 +76,8 @@ pub async fn proj_measures_options(
 ///
 /// List all measures for a project.
 /// If the project is public, then the user does not need to be authenticated.
-/// If the project is private, then the user must be authenticated and have `view` permissions for the project.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
 /// By default, the measures are sorted in alphabetical order by name.
 /// The HTTP response header `X-Total-Count` contains the total number of measures.
 #[endpoint {
@@ -250,7 +251,8 @@ pub async fn proj_measure_options(
 ///
 /// View a measure for a project.
 /// If the project is public, then the user does not need to be authenticated.
-/// If the project is private, then the user must be authenticated and have `view` permissions for the project.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
 #[endpoint {
     method = GET,
     path =  "/v0/projects/{project}/measures/{measure}",
@@ -278,21 +280,19 @@ async fn get_one_inner(
     path_params: ProjMeasureParams,
     api_actor: &ApiActor,
 ) -> Result<JsonMeasure, HttpError> {
-    let query_project = QueryProject::is_allowed_actor(
-        actor_conn!(context, api_actor),
-        &context.rbac,
-        &path_params.project,
-        api_actor,
-    )?;
+    actor_conn!(context, api_actor, |conn| {
+        let query_project =
+            QueryProject::is_allowed_actor(conn, &context.rbac, &path_params.project, api_actor)?;
 
-    QueryMeasure::belonging_to(&query_project)
-        .filter(QueryMeasure::eq_resource_id(&path_params.measure))
-        .first::<QueryMeasure>(actor_conn!(context, api_actor))
-        .map(|measure| measure.into_json_for_project(&query_project))
-        .map_err(resource_not_found_err!(
-            Measure,
-            (&query_project, path_params.measure)
-        ))
+        QueryMeasure::belonging_to(&query_project)
+            .filter(QueryMeasure::eq_resource_id(&path_params.measure))
+            .first::<QueryMeasure>(conn)
+            .map(|measure| measure.into_json_for_project(&query_project))
+            .map_err(resource_not_found_err!(
+                Measure,
+                (&query_project, path_params.measure)
+            ))
+    })
 }
 
 /// Update a measure

--- a/lib/api_projects/src/metrics.rs
+++ b/lib/api_projects/src/metrics.rs
@@ -57,7 +57,8 @@ pub async fn proj_metric_options(
 ///
 /// View a metric for a project.
 /// If the project is public, then the user does not need to be authenticated.
-/// If the project is private, then the user must be authenticated and have `view` permissions for the project.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
 #[endpoint {
     method = GET,
     path =  "/v0/projects/{project}/metrics/{metric}",

--- a/lib/api_projects/src/metrics.rs
+++ b/lib/api_projects/src/metrics.rs
@@ -4,6 +4,7 @@ use bencher_json::{
 };
 use bencher_schema::model::spec::SpecId;
 use bencher_schema::{
+    actor_conn,
     context::{ApiContext, DbConnection},
     error::resource_not_found_err,
     model::{
@@ -18,9 +19,9 @@ use bencher_schema::{
                 QueryThreshold, alert::QueryAlert, boundary::QueryBoundary, model::QueryModel,
             },
         },
-        user::public::{PubBearerToken, PublicUser},
+        user::actor::{ApiActor, PubProjectBearerToken},
     },
-    public_conn, schema, view,
+    schema, view,
 };
 use diesel::{
     ExpressionMethods as _, JoinOnDsl as _, NullableExpressionMethods as _, QueryDsl as _,
@@ -64,10 +65,10 @@ pub async fn proj_metric_options(
 }]
 pub async fn proj_metric_get(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: PubBearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjMetricParams>,
 ) -> Result<ResponseOk<JsonOneMetric>, HttpError> {
-    let public_user = PublicUser::from_token(
+    let api_actor = ApiActor::from_token(
         &rqctx.log,
         rqctx.context(),
         #[cfg(feature = "plus")]
@@ -75,23 +76,23 @@ pub async fn proj_metric_get(
         bearer_token,
     )
     .await?;
-    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &public_user).await?;
-    Ok(Get::response_ok(json, public_user.is_auth()))
+    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &api_actor).await?;
+    Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 
 async fn get_one_inner(
     context: &ApiContext,
     path_params: ProjMetricParams,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
 ) -> Result<JsonOneMetric, HttpError> {
-    let query_project = QueryProject::is_allowed_public(
-        public_conn!(context, public_user),
+    let query_project = QueryProject::is_allowed_actor(
+        actor_conn!(context, api_actor),
         &context.rbac,
         &path_params.project,
-        public_user,
+        api_actor,
     )?;
 
-    public_conn!(context, public_user, |conn| {
+    actor_conn!(context, api_actor, |conn| {
         view::metric_boundary::table
         .inner_join(
             schema::report_benchmark::table.inner_join(

--- a/lib/api_projects/src/perf/img.rs
+++ b/lib/api_projects/src/perf/img.rs
@@ -7,7 +7,7 @@ use bencher_plot::LinePlot;
 use bencher_schema::{
     context::ApiContext,
     error::{bad_request_error, issue_error},
-    model::user::public::{PubBearerToken, PublicUser},
+    model::user::actor::{ApiActor, PubProjectBearerToken},
 };
 use dropshot::{Body, HttpError, Path, Query, RequestContext, endpoint};
 use http::Response;
@@ -42,7 +42,7 @@ pub async fn proj_perf_img_options(
 }]
 pub async fn proj_perf_img_get(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: PubBearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjPerfParams>,
     query_params: Query<JsonPerfImgQueryParams>,
 ) -> Result<Response<Body>, HttpError> {
@@ -54,7 +54,7 @@ pub async fn proj_perf_img_get(
         .try_into()
         .map_err(bad_request_error)?;
 
-    let public_user = PublicUser::from_token(
+    let api_actor = ApiActor::from_token(
         &rqctx.log,
         rqctx.context(),
         #[cfg(feature = "plus")]
@@ -68,7 +68,7 @@ pub async fn proj_perf_img_get(
         path_params.into_inner(),
         title.as_deref(),
         json_perf_query,
-        &public_user,
+        &api_actor,
     )
     .await?;
 
@@ -86,10 +86,9 @@ async fn get_inner(
     path_params: ProjPerfParams,
     title: Option<&str>,
     json_perf_query: JsonPerfQuery,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
 ) -> Result<Vec<u8>, HttpError> {
-    let json_perf =
-        super::get_inner(log, context, path_params, json_perf_query, public_user).await?;
+    let json_perf = super::get_inner(log, context, path_params, json_perf_query, api_actor).await?;
     LinePlot::new().draw(title, &json_perf).map_err(|e| {
         issue_error(
             "Failed to draw perf plot",

--- a/lib/api_projects/src/perf/img.rs
+++ b/lib/api_projects/src/perf/img.rs
@@ -34,7 +34,8 @@ pub async fn proj_perf_img_options(
 /// There is a limit of 8 permutations for a single image.
 /// Therefore, only the first 8 permutations are plotted.
 /// If the project is public, then the user does not need to be authenticated.
-/// If the project is private, then the user must be authenticated and have `view` permissions for the project.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
 #[endpoint {
     method = GET,
     path =  "/v0/projects/{project}/perf/img",

--- a/lib/api_projects/src/perf/mod.rs
+++ b/lib/api_projects/src/perf/mod.rs
@@ -73,7 +73,8 @@ pub async fn proj_perf_options(
 /// There is a limit of 255 permutations for a single request.
 /// Therefore, only the first 255 permutations are returned.
 /// If the project is public, then the user does not need to be authenticated.
-/// If the project is private, then the user must be authenticated and have `view` permissions for the project.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
 #[endpoint {
     method = GET,
     path =  "/v0/projects/{project}/perf",

--- a/lib/api_projects/src/perf/mod.rs
+++ b/lib/api_projects/src/perf/mod.rs
@@ -16,6 +16,7 @@ use bencher_json::{
 use bencher_schema::model::spec::QuerySpec;
 use bencher_schema::model::spec::SpecId;
 use bencher_schema::{
+    actor_conn,
     context::{ApiContext, DbConnection},
     error::{bad_request_error, resource_not_found_err},
     model::{
@@ -30,9 +31,9 @@ use bencher_schema::{
                 QueryThreshold, alert::QueryAlert, boundary::QueryBoundary, model::QueryModel,
             },
         },
-        user::public::{PubBearerToken, PublicUser},
+        user::actor::{ApiActor, PubProjectBearerToken},
     },
-    public_conn, schema, view,
+    schema, view,
 };
 use diesel::{
     ExpressionMethods as _, JoinOnDsl as _, NullableExpressionMethods as _, QueryDsl as _,
@@ -80,7 +81,7 @@ pub async fn proj_perf_options(
 }]
 pub async fn proj_perf_get(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: PubBearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjPerfParams>,
     query_params: Query<JsonPerfQueryParams>,
 ) -> Result<ResponseOk<JsonPerf>, HttpError> {
@@ -90,7 +91,7 @@ pub async fn proj_perf_get(
         .try_into()
         .map_err(bad_request_error)?;
 
-    let public_user = PublicUser::from_token(
+    let api_actor = ApiActor::from_token(
         &rqctx.log,
         rqctx.context(),
         #[cfg(feature = "plus")]
@@ -103,10 +104,10 @@ pub async fn proj_perf_get(
         rqctx.context(),
         path_params.into_inner(),
         json_perf_query,
-        &public_user,
+        &api_actor,
     )
     .await?;
-    Ok(Get::response_ok(json, public_user.is_auth()))
+    Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 
 async fn get_inner(
@@ -114,13 +115,13 @@ async fn get_inner(
     context: &ApiContext,
     path_params: ProjPerfParams,
     json_perf_query: JsonPerfQuery,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
 ) -> Result<JsonPerf, HttpError> {
-    let project = QueryProject::is_allowed_public(
-        public_conn!(context, public_user),
+    let project = QueryProject::is_allowed_actor(
+        actor_conn!(context, api_actor),
         &context.rbac,
         &path_params.project,
-        public_user,
+        api_actor,
     )?;
 
     let JsonPerfQuery {
@@ -143,7 +144,7 @@ async fn get_inner(
     let results = perf_results(
         log,
         context,
-        public_user,
+        api_actor,
         &project,
         &branches,
         &heads,
@@ -157,7 +158,7 @@ async fn get_inner(
     .await?;
 
     Ok(JsonPerf {
-        project: project.into_json(public_conn!(context, public_user))?,
+        project: project.into_json(actor_conn!(context, api_actor))?,
         start_time,
         end_time,
         results,
@@ -174,7 +175,7 @@ struct Times {
 async fn perf_results(
     log: &slog::Logger,
     context: &ApiContext,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
     project: &QueryProject,
     branches: &[BranchUuid],
     heads: &[Option<HeadUuid>],
@@ -196,7 +197,7 @@ async fn perf_results(
             let spec_id: Option<SpecId> = if let Some(spec_uuid) =
                 specs.get(testbed_index).copied().flatten()
             {
-                match QuerySpec::get_id(public_conn!(context, public_user), spec_uuid) {
+                match QuerySpec::get_id(actor_conn!(context, api_actor), spec_uuid) {
                     Ok(id) => Some(id),
                     Err(e) => {
                         slog::info!(log, "Skipping perf query for nonexistent spec UUID: {spec_uuid}"; "error" => %e);
@@ -223,7 +224,7 @@ async fn perf_results(
 
                     let pq = perf_query(
                         context,
-                        public_user,
+                        api_actor,
                         project,
                         *branch_uuid,
                         *head_uuid,
@@ -243,7 +244,7 @@ async fn perf_results(
                             perf_metrics.metrics.push(perf_metric);
                         } else {
                             perf_metrics = new_perf_metrics(
-                                public_conn!(context, public_user),
+                                actor_conn!(context, api_actor),
                                 project,
                                 query_dimensions,
                                 perf_metric,
@@ -265,7 +266,7 @@ async fn perf_results(
 #[expect(clippy::too_many_arguments, clippy::too_many_lines)]
 async fn perf_query(
     context: &ApiContext,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
     project: &QueryProject,
     branch_uuid: BranchUuid,
     head_uuid: Option<HeadUuid>,
@@ -404,7 +405,7 @@ async fn perf_query(
         // Acquire the lock on the database connection for every query.
         // This helps to avoid resource contention when the database is under heavy load.
         // This will make the perf query itself slower, but it will make the overall system more stable.
-        .load::<PerfQuery>(public_conn!(context, public_user))
+        .load::<PerfQuery>(actor_conn!(context, api_actor))
         .map_err(resource_not_found_err!(Metric, (project,  branch_uuid, testbed_uuid, benchmark_uuid, measure_uuid)))
 }
 

--- a/lib/api_projects/src/plots.rs
+++ b/lib/api_projects/src/plots.rs
@@ -76,7 +76,8 @@ pub async fn proj_plots_options(
 ///
 /// List all plots for a project.
 /// If the project is public, then the user does not need to be authenticated.
-/// If the project is private, then the user must be authenticated and have `view` permissions for the project.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
 /// By default, the plots are sorted in their index order.
 /// The HTTP response header `X-Total-Count` contains the total number of plots.
 #[endpoint {
@@ -266,7 +267,8 @@ pub async fn proj_plot_options(
 ///
 /// View a plot for a project.
 /// If the project is public, then the user does not need to be authenticated.
-/// If the project is private, then the user must be authenticated and have `view` permissions for the project.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
 #[endpoint {
     method = GET,
     path =  "/v0/projects/{project}/plots/{plot}",

--- a/lib/api_projects/src/plots.rs
+++ b/lib/api_projects/src/plots.rs
@@ -8,7 +8,7 @@ use bencher_json::{
 };
 use bencher_rbac::project::Permission;
 use bencher_schema::{
-    auth_conn,
+    actor_conn, auth_conn,
     context::ApiContext,
     error::{resource_conflict_err, resource_not_found_err},
     model::{
@@ -17,11 +17,11 @@ use bencher_schema::{
             plot::{InsertPlot, QueryPlot, UpdatePlot},
         },
         user::{
+            actor::{ApiActor, PubProjectBearerToken},
             auth::{AuthUser, BearerToken},
-            public::{PubBearerToken, PublicUser},
         },
     },
-    public_conn, schema, write_conn,
+    schema, write_conn,
 };
 use diesel::{
     BelongingToDsl as _, BoolExpressionMethods as _, ExpressionMethods as _,
@@ -90,10 +90,10 @@ pub async fn proj_plots_get(
     pagination_params: Query<ProjPlotsPagination>,
     query_params: Query<ProjPlotsQuery>,
 ) -> Result<ResponseOk<JsonPlots>, HttpError> {
-    let public_user = PublicUser::new(&rqctx).await?;
+    let api_actor = ApiActor::new(&rqctx).await?;
     let (json, total_count) = get_ls_inner(
         rqctx.context(),
-        &public_user,
+        &api_actor,
         path_params.into_inner(),
         pagination_params.into_inner(),
         query_params.into_inner(),
@@ -101,29 +101,29 @@ pub async fn proj_plots_get(
     .await?;
     Ok(Get::response_ok_with_total_count(
         json,
-        public_user.is_auth(),
+        api_actor.is_auth(),
         total_count,
     ))
 }
 
 async fn get_ls_inner(
     context: &ApiContext,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
     path_params: ProjPlotsParams,
     pagination_params: ProjPlotsPagination,
     query_params: ProjPlotsQuery,
 ) -> Result<(JsonPlots, TotalCount), HttpError> {
-    let query_project = QueryProject::is_allowed_public(
-        public_conn!(context, public_user),
+    let query_project = QueryProject::is_allowed_actor(
+        actor_conn!(context, api_actor),
         &context.rbac,
         &path_params.project,
-        public_user,
+        api_actor,
     )?;
 
     let plots = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
         .limit(pagination_params.limit())
-        .load::<QueryPlot>(public_conn!(context, public_user))
+        .load::<QueryPlot>(actor_conn!(context, api_actor))
         .map_err(resource_not_found_err!(
             Plot,
             (&query_project, &pagination_params, &query_params)
@@ -133,7 +133,7 @@ async fn get_ls_inner(
     let json_plots = plots
         .into_iter()
         .map(|plot| async {
-            plot.into_json_for_project(public_conn!(context, public_user), &query_project)
+            plot.into_json_for_project(actor_conn!(context, api_actor), &query_project)
         })
         .collect::<FuturesOrdered<_>>()
         .collect::<Vec<_>>()
@@ -152,7 +152,7 @@ async fn get_ls_inner(
 
     let total_count = get_ls_query(&query_project, &pagination_params, &query_params)
         .count()
-        .get_result::<i64>(public_conn!(context, public_user))
+        .get_result::<i64>(actor_conn!(context, api_actor))
         .map_err(resource_not_found_err!(
             Plot,
             (&query_project, &pagination_params, &query_params)
@@ -274,10 +274,10 @@ pub async fn proj_plot_options(
 }]
 pub async fn proj_plot_get(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: PubBearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjPlotParams>,
 ) -> Result<ResponseOk<JsonPlot>, HttpError> {
-    let public_user = PublicUser::from_token(
+    let api_actor = ApiActor::from_token(
         &rqctx.log,
         rqctx.context(),
         #[cfg(feature = "plus")]
@@ -285,23 +285,23 @@ pub async fn proj_plot_get(
         bearer_token,
     )
     .await?;
-    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &public_user).await?;
-    Ok(Get::response_ok(json, public_user.is_auth()))
+    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &api_actor).await?;
+    Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 
 async fn get_one_inner(
     context: &ApiContext,
     path_params: ProjPlotParams,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
 ) -> Result<JsonPlot, HttpError> {
-    let query_project = QueryProject::is_allowed_public(
-        public_conn!(context, public_user),
+    let query_project = QueryProject::is_allowed_actor(
+        actor_conn!(context, api_actor),
         &context.rbac,
         &path_params.project,
-        public_user,
+        api_actor,
     )?;
 
-    public_conn!(context, public_user, |conn| {
+    actor_conn!(context, api_actor, |conn| {
         QueryPlot::get_with_uuid(conn, &query_project, path_params.plot)
             .and_then(|plot| plot.into_json_for_project(conn, &query_project))
     })

--- a/lib/api_projects/src/projects.rs
+++ b/lib/api_projects/src/projects.rs
@@ -18,10 +18,10 @@ use bencher_schema::{
         user::{
             actor::{ApiActor, PubProjectBearerToken},
             auth::{AuthUser, BearerToken},
-            public::{PubBearerToken, PublicUser},
+            public::PublicUser,
         },
     },
-    public_conn, schema, write_conn,
+    schema, write_conn,
 };
 use diesel::{
     BoolExpressionMethods as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _,
@@ -70,6 +70,7 @@ pub async fn projects_options(
 /// If the user is not authenticated, then only public projects are returned.
 /// If the user is authenticated, then all public projects and
 /// any private project where the user has `view` permissions are returned.
+/// If a project key is provided, then only the key's project is returned.
 /// By default, the projects are sorted in alphabetical order by name.
 /// The HTTP response header `X-Total-Count` contains the total number of projects.
 #[endpoint {
@@ -79,11 +80,11 @@ pub async fn projects_options(
 }]
 pub async fn projects_get(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: PubBearerToken,
+    bearer_token: PubProjectBearerToken,
     pagination_params: Query<ProjectsPagination>,
     query_params: Query<ProjectsQuery>,
 ) -> Result<ResponseOk<JsonProjects>, HttpError> {
-    let public_user = PublicUser::from_token(
+    let api_actor = ApiActor::from_token(
         &rqctx.log,
         rqctx.context(),
         #[cfg(feature = "plus")]
@@ -95,12 +96,12 @@ pub async fn projects_get(
         rqctx.context(),
         pagination_params.into_inner(),
         query_params.into_inner(),
-        &public_user,
+        &api_actor,
     )
     .await?;
     Ok(Get::response_ok_with_total_count(
         json,
-        public_user.is_auth(),
+        api_actor.is_auth(),
         total_count,
     ))
 }
@@ -109,21 +110,21 @@ async fn get_ls_inner(
     context: &ApiContext,
     pagination_params: ProjectsPagination,
     query_params: ProjectsQuery,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
 ) -> Result<(JsonProjects, TotalCount), HttpError> {
-    let projects = get_ls_query(context, &pagination_params, &query_params, public_user)
+    let projects = get_ls_query(context, &pagination_params, &query_params, api_actor)
         .offset(pagination_params.offset())
         .limit(pagination_params.limit())
-        .load::<QueryProject>(public_conn!(context, public_user))
+        .load::<QueryProject>(actor_conn!(context, api_actor))
         .map_err(resource_not_found_err!(
             Project,
-            (&pagination_params, &query_params, public_user)
+            (&pagination_params, &query_params)
         ))?;
 
     // Drop connection lock before iterating
     let json_projects = projects
         .into_iter()
-        .map(|project| async { project.into_json(public_conn!(context, public_user)) })
+        .map(|project| async { project.into_json(actor_conn!(context, api_actor)) })
         .collect::<FuturesOrdered<_>>()
         .collect::<Vec<_>>()
         .await
@@ -139,12 +140,12 @@ async fn get_ls_inner(
         })
         .collect::<Vec<_>>();
 
-    let total_count = get_ls_query(context, &pagination_params, &query_params, public_user)
+    let total_count = get_ls_query(context, &pagination_params, &query_params, api_actor)
         .count()
-        .get_result::<i64>(public_conn!(context, public_user))
+        .get_result::<i64>(actor_conn!(context, api_actor))
         .map_err(resource_not_found_err!(
             Project,
-            (&pagination_params, &query_params, public_user)
+            (&pagination_params, &query_params)
         ))?
         .try_into()?;
 
@@ -155,24 +156,30 @@ fn get_ls_query<'q>(
     context: &ApiContext,
     pagination_params: &ProjectsPagination,
     query_params: &'q ProjectsQuery,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
 ) -> schema::project::BoxedQuery<'q, diesel::sqlite::Sqlite> {
     let mut query = schema::project::table
         .into_boxed()
         .filter(schema::project::deleted.is_null());
 
-    // All users should just see the public projects if the query is for public projects
-    if let PublicUser::Auth(auth_user) = public_user {
-        if !auth_user.is_admin(&context.rbac) {
-            let projects = auth_user.projects(&context.rbac, Permission::View);
-            query = query.filter(
-                schema::project::id
-                    .eq_any(projects)
-                    .or(schema::project::visibility.eq(Visibility::Public)),
-            );
-        }
-    } else {
-        query = query.filter(schema::project::visibility.eq(Visibility::Public));
+    match api_actor {
+        ApiActor::Public(public_user) => {
+            if let PublicUser::Auth(auth_user) = public_user {
+                if !auth_user.is_admin(&context.rbac) {
+                    let projects = auth_user.projects(&context.rbac, Permission::View);
+                    query = query.filter(
+                        schema::project::id
+                            .eq_any(projects)
+                            .or(schema::project::visibility.eq(Visibility::Public)),
+                    );
+                }
+            } else {
+                query = query.filter(schema::project::visibility.eq(Visibility::Public));
+            }
+        },
+        ApiActor::ProjectKey(project_key_actor) => {
+            query = query.filter(schema::project::id.eq(project_key_actor.project_id));
+        },
     }
 
     if let Some(name) = query_params.name.as_ref() {
@@ -219,6 +226,7 @@ pub async fn project_options(
 /// If the user is not authenticated, then only a public project is available.
 /// If the user is authenticated, then any public project and
 /// any private project where the user has `view` permissions is available.
+/// A valid project key for the project may also be used for authentication.
 #[endpoint {
     method = GET,
     path =  "/v0/projects/{project}",

--- a/lib/api_projects/src/projects.rs
+++ b/lib/api_projects/src/projects.rs
@@ -10,12 +10,13 @@ use bencher_rbac::project::Permission;
 #[cfg(feature = "plus")]
 use bencher_schema::model::organization::plan::PlanKind;
 use bencher_schema::{
-    auth_conn,
+    actor_conn, auth_conn,
     context::ApiContext,
     error::{forbidden_error, resource_conflict_err, resource_not_found_err},
     model::{
         project::{QueryProject, UpdateProject},
         user::{
+            actor::{ApiActor, PubProjectBearerToken},
             auth::{AuthUser, BearerToken},
             public::{PubBearerToken, PublicUser},
         },
@@ -225,10 +226,10 @@ pub async fn project_options(
 }]
 pub async fn project_get(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: PubBearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjectParams>,
 ) -> Result<ResponseOk<JsonProject>, HttpError> {
-    let public_user = PublicUser::from_token(
+    let api_actor = ApiActor::from_token(
         &rqctx.log,
         rqctx.context(),
         #[cfg(feature = "plus")]
@@ -236,17 +237,17 @@ pub async fn project_get(
         bearer_token,
     )
     .await?;
-    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &public_user).await?;
-    Ok(Get::response_ok(json, public_user.is_auth()))
+    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &api_actor).await?;
+    Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 
 async fn get_one_inner(
     context: &ApiContext,
     path_params: ProjectParams,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
 ) -> Result<JsonProject, HttpError> {
-    public_conn!(context, public_user, |conn| {
-        QueryProject::is_allowed_public(conn, &context.rbac, &path_params.project, public_user)?
+    actor_conn!(context, api_actor, |conn| {
+        QueryProject::is_allowed_actor(conn, &context.rbac, &path_params.project, api_actor)?
             .into_json(conn)
     })
 }

--- a/lib/api_projects/src/reports.rs
+++ b/lib/api_projects/src/reports.rs
@@ -81,7 +81,8 @@ pub async fn proj_reports_options(
 ///
 /// List all reports for a project.
 /// If the project is public, then the user does not need to be authenticated.
-/// If the project is private, then the user must be authenticated and have `view` permissions for the project.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
 /// By default, the reports are sorted by date time in reverse chronological order.
 /// The HTTP response header `X-Total-Count` contains the total number of reports.
 #[endpoint {
@@ -353,7 +354,8 @@ pub async fn proj_report_options(
 ///
 /// View a report for a project.
 /// If the project is public, then the user does not need to be authenticated.
-/// If the project is private, then the user must be authenticated and have `view` permissions for the project.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
 #[endpoint {
     method = GET,
     path =  "/v0/projects/{project}/reports/{report}",

--- a/lib/api_projects/src/reports.rs
+++ b/lib/api_projects/src/reports.rs
@@ -16,7 +16,7 @@ use bencher_rbac::project::Permission;
 #[cfg(feature = "plus")]
 use bencher_schema::model::project::testbed::RunTestbed;
 use bencher_schema::{
-    auth_conn,
+    actor_conn, auth_conn,
     context::ApiContext,
     error::{bad_request_error, resource_conflict_err, resource_not_found_err},
     model::{
@@ -29,11 +29,11 @@ use bencher_schema::{
             report::{NewRunReport, QueryReport, ReportId},
         },
         user::{
+            actor::{ApiActor, PubProjectBearerToken},
             auth::{AuthUser, BearerToken},
-            public::{PubBearerToken, PublicUser},
         },
     },
-    public_conn, schema, write_conn,
+    schema, write_conn,
 };
 use diesel::{
     BelongingToDsl as _, BoolExpressionMethods as _, ExpressionMethods as _, JoinOnDsl as _,
@@ -101,19 +101,19 @@ pub async fn proj_reports_get(
         .try_into()
         .map_err(bad_request_error)?;
 
-    let public_user = PublicUser::new(&rqctx).await?;
+    let api_actor = ApiActor::new(&rqctx).await?;
     let (json, total_count) = get_ls_inner(
         &rqctx.log,
         rqctx.context(),
         path_params.into_inner(),
         pagination_params.into_inner(),
         json_report_query,
-        &public_user,
+        &api_actor,
     )
     .await?;
     Ok(Get::response_ok_with_total_count(
         json,
-        public_user.is_auth(),
+        api_actor.is_auth(),
         total_count,
     ))
 }
@@ -124,19 +124,19 @@ async fn get_ls_inner(
     path_params: ProjReportsParams,
     pagination_params: ProjReportsPagination,
     query_params: JsonReportQuery,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
 ) -> Result<(JsonReports, TotalCount), HttpError> {
-    let query_project = QueryProject::is_allowed_public(
-        public_conn!(context, public_user),
+    let query_project = QueryProject::is_allowed_actor(
+        actor_conn!(context, api_actor),
         &context.rbac,
         &path_params.project,
-        public_user,
+        api_actor,
     )?;
 
     let reports = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
         .limit(pagination_params.limit())
-        .load(public_conn!(context, public_user))
+        .load(actor_conn!(context, api_actor))
         .map_err(resource_not_found_err!(
             Report,
             (&query_project, &pagination_params, &query_params)
@@ -145,7 +145,7 @@ async fn get_ls_inner(
     // Drop connection lock before iterating
     let json_reports = reports
         .into_iter()
-        .map(|report| async { report.into_json(log, public_conn!(context, public_user)) })
+        .map(|report| async { report.into_json(log, actor_conn!(context, api_actor)) })
         .collect::<FuturesOrdered<_>>()
         .collect::<Vec<_>>()
         .await
@@ -163,7 +163,7 @@ async fn get_ls_inner(
 
     let total_count = get_ls_query(&query_project, &pagination_params, &query_params)
         .count()
-        .get_result::<i64>(public_conn!(context, public_user))
+        .get_result::<i64>(actor_conn!(context, api_actor))
         .map_err(resource_not_found_err!(
             Report,
             (&query_project, &pagination_params, &query_params)
@@ -361,10 +361,10 @@ pub async fn proj_report_options(
 }]
 pub async fn proj_report_get(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: PubBearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjReportParams>,
 ) -> Result<ResponseOk<JsonReport>, HttpError> {
-    let public_user = PublicUser::from_token(
+    let api_actor = ApiActor::from_token(
         &rqctx.log,
         rqctx.context(),
         #[cfg(feature = "plus")]
@@ -376,26 +376,26 @@ pub async fn proj_report_get(
         &rqctx.log,
         rqctx.context(),
         path_params.into_inner(),
-        &public_user,
+        &api_actor,
     )
     .await?;
-    Ok(Get::response_ok(json, public_user.is_auth()))
+    Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 
 async fn get_one_inner(
     log: &Logger,
     context: &ApiContext,
     path_params: ProjReportParams,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
 ) -> Result<JsonReport, HttpError> {
-    let query_project = QueryProject::is_allowed_public(
-        public_conn!(context, public_user),
+    let query_project = QueryProject::is_allowed_actor(
+        actor_conn!(context, api_actor),
         &context.rbac,
         &path_params.project,
-        public_user,
+        api_actor,
     )?;
 
-    public_conn!(context, public_user, |conn| {
+    actor_conn!(context, api_actor, |conn| {
         QueryReport::belonging_to(&query_project)
             .filter(schema::report::uuid.eq(path_params.report.to_string()))
             .first::<QueryReport>(conn)

--- a/lib/api_projects/src/testbeds.rs
+++ b/lib/api_projects/src/testbeds.rs
@@ -12,7 +12,7 @@ use bencher_rbac::project::Permission;
 #[cfg(feature = "plus")]
 use bencher_schema::model::spec::QuerySpec;
 use bencher_schema::{
-    auth_conn,
+    actor_conn, auth_conn,
     context::ApiContext,
     error::{resource_conflict_err, resource_not_found_err},
     model::{
@@ -21,11 +21,11 @@ use bencher_schema::{
             testbed::{QueryTestbed, UpdateTestbed},
         },
         user::{
+            actor::{ApiActor, PubProjectBearerToken},
             auth::{AuthUser, BearerToken},
-            public::{PubBearerToken, PublicUser},
         },
     },
-    public_conn, schema, write_conn,
+    schema, write_conn,
 };
 use diesel::{
     BelongingToDsl as _, BoolExpressionMethods as _, ExpressionMethods as _, QueryDsl as _,
@@ -94,10 +94,10 @@ pub async fn proj_testbeds_get(
     pagination_params: Query<ProjTestbedsPagination>,
     query_params: Query<ProjTestbedsQuery>,
 ) -> Result<ResponseOk<JsonTestbeds>, HttpError> {
-    let public_user = PublicUser::new(&rqctx).await?;
+    let api_actor = ApiActor::new(&rqctx).await?;
     let (json, total_count) = get_ls_inner(
         rqctx.context(),
-        &public_user,
+        &api_actor,
         path_params.into_inner(),
         pagination_params.into_inner(),
         query_params.into_inner(),
@@ -105,26 +105,26 @@ pub async fn proj_testbeds_get(
     .await?;
     Ok(Get::response_ok_with_total_count(
         json,
-        public_user.is_auth(),
+        api_actor.is_auth(),
         total_count,
     ))
 }
 
 async fn get_ls_inner(
     context: &ApiContext,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
     path_params: ProjTestbedsParams,
     pagination_params: ProjTestbedsPagination,
     query_params: ProjTestbedsQuery,
 ) -> Result<(JsonTestbeds, TotalCount), HttpError> {
-    let query_project = QueryProject::is_allowed_public(
-        public_conn!(context, public_user),
+    let query_project = QueryProject::is_allowed_actor(
+        actor_conn!(context, api_actor),
         &context.rbac,
         &path_params.project,
-        public_user,
+        api_actor,
     )?;
 
-    public_conn!(context, public_user, |conn| {
+    actor_conn!(context, api_actor, |conn| {
         let testbeds = get_ls_query(&query_project, &pagination_params, &query_params)
             .offset(pagination_params.offset())
             .limit(pagination_params.limit())
@@ -274,11 +274,11 @@ pub async fn proj_testbed_options(
 }]
 pub async fn proj_testbed_get(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: PubBearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjTestbedParams>,
     query_params: Query<ProjTestbedQuery>,
 ) -> Result<ResponseOk<JsonTestbed>, HttpError> {
-    let public_user = PublicUser::from_token(
+    let api_actor = ApiActor::from_token(
         &rqctx.log,
         rqctx.context(),
         #[cfg(feature = "plus")]
@@ -290,26 +290,26 @@ pub async fn proj_testbed_get(
         rqctx.context(),
         path_params.into_inner(),
         query_params.into_inner(),
-        &public_user,
+        &api_actor,
     )
     .await?;
-    Ok(Get::response_ok(json, public_user.is_auth()))
+    Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 
 async fn get_one_inner(
     context: &ApiContext,
     path_params: ProjTestbedParams,
     query_params: ProjTestbedQuery,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
 ) -> Result<JsonTestbed, HttpError> {
-    let query_project = QueryProject::is_allowed_public(
-        public_conn!(context, public_user),
+    let query_project = QueryProject::is_allowed_actor(
+        actor_conn!(context, api_actor),
         &context.rbac,
         &path_params.project,
-        public_user,
+        api_actor,
     )?;
 
-    public_conn!(context, public_user, |conn| {
+    actor_conn!(context, api_actor, |conn| {
         let testbed = QueryTestbed::belonging_to(&query_project)
             .filter(QueryTestbed::eq_resource_id(&path_params.testbed))
             .first::<QueryTestbed>(conn)

--- a/lib/api_projects/src/testbeds.rs
+++ b/lib/api_projects/src/testbeds.rs
@@ -80,7 +80,8 @@ pub async fn proj_testbeds_options(
 ///
 /// List all testbeds for a project.
 /// If the project is public, then the user does not need to be authenticated.
-/// If the project is private, then the user must be authenticated and have `view` permissions for the project.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
 /// By default, the testbeds are sorted in alphabetical order by name.
 /// The HTTP response header `X-Total-Count` contains the total number of testbeds.
 #[endpoint {
@@ -266,7 +267,8 @@ pub async fn proj_testbed_options(
 ///
 /// View a testbed for a project.
 /// If the project is public, then the user does not need to be authenticated.
-/// If the project is private, then the user must be authenticated and have `view` permissions for the project.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
 #[endpoint {
     method = GET,
     path =  "/v0/projects/{project}/testbeds/{testbed}",

--- a/lib/api_projects/src/thresholds.rs
+++ b/lib/api_projects/src/thresholds.rs
@@ -79,7 +79,8 @@ pub async fn proj_thresholds_options(
 ///
 /// List all thresholds for a project.
 /// If the project is public, then the user does not need to be authenticated.
-/// If the project is private, then the user must be authenticated and have `view` permissions for the project.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
 /// By default, the thresholds are sorted by creation date time in chronological order.
 /// The HTTP response header `X-Total-Count` contains the total number of thresholds.
 #[endpoint {
@@ -347,7 +348,8 @@ pub async fn proj_threshold_options(
 ///
 /// View a threshold for a project.
 /// If the project is public, then the user does not need to be authenticated.
-/// If the project is private, then the user must be authenticated and have `view` permissions for the project.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
 #[endpoint {
     method = GET,
     path =  "/v0/projects/{project}/thresholds/{threshold}",

--- a/lib/api_projects/src/thresholds.rs
+++ b/lib/api_projects/src/thresholds.rs
@@ -11,7 +11,7 @@ use bencher_json::{
 };
 use bencher_rbac::project::Permission;
 use bencher_schema::{
-    auth_conn,
+    actor_conn, auth_conn,
     context::ApiContext,
     error::{
         BencherResource, bad_request_error, resource_conflict_err, resource_not_found_err,
@@ -26,11 +26,11 @@ use bencher_schema::{
             threshold::{InsertThreshold, QueryThreshold, ThresholdSpec, model::QueryModel},
         },
         user::{
+            actor::{ApiActor, PubProjectBearerToken},
             auth::{AuthUser, BearerToken},
-            public::{PubBearerToken, PublicUser},
         },
     },
-    public_conn, schema, write_conn,
+    schema, write_conn,
 };
 use diesel::{
     BelongingToDsl as _, BoolExpressionMethods as _, ExpressionMethods as _, QueryDsl as _,
@@ -99,18 +99,18 @@ pub async fn proj_thresholds_get(
         .try_into()
         .map_err(bad_request_error)?;
 
-    let public_user = PublicUser::new(&rqctx).await?;
+    let api_actor = ApiActor::new(&rqctx).await?;
     let (json, total_count) = get_ls_inner(
         rqctx.context(),
         path_params.into_inner(),
         pagination_params.into_inner(),
         json_threshold_query,
-        &public_user,
+        &api_actor,
     )
     .await?;
     Ok(Get::response_ok_with_total_count(
         json,
-        public_user.is_auth(),
+        api_actor.is_auth(),
         total_count,
     ))
 }
@@ -120,19 +120,19 @@ async fn get_ls_inner(
     path_params: ProjThresholdsParams,
     pagination_params: ProjThresholdsPagination,
     query_params: JsonThresholdQuery,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
 ) -> Result<(JsonThresholds, TotalCount), HttpError> {
-    let query_project = QueryProject::is_allowed_public(
-        public_conn!(context, public_user),
+    let query_project = QueryProject::is_allowed_actor(
+        actor_conn!(context, api_actor),
         &context.rbac,
         &path_params.project,
-        public_user,
+        api_actor,
     )?;
 
     let thresholds = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
         .limit(pagination_params.limit())
-        .load::<QueryThreshold>(public_conn!(context, public_user))
+        .load::<QueryThreshold>(actor_conn!(context, api_actor))
         .map_err(resource_not_found_err!(
             Threshold,
             (&query_project, &pagination_params, &query_params)
@@ -141,7 +141,7 @@ async fn get_ls_inner(
     // Drop connection lock before iterating
     let json_thresholds = thresholds
         .into_iter()
-        .map(|threshold| async { threshold.into_json(public_conn!(context, public_user)) })
+        .map(|threshold| async { threshold.into_json(actor_conn!(context, api_actor)) })
         .collect::<FuturesOrdered<_>>()
         .collect::<Vec<_>>()
         .await
@@ -159,7 +159,7 @@ async fn get_ls_inner(
 
     let total_count = get_ls_query(&query_project, &pagination_params, &query_params)
         .count()
-        .get_result::<i64>(public_conn!(context, public_user))
+        .get_result::<i64>(actor_conn!(context, api_actor))
         .map_err(resource_not_found_err!(
             Threshold,
             (&query_project, &pagination_params, &query_params)
@@ -355,11 +355,11 @@ pub async fn proj_threshold_options(
 }]
 pub async fn proj_threshold_get(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: PubBearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjThresholdParams>,
     query_params: Query<ProjThresholdQuery>,
 ) -> Result<ResponseOk<JsonThreshold>, HttpError> {
-    let public_user = PublicUser::from_token(
+    let api_actor = ApiActor::from_token(
         &rqctx.log,
         rqctx.context(),
         #[cfg(feature = "plus")]
@@ -371,56 +371,47 @@ pub async fn proj_threshold_get(
         rqctx.context(),
         path_params.into_inner(),
         query_params.into_inner(),
-        &public_user,
+        &api_actor,
     )
     .await?;
-    Ok(Get::response_ok(json, public_user.is_auth()))
+    Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 
 async fn get_one_inner(
     context: &ApiContext,
     path_params: ProjThresholdParams,
     query_params: ProjThresholdQuery,
-    public_user: &PublicUser,
+    api_actor: &ApiActor,
 ) -> Result<JsonThreshold, HttpError> {
-    let query_project = QueryProject::is_allowed_public(
-        public_conn!(context, public_user),
-        &context.rbac,
-        &path_params.project,
-        public_user,
-    )?;
+    actor_conn!(context, api_actor, |conn| {
+        let query_project =
+            QueryProject::is_allowed_actor(conn, &context.rbac, &path_params.project, api_actor)?;
 
-    let query_threshold = QueryThreshold::get_with_uuid(
-        public_conn!(context, public_user),
-        &query_project,
-        path_params.threshold,
-    )?;
+        let query_threshold =
+            QueryThreshold::get_with_uuid(conn, &query_project, path_params.threshold)?;
 
-    if let Some(model_uuid) = query_params.model {
-        let query_model = QueryModel::from_uuid(
-            public_conn!(context, public_user),
-            query_project.id,
-            model_uuid,
-        )?;
-        if query_model.threshold_id != query_threshold.id {
-            return Err(resource_not_found_error(
-                BencherResource::Model,
-                model_uuid,
-                format!(
-                    "Specified model {model_uuid} does not belong to threshold {threshold_uuid}",
-                    threshold_uuid = query_threshold.uuid
-                ),
-            ));
+        if let Some(model_uuid) = query_params.model {
+            let query_model = QueryModel::from_uuid(conn, query_project.id, model_uuid)?;
+            if query_model.threshold_id != query_threshold.id {
+                return Err(resource_not_found_error(
+                    BencherResource::Model,
+                    model_uuid,
+                    format!(
+                        "Specified model {model_uuid} does not belong to threshold {threshold_uuid}",
+                        threshold_uuid = query_threshold.uuid
+                    ),
+                ));
+            }
+            query_threshold.into_json_for_model(
+                conn,
+                Some(query_model),
+                None,
+                ThresholdSpec::Testbed,
+            )
+        } else {
+            query_threshold.into_json(conn)
         }
-        query_threshold.into_json_for_model(
-            public_conn!(context, public_user),
-            Some(query_model),
-            None,
-            ThresholdSpec::Testbed,
-        )
-    } else {
-        query_threshold.into_json(public_conn!(context, public_user))
-    }
+    })
 }
 
 /// Update a threshold

--- a/lib/api_projects/tests/project_key_auth.rs
+++ b/lib/api_projects/tests/project_key_auth.rs
@@ -1,0 +1,389 @@
+#![expect(
+    unused_crate_dependencies,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::missing_assert_message,
+    clippy::tests_outside_test_module,
+    clippy::uninlined_format_args
+)]
+//! Integration tests for project key authentication on GET endpoints.
+
+use bencher_api_tests::TestServer;
+use bencher_json::{JsonBranches, JsonProject, JsonProjectKeyCreated, JsonProjects, ProjectKey};
+use http::StatusCode;
+
+async fn setup() -> (TestServer, String, ProjectKey) {
+    let server = TestServer::new().await;
+    let user = server.signup("Key User", "keyuser@example.com").await;
+    let org = server.create_org(&user, "Key Org").await;
+    let project = server.create_project(&user, &org, "Key Project").await;
+
+    let project_slug: &str = project.slug.as_ref();
+    let project_slug = project_slug.to_owned();
+
+    // Create a project key
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/keys", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(&serde_json::json!({"name": "ci-key"}))
+        .send()
+        .await
+        .expect("Failed to create project key");
+
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let key_created: JsonProjectKeyCreated = resp.json().await.expect("Failed to parse key");
+
+    (server, project_slug, key_created.key)
+}
+
+// GET /v0/projects/{project} - view project with key
+#[tokio::test]
+async fn project_key_get_project() {
+    let (server, project_slug, key) = setup().await;
+
+    let resp = server
+        .client
+        .get(server.api_url(&format!("/v0/projects/{}", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let project: JsonProject = resp.json().await.expect("Failed to parse response");
+    let slug: &str = project.slug.as_ref();
+    assert_eq!(slug, project_slug);
+}
+
+// GET /v0/projects - list projects with key returns only key's project
+#[tokio::test]
+async fn project_key_list_projects() {
+    let (server, project_slug, key) = setup().await;
+
+    let resp = server
+        .client
+        .get(server.api_url("/v0/projects"))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let projects: JsonProjects = resp.json().await.expect("Failed to parse response");
+    assert_eq!(projects.0.len(), 1);
+    let slug: &str = projects.0[0].slug.as_ref();
+    assert_eq!(slug, project_slug);
+}
+
+// GET /v0/projects/{project}/branches - list branches with key
+#[tokio::test]
+async fn project_key_list_branches() {
+    let (server, project_slug, key) = setup().await;
+
+    let resp = server
+        .client
+        .get(server.api_url(&format!("/v0/projects/{}/branches", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let _branches: JsonBranches = resp.json().await.expect("Failed to parse response");
+}
+
+// GET /v0/projects/{project}/testbeds - list testbeds with key
+#[tokio::test]
+async fn project_key_list_testbeds() {
+    let (server, project_slug, key) = setup().await;
+
+    let resp = server
+        .client
+        .get(server.api_url(&format!("/v0/projects/{}/testbeds", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+// GET /v0/projects/{project}/benchmarks - list benchmarks with key
+#[tokio::test]
+async fn project_key_list_benchmarks() {
+    let (server, project_slug, key) = setup().await;
+
+    let resp = server
+        .client
+        .get(server.api_url(&format!("/v0/projects/{}/benchmarks", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+// GET /v0/projects/{project}/measures - list measures with key
+#[tokio::test]
+async fn project_key_list_measures() {
+    let (server, project_slug, key) = setup().await;
+
+    let resp = server
+        .client
+        .get(server.api_url(&format!("/v0/projects/{}/measures", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+// GET /v0/projects/{project}/thresholds - list thresholds with key
+#[tokio::test]
+async fn project_key_list_thresholds() {
+    let (server, project_slug, key) = setup().await;
+
+    let resp = server
+        .client
+        .get(server.api_url(&format!("/v0/projects/{}/thresholds", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+// GET /v0/projects/{project}/alerts - list alerts with key
+#[tokio::test]
+async fn project_key_list_alerts() {
+    let (server, project_slug, key) = setup().await;
+
+    let resp = server
+        .client
+        .get(server.api_url(&format!("/v0/projects/{}/alerts", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+// GET /v0/projects/{project}/reports - list reports with key
+#[tokio::test]
+async fn project_key_list_reports() {
+    let (server, project_slug, key) = setup().await;
+
+    let resp = server
+        .client
+        .get(server.api_url(&format!("/v0/projects/{}/reports", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+// GET /v0/projects/{project}/plots - list plots with key
+#[tokio::test]
+async fn project_key_list_plots() {
+    let (server, project_slug, key) = setup().await;
+
+    let resp = server
+        .client
+        .get(server.api_url(&format!("/v0/projects/{}/plots", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+// Negative: project key cannot access a different project
+#[tokio::test]
+async fn project_key_wrong_project() {
+    let server = TestServer::new().await;
+    let user = server.signup("Key User", "keywrong@example.com").await;
+    let org = server.create_org(&user, "Key Wrong Org").await;
+    let project_a = server.create_project(&user, &org, "Project A").await;
+    let project_b = server.create_project(&user, &org, "Project B").await;
+
+    let slug_a: &str = project_a.slug.as_ref();
+    let slug_b: &str = project_b.slug.as_ref();
+
+    // Create key for project A
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/keys", slug_a)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(&serde_json::json!({"name": "a-key"}))
+        .send()
+        .await
+        .expect("Failed to create key");
+
+    let key_created: JsonProjectKeyCreated = resp.json().await.expect("Failed to parse key");
+
+    // Try to access project B with project A's key
+    let resp = server
+        .client
+        .get(server.api_url(&format!("/v0/projects/{}/branches", slug_b)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key_created.key.as_ref()),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+// Negative: project key cannot list keys (requires Manage permission)
+#[tokio::test]
+async fn project_key_cannot_list_keys() {
+    let (server, project_slug, key) = setup().await;
+
+    let resp = server
+        .client
+        .get(server.api_url(&format!("/v0/projects/{}/keys", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+// Negative: project key cannot write (POST requires user auth)
+#[tokio::test]
+async fn project_key_cannot_write() {
+    let (server, project_slug, key) = setup().await;
+
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/branches", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .json(&serde_json::json!({"name": "new-branch"}))
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+// Negative: revoked project key is rejected
+#[tokio::test]
+async fn project_key_revoked() {
+    let server = TestServer::new().await;
+    let user = server.signup("Key User", "keyrevoked@example.com").await;
+    let org = server.create_org(&user, "Revoke Key Org").await;
+    let project = server.create_project(&user, &org, "Revoke Project").await;
+
+    let project_slug: &str = project.slug.as_ref();
+
+    // Create a project key
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/keys", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(&serde_json::json!({"name": "revoke-key"}))
+        .send()
+        .await
+        .expect("Failed to create key");
+
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let key_created: JsonProjectKeyCreated = resp.json().await.expect("Failed to parse key");
+
+    // Verify key works
+    let resp = server
+        .client
+        .get(server.api_url(&format!("/v0/projects/{}", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key_created.key.as_ref()),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Revoke the key
+    let resp = server
+        .client
+        .delete(server.api_url(&format!(
+            "/v0/projects/{}/keys/{}",
+            project_slug, key_created.uuid
+        )))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .send()
+        .await
+        .expect("Failed to revoke key");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    // Revoked key should be rejected
+    let resp = server
+        .client
+        .get(server.api_url(&format!("/v0/projects/{}", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key_created.key.as_ref()),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}

--- a/lib/api_projects/tests/project_key_auth.rs
+++ b/lib/api_projects/tests/project_key_auth.rs
@@ -9,10 +9,12 @@
 //! Integration tests for project key authentication on GET endpoints.
 
 use bencher_api_tests::TestServer;
-use bencher_json::{JsonBranches, JsonProject, JsonProjectKeyCreated, JsonProjects, ProjectKey};
+use bencher_json::{
+    JsonBranch, JsonBranches, JsonProject, JsonProjectKeyCreated, JsonProjects, ProjectKey,
+};
 use http::StatusCode;
 
-async fn setup() -> (TestServer, String, ProjectKey) {
+async fn setup() -> (TestServer, String, String, ProjectKey) {
     let server = TestServer::new().await;
     let user = server.signup("Key User", "keyuser@example.com").await;
     let org = server.create_org(&user, "Key Org").await;
@@ -37,13 +39,13 @@ async fn setup() -> (TestServer, String, ProjectKey) {
     assert_eq!(resp.status(), StatusCode::CREATED);
     let key_created: JsonProjectKeyCreated = resp.json().await.expect("Failed to parse key");
 
-    (server, project_slug, key_created.key)
+    (server, project_slug, user.token, key_created.key)
 }
 
 // GET /v0/projects/{project} - view project with key
 #[tokio::test]
 async fn project_key_get_project() {
-    let (server, project_slug, key) = setup().await;
+    let (server, project_slug, _token, key) = setup().await;
 
     let resp = server
         .client
@@ -65,7 +67,7 @@ async fn project_key_get_project() {
 // GET /v0/projects - list projects with key returns only key's project
 #[tokio::test]
 async fn project_key_list_projects() {
-    let (server, project_slug, key) = setup().await;
+    let (server, project_slug, _token, key) = setup().await;
 
     let resp = server
         .client
@@ -88,7 +90,7 @@ async fn project_key_list_projects() {
 // GET /v0/projects/{project}/branches - list branches with key
 #[tokio::test]
 async fn project_key_list_branches() {
-    let (server, project_slug, key) = setup().await;
+    let (server, project_slug, _token, key) = setup().await;
 
     let resp = server
         .client
@@ -105,10 +107,51 @@ async fn project_key_list_branches() {
     let _branches: JsonBranches = resp.json().await.expect("Failed to parse response");
 }
 
+// GET /v0/projects/{project}/branches/{branch} - get single branch with key
+// This exercises the PubProjectBearerToken extractor path (different from list endpoints)
+#[tokio::test]
+async fn project_key_get_branch() {
+    let (server, project_slug, token, key) = setup().await;
+
+    // Create a branch using JWT auth
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/branches", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&token),
+        )
+        .json(&serde_json::json!({"name": "feature-branch", "slug": "feature-branch"}))
+        .send()
+        .await
+        .expect("Failed to create branch");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    // GET the branch using the project key
+    let resp = server
+        .client
+        .get(server.api_url(&format!(
+            "/v0/projects/{}/branches/feature-branch",
+            project_slug
+        )))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let branch: JsonBranch = resp.json().await.expect("Failed to parse response");
+    let name: &str = branch.name.as_ref();
+    assert_eq!(name, "feature-branch");
+}
+
 // GET /v0/projects/{project}/testbeds - list testbeds with key
 #[tokio::test]
 async fn project_key_list_testbeds() {
-    let (server, project_slug, key) = setup().await;
+    let (server, project_slug, _token, key) = setup().await;
 
     let resp = server
         .client
@@ -127,7 +170,7 @@ async fn project_key_list_testbeds() {
 // GET /v0/projects/{project}/benchmarks - list benchmarks with key
 #[tokio::test]
 async fn project_key_list_benchmarks() {
-    let (server, project_slug, key) = setup().await;
+    let (server, project_slug, _token, key) = setup().await;
 
     let resp = server
         .client
@@ -146,7 +189,7 @@ async fn project_key_list_benchmarks() {
 // GET /v0/projects/{project}/measures - list measures with key
 #[tokio::test]
 async fn project_key_list_measures() {
-    let (server, project_slug, key) = setup().await;
+    let (server, project_slug, _token, key) = setup().await;
 
     let resp = server
         .client
@@ -165,7 +208,7 @@ async fn project_key_list_measures() {
 // GET /v0/projects/{project}/thresholds - list thresholds with key
 #[tokio::test]
 async fn project_key_list_thresholds() {
-    let (server, project_slug, key) = setup().await;
+    let (server, project_slug, _token, key) = setup().await;
 
     let resp = server
         .client
@@ -184,7 +227,7 @@ async fn project_key_list_thresholds() {
 // GET /v0/projects/{project}/alerts - list alerts with key
 #[tokio::test]
 async fn project_key_list_alerts() {
-    let (server, project_slug, key) = setup().await;
+    let (server, project_slug, _token, key) = setup().await;
 
     let resp = server
         .client
@@ -203,7 +246,7 @@ async fn project_key_list_alerts() {
 // GET /v0/projects/{project}/reports - list reports with key
 #[tokio::test]
 async fn project_key_list_reports() {
-    let (server, project_slug, key) = setup().await;
+    let (server, project_slug, _token, key) = setup().await;
 
     let resp = server
         .client
@@ -222,7 +265,7 @@ async fn project_key_list_reports() {
 // GET /v0/projects/{project}/plots - list plots with key
 #[tokio::test]
 async fn project_key_list_plots() {
-    let (server, project_slug, key) = setup().await;
+    let (server, project_slug, _token, key) = setup().await;
 
     let resp = server
         .client
@@ -283,7 +326,7 @@ async fn project_key_wrong_project() {
 // Negative: project key cannot list keys (requires Manage permission)
 #[tokio::test]
 async fn project_key_cannot_list_keys() {
-    let (server, project_slug, key) = setup().await;
+    let (server, project_slug, _token, key) = setup().await;
 
     let resp = server
         .client
@@ -302,7 +345,7 @@ async fn project_key_cannot_list_keys() {
 // Negative: project key cannot write (POST requires user auth)
 #[tokio::test]
 async fn project_key_cannot_write() {
-    let (server, project_slug, key) = setup().await;
+    let (server, project_slug, _token, key) = setup().await;
 
     let resp = server
         .client

--- a/lib/bencher_schema/src/context/mod.rs
+++ b/lib/bencher_schema/src/context/mod.rs
@@ -131,6 +131,10 @@ macro_rules! actor_conn {
             },
         }
     };
+    ($context:expr, $actor:expr, |$conn:ident| $multi:expr) => {{
+        let $conn = $crate::actor_conn!($context, $actor);
+        $multi
+    }};
 }
 
 #[macro_export]

--- a/lib/bencher_schema/src/model/project/mod.rs
+++ b/lib/bencher_schema/src/model/project/mod.rs
@@ -30,7 +30,7 @@ use crate::{
     },
     model::{
         organization::QueryOrganization,
-        user::{auth::AuthUser, public::PublicUser},
+        user::{actor::ApiActor, auth::AuthUser, public::PublicUser},
     },
     schema::{self, project as project_table},
     write_conn, write_transaction,
@@ -446,6 +446,38 @@ impl QueryProject {
             Ok(query_project)
         } else {
             Err(unauthorized_error(project))
+        }
+    }
+
+    pub fn is_allowed_actor(
+        conn: &mut DbConnection,
+        rbac: &Rbac,
+        project: &ProjectResourceId,
+        api_actor: &ApiActor,
+    ) -> Result<Self, HttpError> {
+        Self::is_allowed_actor_inner(conn, rbac, project, api_actor).map_err(|_e| {
+            resource_not_found_error(BencherResource::Project, project, Permission::View)
+        })
+    }
+
+    fn is_allowed_actor_inner(
+        conn: &mut DbConnection,
+        rbac: &Rbac,
+        project: &ProjectResourceId,
+        api_actor: &ApiActor,
+    ) -> Result<Self, HttpError> {
+        match api_actor {
+            ApiActor::Public(public_user) => {
+                Self::is_allowed_public_inner(conn, rbac, project, public_user)
+            },
+            ApiActor::ProjectKey(project_key_actor) => {
+                let query_project = Self::from_resource_id(conn, project)?;
+                if query_project.id == project_key_actor.project_id {
+                    Ok(query_project)
+                } else {
+                    Err(unauthorized_error(project))
+                }
+            },
         }
     }
 

--- a/lib/bencher_schema/src/model/user/actor.rs
+++ b/lib/bencher_schema/src/model/user/actor.rs
@@ -65,6 +65,25 @@ impl SharedExtractor for PubProjectBearerToken {
 }
 
 impl ApiActor {
+    pub async fn new(rqctx: &RequestContext<ApiContext>) -> Result<Self, HttpError> {
+        let pub_project_bearer_token = PubProjectBearerToken::from_request(rqctx).await?;
+        Self::from_token(
+            &rqctx.log,
+            rqctx.context(),
+            #[cfg(feature = "plus")]
+            rqctx.request.headers(),
+            pub_project_bearer_token,
+        )
+        .await
+    }
+
+    pub fn is_auth(&self) -> bool {
+        match self {
+            Self::Public(public_user) => public_user.is_auth(),
+            Self::ProjectKey(_) => true,
+        }
+    }
+
     pub fn user_id(&self) -> Option<UserId> {
         match self {
             Self::Public(public_user) => public_user.user_id(),

--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -2844,7 +2844,7 @@
           "projects"
         ],
         "summary": "List projects",
-        "description": "List all projects. If the user is not authenticated, then only public projects are returned. If the user is authenticated, then all public projects and any private project where the user has `view` permissions are returned. By default, the projects are sorted in alphabetical order by name. The HTTP response header `X-Total-Count` contains the total number of projects.",
+        "description": "List all projects. If the user is not authenticated, then only public projects are returned. If the user is authenticated, then all public projects and any private project where the user has `view` permissions are returned. If a project key is provided, then only the key's project is returned. By default, the projects are sorted in alphabetical order by name. The HTTP response header `X-Total-Count` contains the total number of projects.",
         "operationId": "projects_get",
         "parameters": [
           {
@@ -2965,7 +2965,7 @@
           "projects"
         ],
         "summary": "View a project",
-        "description": "View a project. If the user is not authenticated, then only a public project is available. If the user is authenticated, then any public project and any private project where the user has `view` permissions is available.",
+        "description": "View a project. If the user is not authenticated, then only a public project is available. If the user is authenticated, then any public project and any private project where the user has `view` permissions is available. A valid project key for the project may also be used for authentication.",
         "operationId": "project_get",
         "parameters": [
           {
@@ -3202,7 +3202,7 @@
           "alerts"
         ],
         "summary": "List alerts for a project",
-        "description": "List all alerts for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project. By default, the alerts are sorted by status (active then dismissed) and modification date time in reverse chronological order. The HTTP response header `X-Total-Count` contains the total number of alerts.",
+        "description": "List all alerts for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project. By default, the alerts are sorted by status (active then dismissed) and modification date time in reverse chronological order. The HTTP response header `X-Total-Count` contains the total number of alerts.",
         "operationId": "proj_alerts_get",
         "parameters": [
           {
@@ -3334,7 +3334,7 @@
           "alerts"
         ],
         "summary": "View an alert",
-        "description": "View an alert for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project.",
+        "description": "View an alert for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project.",
         "operationId": "proj_alert_get",
         "parameters": [
           {
@@ -3598,7 +3598,7 @@
           "benchmarks"
         ],
         "summary": "List benchmarks for a project",
-        "description": "List all benchmarks for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project. By default, the benchmarks are sorted in alphabetical order by name. The HTTP response header `X-Total-Count` contains the total number of benchmarks.",
+        "description": "List all benchmarks for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project. By default, the benchmarks are sorted in alphabetical order by name. The HTTP response header `X-Total-Count` contains the total number of benchmarks.",
         "operationId": "proj_benchmarks_get",
         "parameters": [
           {
@@ -3823,7 +3823,7 @@
           "benchmarks"
         ],
         "summary": "View a benchmark",
-        "description": "View a benchmark for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project.",
+        "description": "View a benchmark for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project.",
         "operationId": "proj_benchmark_get",
         "parameters": [
           {
@@ -4080,7 +4080,7 @@
           "branches"
         ],
         "summary": "List branches for a project",
-        "description": "List all branches for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project. By default, the branches are sorted in alphabetical order by name. The HTTP response header `X-Total-Count` contains the total number of branches.",
+        "description": "List all branches for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project. By default, the branches are sorted in alphabetical order by name. The HTTP response header `X-Total-Count` contains the total number of branches.",
         "operationId": "proj_branches_get",
         "parameters": [
           {
@@ -4305,7 +4305,7 @@
           "branches"
         ],
         "summary": "View a branch",
-        "description": "View a branch for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project.",
+        "description": "View a branch for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project.",
         "operationId": "proj_branch_get",
         "parameters": [
           {
@@ -4570,7 +4570,7 @@
           "jobs"
         ],
         "summary": "List jobs for a project",
-        "description": "➕ Bencher Plus: List all jobs for a project. The job output is not included in the list response. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project. By default, the jobs are sorted by creation date time in reverse chronological order. The HTTP response header `X-Total-Count` contains the total number of jobs.",
+        "description": "➕ Bencher Plus: List all jobs for a project. The job output is not included in the list response. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project. By default, the jobs are sorted by creation date time in reverse chronological order. The HTTP response header `X-Total-Count` contains the total number of jobs.",
         "operationId": "proj_jobs_get",
         "parameters": [
           {
@@ -4693,7 +4693,7 @@
           "jobs"
         ],
         "summary": "View a job",
-        "description": "➕ Bencher Plus: View a job for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project. The job output is only included in the response for terminal (completed, failed, or canceled) jobs when the user is authenticated and has `view` permissions for the project.",
+        "description": "➕ Bencher Plus: View a job for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project. The job output is only included in the response for terminal (completed, failed, or canceled) jobs when the user is authenticated and has `view` permissions for the project.",
         "operationId": "proj_job_get",
         "parameters": [
           {
@@ -5261,7 +5261,7 @@
           "measures"
         ],
         "summary": "List measures for a project",
-        "description": "List all measures for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project. By default, the measures are sorted in alphabetical order by name. The HTTP response header `X-Total-Count` contains the total number of measures.",
+        "description": "List all measures for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project. By default, the measures are sorted in alphabetical order by name. The HTTP response header `X-Total-Count` contains the total number of measures.",
         "operationId": "proj_measures_get",
         "parameters": [
           {
@@ -5486,7 +5486,7 @@
           "measures"
         ],
         "summary": "View a measure",
-        "description": "View a measure for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project.",
+        "description": "View a measure for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project.",
         "operationId": "proj_measure_get",
         "parameters": [
           {
@@ -5743,7 +5743,7 @@
           "metrics"
         ],
         "summary": "View a metric",
-        "description": "View a metric for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project.",
+        "description": "View a metric for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project.",
         "operationId": "proj_metric_get",
         "parameters": [
           {
@@ -5829,7 +5829,7 @@
           "perf"
         ],
         "summary": "Query project performance metrics",
-        "description": "Query the performance metrics for a project. The query results are every permutation of each branch, testbed, benchmark, and measure. There is a limit of 255 permutations for a single request. Therefore, only the first 255 permutations are returned. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project.",
+        "description": "Query the performance metrics for a project. The query results are every permutation of each branch, testbed, benchmark, and measure. There is a limit of 255 permutations for a single request. Therefore, only the first 255 permutations are returned. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project.",
         "operationId": "proj_perf_get",
         "parameters": [
           {
@@ -5976,7 +5976,7 @@
           "perf"
         ],
         "summary": "Generate a dynamic image of project performance metrics",
-        "description": "Generate a dynamic image of performance metrics for a project. The query results are every permutation of each branch, testbed, benchmark, and measure. There is a limit of 8 permutations for a single image. Therefore, only the first 8 permutations are plotted. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project.",
+        "description": "Generate a dynamic image of performance metrics for a project. The query results are every permutation of each branch, testbed, benchmark, and measure. There is a limit of 8 permutations for a single image. Therefore, only the first 8 permutations are plotted. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project.",
         "operationId": "proj_perf_img_get",
         "parameters": [
           {
@@ -6087,7 +6087,7 @@
           "plots"
         ],
         "summary": "List plots for a project",
-        "description": "List all plots for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project. By default, the plots are sorted in their index order. The HTTP response header `X-Total-Count` contains the total number of plots.",
+        "description": "List all plots for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project. By default, the plots are sorted in their index order. The HTTP response header `X-Total-Count` contains the total number of plots.",
         "operationId": "proj_plots_get",
         "parameters": [
           {
@@ -6303,7 +6303,7 @@
           "plots"
         ],
         "summary": "View a plot",
-        "description": "View a plot for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project.",
+        "description": "View a plot for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project.",
         "operationId": "proj_plot_get",
         "parameters": [
           {
@@ -6560,7 +6560,7 @@
           "reports"
         ],
         "summary": "List reports for a project",
-        "description": "List all reports for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project. By default, the reports are sorted by date time in reverse chronological order. The HTTP response header `X-Total-Count` contains the total number of reports.",
+        "description": "List all reports for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project. By default, the reports are sorted by date time in reverse chronological order. The HTTP response header `X-Total-Count` contains the total number of reports.",
         "operationId": "proj_reports_get",
         "parameters": [
           {
@@ -6803,7 +6803,7 @@
           "reports"
         ],
         "summary": "View a report",
-        "description": "View a report for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project.",
+        "description": "View a report for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project.",
         "operationId": "proj_report_get",
         "parameters": [
           {
@@ -6966,7 +6966,7 @@
           "testbeds"
         ],
         "summary": "List testbeds for a project",
-        "description": "List all testbeds for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project. By default, the testbeds are sorted in alphabetical order by name. The HTTP response header `X-Total-Count` contains the total number of testbeds.",
+        "description": "List all testbeds for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project. By default, the testbeds are sorted in alphabetical order by name. The HTTP response header `X-Total-Count` contains the total number of testbeds.",
         "operationId": "proj_testbeds_get",
         "parameters": [
           {
@@ -7191,7 +7191,7 @@
           "testbeds"
         ],
         "summary": "View a testbed",
-        "description": "View a testbed for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project.",
+        "description": "View a testbed for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project.",
         "operationId": "proj_testbed_get",
         "parameters": [
           {
@@ -7456,7 +7456,7 @@
           "thresholds"
         ],
         "summary": "List thresholds for a project",
-        "description": "List all thresholds for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project. By default, the thresholds are sorted by creation date time in chronological order. The HTTP response header `X-Total-Count` contains the total number of thresholds.",
+        "description": "List all thresholds for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project. By default, the thresholds are sorted by creation date time in chronological order. The HTTP response header `X-Total-Count` contains the total number of thresholds.",
         "operationId": "proj_thresholds_get",
         "parameters": [
           {
@@ -7692,7 +7692,7 @@
           "thresholds"
         ],
         "summary": "View a threshold",
-        "description": "View a threshold for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project.",
+        "description": "View a threshold for a project. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project.",
         "operationId": "proj_threshold_get",
         "parameters": [
           {


### PR DESCRIPTION
This changeset adds project keys (https://github.com/bencherdev/bencher/pull/823) to all project scoped GET endpoints.