### PR TITLE
Fix `bencher run` handling of `stdin`

### DIFF
--- a/services/cli/src/bencher/sub/run/mod.rs
+++ b/services/cli/src/bencher/sub/run/mod.rs
@@ -146,18 +146,14 @@ impl TryFrom<CliRun> for Run {
         let sub_adapter: SubAdapter = (&cmd).into();
         #[cfg(feature = "plus")]
         let runner = if job.is_some() {
-            // Remote bare metal: only build a local runner if the user
-            // actually provided a local input source. Otherwise skip stdin
-            // entirely so a pure `--image` invocation dispatches directly to
-            // the remote job.
-            if cmd.command.is_none() && cmd.file.is_none() && cmd.file_size.is_none() {
-                None
-            } else {
+            if cmd.has_local_input() {
                 match cmd.try_into() {
                     Ok(runner) => Some(runner),
                     Err(RunError::NoCommand) => None,
                     Err(e) => return Err(e.into()),
                 }
+            } else {
+                None
             }
         } else {
             Some(cmd.try_into()?)

--- a/services/cli/src/bencher/sub/run/mod.rs
+++ b/services/cli/src/bencher/sub/run/mod.rs
@@ -146,10 +146,18 @@ impl TryFrom<CliRun> for Run {
         let sub_adapter: SubAdapter = (&cmd).into();
         #[cfg(feature = "plus")]
         let runner = if job.is_some() {
-            match cmd.try_into() {
-                Ok(runner) => Some(runner),
-                Err(RunError::NoCommand) => None,
-                Err(e) => return Err(e.into()),
+            // Remote bare metal: only build a local runner if the user
+            // actually provided a local input source. Otherwise skip stdin
+            // entirely so a pure `--image` invocation dispatches directly to
+            // the remote job.
+            if cmd.command.is_none() && cmd.file.is_none() && cmd.file_size.is_none() {
+                None
+            } else {
+                match cmd.try_into() {
+                    Ok(runner) => Some(runner),
+                    Err(RunError::NoCommand) => None,
+                    Err(e) => return Err(e.into()),
+                }
             }
         } else {
             Some(cmd.try_into()?)

--- a/services/cli/src/bencher/sub/run/runner/pipe.rs
+++ b/services/cli/src/bencher/sub/run/runner/pipe.rs
@@ -1,4 +1,7 @@
-use std::{fmt, io::BufRead as _};
+use std::{
+    fmt,
+    io::{BufRead as _, IsTerminal as _},
+};
 
 use super::Output;
 
@@ -7,6 +10,12 @@ pub struct Pipe(Output);
 
 impl Pipe {
     pub fn new() -> Option<Self> {
+        // If stdin is an interactive TTY, nothing is being piped — bail
+        // immediately rather than blocking on `read_line` forever.
+        if std::io::stdin().is_terminal() {
+            return None;
+        }
+
         let mut stdin = String::new();
         let mut stdin_handle = std::io::stdin().lock();
         while let Ok(size) = stdin_handle.read_line(&mut stdin) {

--- a/services/cli/src/parser/run.rs
+++ b/services/cli/src/parser/run.rs
@@ -180,6 +180,12 @@ pub struct CliRunCommand {
     pub command: Option<Vec<String>>,
 }
 
+impl CliRunCommand {
+    pub fn has_local_input(&self) -> bool {
+        self.command.is_some() || self.file.is_some() || self.file_size.is_some()
+    }
+}
+
 #[derive(Args, Debug)]
 pub struct CliRunShell {
     /// Shell command path

--- a/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
+++ b/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
@@ -1,3 +1,6 @@
+## Pending `v0.6.5`
+- Fix `bencher run` hanging on stdin when no command is provided, including for `--image` remote bare metal runs (Thank you [@sophie-h](https://github.com/sophie-h))
+
 ## `v0.6.4`
 - Allow a minimum sample size of `1` for the Percentage (`percentage`) Threshold Test (Thank you [@teofr](https://github.com/teofr))
 - **BREAKING CHANGE** Switch runner key format from hex to alphanumeric encoding, reducing key length from 79 to 45 characters; existing runner keys must be rotated

--- a/tasks/test_api/src/task/plus/runner.rs
+++ b/tasks/test_api/src/task/plus/runner.rs
@@ -13,6 +13,7 @@ use crate::task::{is_dev, unwrap_admin_token, unwrap_url, unwrap_user_token};
 const KEY_ARG: &str = "--key";
 const DOCKER_IMAGE: &str = "ghcr.io/bencherdev/bencher:latest";
 const IMAGE_TAG: &str = "runner-test";
+const MOCK_IMAGE_TAG: &str = "runner-test-mock";
 
 #[derive(Debug)]
 pub struct RunnerTest {
@@ -259,6 +260,13 @@ impl RunnerTest {
             Ok(())
         };
 
+        // Run the image-only runner test (no --exec, ENTRYPOINT baked into image)
+        let image_only_result = if project_key_result.is_ok() {
+            run_image_only_runner_test(&self.url, &self.username, &self.token, spec)
+        } else {
+            Ok(())
+        };
+
         // Always kill runner daemons, even if the test failed
         if let Some((mut runner_child, reader_handle)) = runner_child_and_handle {
             let _kill = runner_child.kill();
@@ -274,6 +282,7 @@ impl RunnerTest {
         no_sandbox_result?;
         detach_result?;
         project_key_result?;
+        image_only_result?;
         println!("=== Runner Daemon Test Passed ===");
         Ok(())
     }
@@ -658,6 +667,91 @@ fn run_project_key_runner_test(url: &Url, admin_token: &Jwt, spec: &str) -> anyh
     Ok(())
 }
 
+/// Run the image-only runner smoke test: the image's ENTRYPOINT already
+/// includes the benchmark command (`bencher mock`), so no `--exec` is needed.
+fn run_image_only_runner_test(
+    url: &Url,
+    username: &str,
+    token: &Jwt,
+    spec: &str,
+) -> anyhow::Result<()> {
+    let host = url.as_ref();
+
+    println!("Running image-only runner smoke test against: {host}");
+
+    let registry = if cfg!(target_os = "macos") {
+        let port = registry_host(host)?
+            .rsplit_once(':')
+            .and_then(|(_, p)| p.parse::<u16>().ok())
+            .unwrap_or(bencher_json::BENCHER_API_PORT);
+        let docker_registry = format!("host.docker.internal:{port}");
+        println!("macOS detected, using Docker registry host: {docker_registry}");
+        ensure_hosts_entry()?;
+        ensure_insecure_registry(&docker_registry)?;
+        docker_registry
+    } else {
+        registry_for_api(host)?
+    };
+
+    let local_ref = format!("{registry}/{PROJECT_SLUG}:{MOCK_IMAGE_TAG}");
+
+    println!("Building mock image (ENTRYPOINT includes `mock`)...");
+    docker_build_mock_image(&local_ref)?;
+
+    println!("Logging in to {registry}...");
+    docker_login(&registry, username, token.as_ref())?;
+
+    println!("Pushing mock image to {registry}...");
+    docker_push(&local_ref)?;
+
+    println!("Submitting job via bencher run --image (no --exec)...");
+    let mut cmd = Command::cargo_bin(BENCHER_CMD)?;
+    let image_ref = format!("{PROJECT_SLUG}:{MOCK_IMAGE_TAG}");
+    let args = [
+        "run",
+        HOST_ARG,
+        host,
+        TOKEN_ARG,
+        token.as_ref(),
+        "--project",
+        PROJECT_SLUG,
+        "--branch",
+        "master",
+        "--testbed",
+        "base",
+        "--image",
+        &image_ref,
+        "--spec",
+        spec,
+        "--format",
+        "json",
+        "--quiet",
+        "--job-timeout",
+        "120",
+        "--job-poll-interval",
+        "1",
+    ];
+    cmd.args(args).current_dir(CLI_DIR);
+    let output = cmd.output()?;
+    anyhow::ensure!(
+        output.status.success(),
+        "bencher run (image-only) failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: bencher_json::JsonReport = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(json.project.slug.to_string(), PROJECT_SLUG);
+    #[cfg(feature = "plus")]
+    assert!(
+        json.job.is_some(),
+        "Expected job UUID in image-only report: {json:?}"
+    );
+
+    println!("Image-only runner smoke test passed!");
+    Ok(())
+}
+
 /// Ensure that `host.docker.internal` resolves on the host by adding it to
 /// `/etc/hosts` if not already present. Requires `sudo`.
 fn ensure_hosts_entry() -> anyhow::Result<()> {
@@ -968,6 +1062,46 @@ fn docker_build_local_image(tag: &str) -> anyhow::Result<()> {
 
     drop(std::fs::remove_file(&dockerfile_path));
     anyhow::ensure!(status.success(), "docker build failed");
+    Ok(())
+}
+
+/// Build a Docker image whose ENTRYPOINT runs `bencher mock`.
+///
+/// On macOS, builds from scratch with the local binary.
+/// On Linux, layers on top of the prebuilt Docker image.
+fn docker_build_mock_image(tag: &str) -> anyhow::Result<()> {
+    let dockerfile_path = std::env::temp_dir().join("Dockerfile.bencher-runner-mock-test");
+
+    if cfg!(target_os = "macos") {
+        let bencher_bin = assert_cmd::cargo::cargo_bin(BENCHER_CMD);
+        let build_context = bencher_bin.parent().expect("binary should have parent dir");
+
+        let dockerfile = "FROM scratch\nCOPY bencher /usr/bin/bencher\nENTRYPOINT [\"/usr/bin/bencher\", \"mock\"]\n";
+        std::fs::write(&dockerfile_path, dockerfile)?;
+
+        let status = Command::new("docker")
+            .args(["build", "-t", tag, "-f"])
+            .arg(&dockerfile_path)
+            .arg(build_context)
+            .status()?;
+
+        drop(std::fs::remove_file(&dockerfile_path));
+        anyhow::ensure!(status.success(), "docker build (mock) failed");
+    } else {
+        let dockerfile =
+            format!("FROM {DOCKER_IMAGE}\nENTRYPOINT [\"/usr/bin/bencher\", \"mock\"]\n");
+        std::fs::write(&dockerfile_path, &dockerfile)?;
+
+        let status = Command::new("docker")
+            .args(["build", "-t", tag, "-f"])
+            .arg(&dockerfile_path)
+            .arg(".")
+            .status()?;
+
+        drop(std::fs::remove_file(&dockerfile_path));
+        anyhow::ensure!(status.success(), "docker build (mock) failed");
+    }
+
     Ok(())
 }
 

--- a/tasks/test_api/src/task/test/seed_test.rs
+++ b/tasks/test_api/src/task/test/seed_test.rs
@@ -672,7 +672,7 @@ impl SeedTest {
             .spawn()
             .and_then(|mut child| {
                 use std::io::Write as _;
-                if let Some(ref mut stdin) = child.stdin {
+                if let Some(mut stdin) = child.stdin.take() {
                     stdin.write_all(&mock_output.stdout)?;
                 }
                 child.wait_with_output()

--- a/tasks/test_api/src/task/test/seed_test.rs
+++ b/tasks/test_api/src/task/test/seed_test.rs
@@ -646,6 +646,45 @@ impl SeedTest {
         let _json: bencher_json::JsonReport =
             serde_json::from_slice(&assert.get_output().stdout).unwrap();
 
+        // bencher mock --seed 6 | bencher run --host http://localhost:61016 --key $PROJECT_KEY --project the-computer --format json --quiet
+        let mock_output = Command::cargo_bin(BENCHER_CMD)?
+            .args(["mock", "--seed", PERFECT_SEED])
+            .current_dir(CLI_DIR)
+            .output()?;
+        assert!(mock_output.status.success(), "{mock_output:?}");
+        let output = Command::cargo_bin(BENCHER_CMD)?
+            .args([
+                "run",
+                HOST_ARG,
+                host,
+                KEY_ARG,
+                project_key.as_str(),
+                PROJECT_ARG,
+                PROJECT_SLUG,
+                "--format",
+                "json",
+                "--quiet",
+            ])
+            .current_dir(CLI_DIR)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .and_then(|mut child| {
+                use std::io::Write as _;
+                if let Some(ref mut stdin) = child.stdin {
+                    stdin.write_all(&mock_output.stdout)?;
+                }
+                child.wait_with_output()
+            })?;
+        assert!(
+            output.status.success(),
+            "piped bencher run failed:\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let _json: bencher_json::JsonReport = serde_json::from_slice(&output.stdout).unwrap();
+
         // cargo run -- threshold ls --host http://localhost:61016 the-computer
         let mut cmd = Command::cargo_bin(BENCHER_CMD)?;
         cmd.args(["threshold", "ls", HOST_ARG, host, PROJECT_SLUG])


### PR DESCRIPTION
- Fix `bencher run` hanging on `stdin` when no command is provided by guarding `Pipe::new()` with an `IsTerminal` check
- For `--image` remote bare metal runs, skip local runner dispatch entirely when no command, `--file`, or `--file-size` is provided so a pure `--image` invocation goes straight to the remote job                                                                                                                                          
- Add piped `stdin` `bencher run` test to the seed test suite                                                                                                           
- Add image-only runner smoke test (`bencher run --image` without `--exec`) that uses a Docker image with `bencher mock` baked into the `ENTRYPOINT`                    
           