### PR TITLE
Add project based API rate limiting

### DIFF
--- a/lib/api_projects/src/alerts.rs
+++ b/lib/api_projects/src/alerts.rs
@@ -116,14 +116,11 @@ async fn get_ls_inner(
     let query_project = QueryProject::is_allowed_actor(
         actor_conn!(context, api_actor),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         api_actor,
     )?;
-
-    #[cfg(feature = "plus")]
-    if api_actor.is_auth() {
-        context.rate_limiting.project_request(query_project.uuid)?;
-    }
 
     let alerts = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
@@ -352,14 +349,11 @@ async fn get_one_inner(
     let query_project = QueryProject::is_allowed_actor(
         actor_conn!(context, api_actor),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         api_actor,
     )?;
-
-    #[cfg(feature = "plus")]
-    if api_actor.is_auth() {
-        context.rate_limiting.project_request(query_project.uuid)?;
-    }
 
     actor_conn!(context, api_actor, |conn| {
         QueryAlert::from_uuid(conn, query_project.id, path_params.alert)?.into_json(conn)
@@ -403,13 +397,12 @@ async fn patch_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Edit,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_alert =
         QueryAlert::from_uuid(auth_conn!(context), query_project.id, path_params.alert)?;

--- a/lib/api_projects/src/alerts.rs
+++ b/lib/api_projects/src/alerts.rs
@@ -120,6 +120,11 @@ async fn get_ls_inner(
         api_actor,
     )?;
 
+    #[cfg(feature = "plus")]
+    if api_actor.is_auth() {
+        context.rate_limiting.project_request(query_project.uuid)?;
+    }
+
     let alerts = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
         .limit(pagination_params.limit())
@@ -351,6 +356,11 @@ async fn get_one_inner(
         api_actor,
     )?;
 
+    #[cfg(feature = "plus")]
+    if api_actor.is_auth() {
+        context.rate_limiting.project_request(query_project.uuid)?;
+    }
+
     actor_conn!(context, api_actor, |conn| {
         QueryAlert::from_uuid(conn, query_project.id, path_params.alert)?.into_json(conn)
     })
@@ -397,6 +407,9 @@ async fn patch_inner(
         auth_user,
         Permission::Edit,
     )?;
+
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_alert =
         QueryAlert::from_uuid(auth_conn!(context), query_project.id, path_params.alert)?;

--- a/lib/api_projects/src/allowed.rs
+++ b/lib/api_projects/src/allowed.rs
@@ -52,20 +52,17 @@ async fn get_inner(
     path_params: ProjAllowedParams,
     auth_user: &AuthUser,
 ) -> Result<JsonAllowed, HttpError> {
-    let allowed = if let Ok(query_project) = QueryProject::is_allowed(
+    match QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::from(path_params.permission).into(),
     ) {
-        #[cfg(feature = "plus")]
-        context.rate_limiting.project_request(query_project.uuid)?;
-        #[cfg(not(feature = "plus"))]
-        drop(query_project);
-        true
-    } else {
-        false
-    };
-    Ok(JsonAllowed { allowed })
+        Ok(_) => Ok(JsonAllowed { allowed: true }),
+        Err(e) if e.status_code == http::StatusCode::TOO_MANY_REQUESTS => Err(e),
+        Err(_) => Ok(JsonAllowed { allowed: false }),
+    }
 }

--- a/lib/api_projects/src/allowed.rs
+++ b/lib/api_projects/src/allowed.rs
@@ -52,14 +52,20 @@ async fn get_inner(
     path_params: ProjAllowedParams,
     auth_user: &AuthUser,
 ) -> Result<JsonAllowed, HttpError> {
-    Ok(JsonAllowed {
-        allowed: QueryProject::is_allowed(
-            auth_conn!(context),
-            &context.rbac,
-            &path_params.project,
-            auth_user,
-            Permission::from(path_params.permission).into(),
-        )
-        .is_ok(),
-    })
+    let allowed = if let Ok(query_project) = QueryProject::is_allowed(
+        auth_conn!(context),
+        &context.rbac,
+        &path_params.project,
+        auth_user,
+        Permission::from(path_params.permission).into(),
+    ) {
+        #[cfg(feature = "plus")]
+        context.rate_limiting.project_request(query_project.uuid)?;
+        #[cfg(not(feature = "plus"))]
+        drop(query_project);
+        true
+    } else {
+        false
+    };
+    Ok(JsonAllowed { allowed })
 }

--- a/lib/api_projects/src/benchmarks.rs
+++ b/lib/api_projects/src/benchmarks.rs
@@ -118,14 +118,11 @@ async fn get_ls_inner(
     let query_project = QueryProject::is_allowed_actor(
         actor_conn!(context, api_actor),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         api_actor,
     )?;
-
-    #[cfg(feature = "plus")]
-    if api_actor.is_auth() {
-        context.rate_limiting.project_request(query_project.uuid)?;
-    }
 
     let benchmarks = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
@@ -223,13 +220,12 @@ async fn post_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Create,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     QueryBenchmark::create(context, query_project.id, json_benchmark)
         .await
@@ -290,13 +286,14 @@ async fn get_one_inner(
     api_actor: &ApiActor,
 ) -> Result<JsonBenchmark, HttpError> {
     actor_conn!(context, api_actor, |conn| {
-        let query_project =
-            QueryProject::is_allowed_actor(conn, &context.rbac, &path_params.project, api_actor)?;
-
-        #[cfg(feature = "plus")]
-        if api_actor.is_auth() {
-            context.rate_limiting.project_request(query_project.uuid)?;
-        }
+        let query_project = QueryProject::is_allowed_actor(
+            conn,
+            &context.rbac,
+            #[cfg(feature = "plus")]
+            &context.rate_limiting,
+            &path_params.project,
+            api_actor,
+        )?;
 
         QueryBenchmark::belonging_to(&query_project)
             .filter(QueryBenchmark::eq_resource_id(&path_params.benchmark))
@@ -345,13 +342,12 @@ async fn patch_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Edit,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_benchmark = QueryBenchmark::from_resource_id(
         auth_conn!(context),
@@ -401,13 +397,12 @@ async fn delete_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Delete,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_benchmark = QueryBenchmark::from_resource_id(
         auth_conn!(context),

--- a/lib/api_projects/src/benchmarks.rs
+++ b/lib/api_projects/src/benchmarks.rs
@@ -122,6 +122,11 @@ async fn get_ls_inner(
         api_actor,
     )?;
 
+    #[cfg(feature = "plus")]
+    if api_actor.is_auth() {
+        context.rate_limiting.project_request(query_project.uuid)?;
+    }
+
     let benchmarks = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
         .limit(pagination_params.limit())
@@ -223,6 +228,9 @@ async fn post_inner(
         Permission::Create,
     )?;
 
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
+
     QueryBenchmark::create(context, query_project.id, json_benchmark)
         .await
         .map(|benchmark| benchmark.into_json_for_project(&query_project))
@@ -285,6 +293,11 @@ async fn get_one_inner(
         let query_project =
             QueryProject::is_allowed_actor(conn, &context.rbac, &path_params.project, api_actor)?;
 
+        #[cfg(feature = "plus")]
+        if api_actor.is_auth() {
+            context.rate_limiting.project_request(query_project.uuid)?;
+        }
+
         QueryBenchmark::belonging_to(&query_project)
             .filter(QueryBenchmark::eq_resource_id(&path_params.benchmark))
             .first::<QueryBenchmark>(conn)
@@ -336,6 +349,9 @@ async fn patch_inner(
         auth_user,
         Permission::Edit,
     )?;
+
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_benchmark = QueryBenchmark::from_resource_id(
         auth_conn!(context),
@@ -389,6 +405,9 @@ async fn delete_inner(
         auth_user,
         Permission::Delete,
     )?;
+
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_benchmark = QueryBenchmark::from_resource_id(
         auth_conn!(context),

--- a/lib/api_projects/src/branches.rs
+++ b/lib/api_projects/src/branches.rs
@@ -125,6 +125,11 @@ async fn get_ls_inner(
         api_actor,
     )?;
 
+    #[cfg(feature = "plus")]
+    if api_actor.is_auth() {
+        context.rate_limiting.project_request(query_project.uuid)?;
+    }
+
     let branches = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
         .limit(pagination_params.limit())
@@ -243,6 +248,9 @@ async fn post_inner(
         Permission::Create,
     )?;
 
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
+
     QueryBranch::create(log, context, query_project.id, json_branch)
         .await?
         .into_json_for_project(auth_conn!(context), &query_project)
@@ -323,6 +331,11 @@ async fn get_one_inner(
         let query_project =
             QueryProject::is_allowed_actor(conn, &context.rbac, &path_params.project, api_actor)?;
 
+        #[cfg(feature = "plus")]
+        if api_actor.is_auth() {
+            context.rate_limiting.project_request(query_project.uuid)?;
+        }
+
         let query_branch = QueryBranch::belonging_to(&query_project)
             .filter(QueryBranch::eq_resource_id(&path_params.branch))
             .first::<QueryBranch>(conn)
@@ -393,6 +406,9 @@ async fn patch_inner(
         Permission::Edit,
     )?;
 
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
+
     let query_branch =
         QueryBranch::from_resource_id(auth_conn!(context), query_project.id, &path_params.branch)?;
 
@@ -454,6 +470,9 @@ async fn delete_inner(
         auth_user,
         Permission::Delete,
     )?;
+
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_branch =
         QueryBranch::from_resource_id(auth_conn!(context), query_project.id, &path_params.branch)?;

--- a/lib/api_projects/src/branches.rs
+++ b/lib/api_projects/src/branches.rs
@@ -121,14 +121,11 @@ async fn get_ls_inner(
     let query_project = QueryProject::is_allowed_actor(
         actor_conn!(context, api_actor),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         api_actor,
     )?;
-
-    #[cfg(feature = "plus")]
-    if api_actor.is_auth() {
-        context.rate_limiting.project_request(query_project.uuid)?;
-    }
 
     let branches = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
@@ -243,13 +240,12 @@ async fn post_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Create,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     QueryBranch::create(log, context, query_project.id, json_branch)
         .await?
@@ -328,13 +324,14 @@ async fn get_one_inner(
     api_actor: &ApiActor,
 ) -> Result<JsonBranch, HttpError> {
     actor_conn!(context, api_actor, |conn| {
-        let query_project =
-            QueryProject::is_allowed_actor(conn, &context.rbac, &path_params.project, api_actor)?;
-
-        #[cfg(feature = "plus")]
-        if api_actor.is_auth() {
-            context.rate_limiting.project_request(query_project.uuid)?;
-        }
+        let query_project = QueryProject::is_allowed_actor(
+            conn,
+            &context.rbac,
+            #[cfg(feature = "plus")]
+            &context.rate_limiting,
+            &path_params.project,
+            api_actor,
+        )?;
 
         let query_branch = QueryBranch::belonging_to(&query_project)
             .filter(QueryBranch::eq_resource_id(&path_params.branch))
@@ -401,13 +398,12 @@ async fn patch_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Edit,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_branch =
         QueryBranch::from_resource_id(auth_conn!(context), query_project.id, &path_params.branch)?;
@@ -466,13 +462,12 @@ async fn delete_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Delete,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_branch =
         QueryBranch::from_resource_id(auth_conn!(context), query_project.id, &path_params.branch)?;

--- a/lib/api_projects/src/jobs.rs
+++ b/lib/api_projects/src/jobs.rs
@@ -102,13 +102,10 @@ async fn get_ls_inner(
     let query_project = QueryProject::is_allowed_actor(
         actor_conn!(context, api_actor),
         &context.rbac,
+        &context.rate_limiting,
         &path_params.project,
         api_actor,
     )?;
-
-    if api_actor.is_auth() {
-        context.rate_limiting.project_request(query_project.uuid)?;
-    }
 
     let jobs = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
@@ -227,13 +224,10 @@ async fn get_one_inner(
     let query_project = QueryProject::is_allowed_actor(
         actor_conn!(context, api_actor),
         &context.rbac,
+        &context.rate_limiting,
         &path_params.project,
         api_actor,
     )?;
-
-    if api_actor.is_auth() {
-        context.rate_limiting.project_request(query_project.uuid)?;
-    }
 
     let job_uuid = path_params.job;
 

--- a/lib/api_projects/src/jobs.rs
+++ b/lib/api_projects/src/jobs.rs
@@ -106,6 +106,10 @@ async fn get_ls_inner(
         api_actor,
     )?;
 
+    if api_actor.is_auth() {
+        context.rate_limiting.project_request(query_project.uuid)?;
+    }
+
     let jobs = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
         .limit(pagination_params.limit())
@@ -226,6 +230,10 @@ async fn get_one_inner(
         &path_params.project,
         api_actor,
     )?;
+
+    if api_actor.is_auth() {
+        context.rate_limiting.project_request(query_project.uuid)?;
+    }
 
     let job_uuid = path_params.job;
 

--- a/lib/api_projects/src/keys.rs
+++ b/lib/api_projects/src/keys.rs
@@ -113,13 +113,12 @@ async fn get_ls_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Manage,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     let keys = get_ls_query(&pagination_params, &query_params, query_project.id)
         .offset(pagination_params.offset())
@@ -230,13 +229,13 @@ async fn post_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Manage,
     )?;
 
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
     #[cfg(feature = "plus")]
     context
         .rate_limiting
@@ -301,13 +300,12 @@ async fn get_one_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Manage,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     auth_conn!(context, |conn| {
         QueryProjectKey::get_project_key(conn, query_project.id, path_params.key)?.into_json(conn)
@@ -349,13 +347,12 @@ async fn patch_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Manage,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_key =
         QueryProjectKey::get_project_key(auth_conn!(context), query_project.id, path_params.key)?;
@@ -405,13 +402,12 @@ async fn delete_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Manage,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_key =
         QueryProjectKey::get_project_key(auth_conn!(context), query_project.id, path_params.key)?;

--- a/lib/api_projects/src/keys.rs
+++ b/lib/api_projects/src/keys.rs
@@ -118,6 +118,9 @@ async fn get_ls_inner(
         Permission::Manage,
     )?;
 
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
+
     let keys = get_ls_query(&pagination_params, &query_params, query_project.id)
         .offset(pagination_params.offset())
         .limit(pagination_params.limit())
@@ -233,6 +236,8 @@ async fn post_inner(
     )?;
 
     #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
+    #[cfg(feature = "plus")]
     context
         .rate_limiting
         .create_credential(auth_user.user.uuid)?;
@@ -301,6 +306,9 @@ async fn get_one_inner(
         Permission::Manage,
     )?;
 
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
+
     auth_conn!(context, |conn| {
         QueryProjectKey::get_project_key(conn, query_project.id, path_params.key)?.into_json(conn)
     })
@@ -345,6 +353,9 @@ async fn patch_inner(
         auth_user,
         Permission::Manage,
     )?;
+
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_key =
         QueryProjectKey::get_project_key(auth_conn!(context), query_project.id, path_params.key)?;
@@ -398,6 +409,9 @@ async fn delete_inner(
         auth_user,
         Permission::Manage,
     )?;
+
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_key =
         QueryProjectKey::get_project_key(auth_conn!(context), query_project.id, path_params.key)?;

--- a/lib/api_projects/src/measures.rs
+++ b/lib/api_projects/src/measures.rs
@@ -117,14 +117,11 @@ async fn get_ls_inner(
     let query_project = QueryProject::is_allowed_actor(
         actor_conn!(context, api_actor),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         api_actor,
     )?;
-
-    #[cfg(feature = "plus")]
-    if api_actor.is_auth() {
-        context.rate_limiting.project_request(query_project.uuid)?;
-    }
 
     let measures = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
@@ -222,13 +219,12 @@ async fn post_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Create,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     QueryMeasure::create(context, query_project.id, json_measure)
         .await
@@ -289,13 +285,14 @@ async fn get_one_inner(
     api_actor: &ApiActor,
 ) -> Result<JsonMeasure, HttpError> {
     actor_conn!(context, api_actor, |conn| {
-        let query_project =
-            QueryProject::is_allowed_actor(conn, &context.rbac, &path_params.project, api_actor)?;
-
-        #[cfg(feature = "plus")]
-        if api_actor.is_auth() {
-            context.rate_limiting.project_request(query_project.uuid)?;
-        }
+        let query_project = QueryProject::is_allowed_actor(
+            conn,
+            &context.rbac,
+            #[cfg(feature = "plus")]
+            &context.rate_limiting,
+            &path_params.project,
+            api_actor,
+        )?;
 
         QueryMeasure::belonging_to(&query_project)
             .filter(QueryMeasure::eq_resource_id(&path_params.measure))
@@ -344,13 +341,12 @@ async fn patch_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Edit,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_measure = QueryMeasure::from_resource_id(
         auth_conn!(context),
@@ -400,13 +396,12 @@ async fn delete_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Delete,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_measure = QueryMeasure::from_resource_id(
         auth_conn!(context),

--- a/lib/api_projects/src/measures.rs
+++ b/lib/api_projects/src/measures.rs
@@ -121,6 +121,11 @@ async fn get_ls_inner(
         api_actor,
     )?;
 
+    #[cfg(feature = "plus")]
+    if api_actor.is_auth() {
+        context.rate_limiting.project_request(query_project.uuid)?;
+    }
+
     let measures = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
         .limit(pagination_params.limit())
@@ -222,6 +227,9 @@ async fn post_inner(
         Permission::Create,
     )?;
 
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
+
     QueryMeasure::create(context, query_project.id, json_measure)
         .await
         .map(|measure| measure.into_json_for_project(&query_project))
@@ -284,6 +292,11 @@ async fn get_one_inner(
         let query_project =
             QueryProject::is_allowed_actor(conn, &context.rbac, &path_params.project, api_actor)?;
 
+        #[cfg(feature = "plus")]
+        if api_actor.is_auth() {
+            context.rate_limiting.project_request(query_project.uuid)?;
+        }
+
         QueryMeasure::belonging_to(&query_project)
             .filter(QueryMeasure::eq_resource_id(&path_params.measure))
             .first::<QueryMeasure>(conn)
@@ -335,6 +348,9 @@ async fn patch_inner(
         auth_user,
         Permission::Edit,
     )?;
+
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_measure = QueryMeasure::from_resource_id(
         auth_conn!(context),
@@ -388,6 +404,9 @@ async fn delete_inner(
         auth_user,
         Permission::Delete,
     )?;
+
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_measure = QueryMeasure::from_resource_id(
         auth_conn!(context),

--- a/lib/api_projects/src/metrics.rs
+++ b/lib/api_projects/src/metrics.rs
@@ -89,14 +89,11 @@ async fn get_one_inner(
     let query_project = QueryProject::is_allowed_actor(
         actor_conn!(context, api_actor),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         api_actor,
     )?;
-
-    #[cfg(feature = "plus")]
-    if api_actor.is_auth() {
-        context.rate_limiting.project_request(query_project.uuid)?;
-    }
 
     actor_conn!(context, api_actor, |conn| {
         view::metric_boundary::table

--- a/lib/api_projects/src/metrics.rs
+++ b/lib/api_projects/src/metrics.rs
@@ -93,6 +93,11 @@ async fn get_one_inner(
         api_actor,
     )?;
 
+    #[cfg(feature = "plus")]
+    if api_actor.is_auth() {
+        context.rate_limiting.project_request(query_project.uuid)?;
+    }
+
     actor_conn!(context, api_actor, |conn| {
         view::metric_boundary::table
         .inner_join(

--- a/lib/api_projects/src/perf/mod.rs
+++ b/lib/api_projects/src/perf/mod.rs
@@ -121,14 +121,11 @@ async fn get_inner(
     let project = QueryProject::is_allowed_actor(
         actor_conn!(context, api_actor),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         api_actor,
     )?;
-
-    #[cfg(feature = "plus")]
-    if api_actor.is_auth() {
-        context.rate_limiting.project_request(project.uuid)?;
-    }
 
     let JsonPerfQuery {
         branches,

--- a/lib/api_projects/src/perf/mod.rs
+++ b/lib/api_projects/src/perf/mod.rs
@@ -125,6 +125,11 @@ async fn get_inner(
         api_actor,
     )?;
 
+    #[cfg(feature = "plus")]
+    if api_actor.is_auth() {
+        context.rate_limiting.project_request(project.uuid)?;
+    }
+
     let JsonPerfQuery {
         branches,
         heads,

--- a/lib/api_projects/src/plots.rs
+++ b/lib/api_projects/src/plots.rs
@@ -117,14 +117,11 @@ async fn get_ls_inner(
     let query_project = QueryProject::is_allowed_actor(
         actor_conn!(context, api_actor),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         api_actor,
     )?;
-
-    #[cfg(feature = "plus")]
-    if api_actor.is_auth() {
-        context.rate_limiting.project_request(query_project.uuid)?;
-    }
 
     let plots = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
@@ -236,13 +233,13 @@ async fn post_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Create,
     )?;
 
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
     #[cfg(feature = "plus")]
     InsertPlot::rate_limit(context, query_project.id).await?;
     let query_plot = InsertPlot::from_json(context, &query_project, json_plot).await?;
@@ -306,14 +303,11 @@ async fn get_one_inner(
     let query_project = QueryProject::is_allowed_actor(
         actor_conn!(context, api_actor),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         api_actor,
     )?;
-
-    #[cfg(feature = "plus")]
-    if api_actor.is_auth() {
-        context.rate_limiting.project_request(query_project.uuid)?;
-    }
 
     actor_conn!(context, api_actor, |conn| {
         QueryPlot::get_with_uuid(conn, &query_project, path_params.plot)
@@ -358,13 +352,12 @@ async fn patch_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Edit,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_plot =
         QueryPlot::get_with_uuid(auth_conn!(context), &query_project, path_params.plot)?;
@@ -410,13 +403,12 @@ async fn delete_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Delete,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_plot =
         QueryPlot::get_with_uuid(auth_conn!(context), &query_project, path_params.plot)?;

--- a/lib/api_projects/src/plots.rs
+++ b/lib/api_projects/src/plots.rs
@@ -121,6 +121,11 @@ async fn get_ls_inner(
         api_actor,
     )?;
 
+    #[cfg(feature = "plus")]
+    if api_actor.is_auth() {
+        context.rate_limiting.project_request(query_project.uuid)?;
+    }
+
     let plots = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
         .limit(pagination_params.limit())
@@ -237,6 +242,8 @@ async fn post_inner(
     )?;
 
     #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
+    #[cfg(feature = "plus")]
     InsertPlot::rate_limit(context, query_project.id).await?;
     let query_plot = InsertPlot::from_json(context, &query_project, json_plot).await?;
 
@@ -303,6 +310,11 @@ async fn get_one_inner(
         api_actor,
     )?;
 
+    #[cfg(feature = "plus")]
+    if api_actor.is_auth() {
+        context.rate_limiting.project_request(query_project.uuid)?;
+    }
+
     actor_conn!(context, api_actor, |conn| {
         QueryPlot::get_with_uuid(conn, &query_project, path_params.plot)
             .and_then(|plot| plot.into_json_for_project(conn, &query_project))
@@ -350,6 +362,9 @@ async fn patch_inner(
         auth_user,
         Permission::Edit,
     )?;
+
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_plot =
         QueryPlot::get_with_uuid(auth_conn!(context), &query_project, path_params.plot)?;
@@ -399,6 +414,9 @@ async fn delete_inner(
         auth_user,
         Permission::Delete,
     )?;
+
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_plot =
         QueryPlot::get_with_uuid(auth_conn!(context), &query_project, path_params.plot)?;

--- a/lib/api_projects/src/projects.rs
+++ b/lib/api_projects/src/projects.rs
@@ -255,8 +255,13 @@ async fn get_one_inner(
     api_actor: &ApiActor,
 ) -> Result<JsonProject, HttpError> {
     actor_conn!(context, api_actor, |conn| {
-        QueryProject::is_allowed_actor(conn, &context.rbac, &path_params.project, api_actor)?
-            .into_json(conn)
+        let query_project =
+            QueryProject::is_allowed_actor(conn, &context.rbac, &path_params.project, api_actor)?;
+        #[cfg(feature = "plus")]
+        if api_actor.is_auth() {
+            context.rate_limiting.project_request(query_project.uuid)?;
+        }
+        query_project.into_json(conn)
     })
 }
 
@@ -304,6 +309,9 @@ async fn patch_inner(
         &auth_user,
         Permission::Edit,
     )?;
+
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
 
     // Check project visibility
     if let Some(visibility) = json_project.visibility() {
@@ -397,6 +405,8 @@ async fn delete_inner(
             .filter(QueryProject::eq_resource_id(&path_params.project))
             .first::<QueryProject>(auth_conn!(context))
             .map_err(resource_not_found_err!(Project, &path_params.project))?;
+        #[cfg(feature = "plus")]
+        context.rate_limiting.project_request(query_project.uuid)?;
         diesel::delete(schema::project::table.filter(schema::project::id.eq(query_project.id)))
             .execute(write_conn!(context))
             .map_err(resource_conflict_err!(Project, query_project))?;
@@ -412,6 +422,9 @@ async fn delete_inner(
             auth_user,
             Permission::Delete,
         )?;
+
+        #[cfg(feature = "plus")]
+        context.rate_limiting.project_request(query_project.uuid)?;
 
         // Soft delete: replace slug/name with valid deleted sentinels to free UNIQUE constraints
         let now = context.clock.now();

--- a/lib/api_projects/src/projects.rs
+++ b/lib/api_projects/src/projects.rs
@@ -406,8 +406,6 @@ async fn delete_inner(
             .filter(QueryProject::eq_resource_id(&path_params.project))
             .first::<QueryProject>(auth_conn!(context))
             .map_err(resource_not_found_err!(Project, &path_params.project))?;
-        #[cfg(feature = "plus")]
-        context.rate_limiting.project_request(query_project.uuid)?;
         diesel::delete(schema::project::table.filter(schema::project::id.eq(query_project.id)))
             .execute(write_conn!(context))
             .map_err(resource_conflict_err!(Project, query_project))?;

--- a/lib/api_projects/src/projects.rs
+++ b/lib/api_projects/src/projects.rs
@@ -255,13 +255,15 @@ async fn get_one_inner(
     api_actor: &ApiActor,
 ) -> Result<JsonProject, HttpError> {
     actor_conn!(context, api_actor, |conn| {
-        let query_project =
-            QueryProject::is_allowed_actor(conn, &context.rbac, &path_params.project, api_actor)?;
-        #[cfg(feature = "plus")]
-        if api_actor.is_auth() {
-            context.rate_limiting.project_request(query_project.uuid)?;
-        }
-        query_project.into_json(conn)
+        QueryProject::is_allowed_actor(
+            conn,
+            &context.rbac,
+            #[cfg(feature = "plus")]
+            &context.rate_limiting,
+            &path_params.project,
+            api_actor,
+        )?
+        .into_json(conn)
     })
 }
 
@@ -305,13 +307,12 @@ async fn patch_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         &auth_user,
         Permission::Edit,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     // Check project visibility
     if let Some(visibility) = json_project.visibility() {
@@ -418,13 +419,12 @@ async fn delete_inner(
         let query_project = QueryProject::is_allowed(
             auth_conn!(context),
             &context.rbac,
+            #[cfg(feature = "plus")]
+            &context.rate_limiting,
             &path_params.project,
             auth_user,
             Permission::Delete,
         )?;
-
-        #[cfg(feature = "plus")]
-        context.rate_limiting.project_request(query_project.uuid)?;
 
         // Soft delete: replace slug/name with valid deleted sentinels to free UNIQUE constraints
         let now = context.clock.now();

--- a/lib/api_projects/src/reports.rs
+++ b/lib/api_projects/src/reports.rs
@@ -134,6 +134,11 @@ async fn get_ls_inner(
         api_actor,
     )?;
 
+    #[cfg(feature = "plus")]
+    if api_actor.is_auth() {
+        context.rate_limiting.project_request(query_project.uuid)?;
+    }
+
     let reports = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
         .limit(pagination_params.limit())
@@ -307,6 +312,10 @@ async fn post_inner(
         &auth_user,
         Permission::Create,
     )?;
+
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
+
     let new_run_report = NewRunReport {
         report: json_report,
         idempotency_key: None,
@@ -397,6 +406,11 @@ async fn get_one_inner(
         api_actor,
     )?;
 
+    #[cfg(feature = "plus")]
+    if api_actor.is_auth() {
+        context.rate_limiting.project_request(query_project.uuid)?;
+    }
+
     actor_conn!(context, api_actor, |conn| {
         QueryReport::belonging_to(&query_project)
             .filter(schema::report::uuid.eq(path_params.report.to_string()))
@@ -443,6 +457,9 @@ async fn delete_inner(
         auth_user,
         Permission::Delete,
     )?;
+
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
 
     let (report_id, version_id) = QueryReport::belonging_to(&query_project)
         .filter(schema::report::uuid.eq(path_params.report.to_string()))

--- a/lib/api_projects/src/reports.rs
+++ b/lib/api_projects/src/reports.rs
@@ -130,14 +130,11 @@ async fn get_ls_inner(
     let query_project = QueryProject::is_allowed_actor(
         actor_conn!(context, api_actor),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         api_actor,
     )?;
-
-    #[cfg(feature = "plus")]
-    if api_actor.is_auth() {
-        context.rate_limiting.project_request(query_project.uuid)?;
-    }
 
     let reports = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
@@ -308,13 +305,12 @@ async fn post_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         &auth_user,
         Permission::Create,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     let new_run_report = NewRunReport {
         report: json_report,
@@ -402,14 +398,11 @@ async fn get_one_inner(
     let query_project = QueryProject::is_allowed_actor(
         actor_conn!(context, api_actor),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         api_actor,
     )?;
-
-    #[cfg(feature = "plus")]
-    if api_actor.is_auth() {
-        context.rate_limiting.project_request(query_project.uuid)?;
-    }
 
     actor_conn!(context, api_actor, |conn| {
         QueryReport::belonging_to(&query_project)
@@ -453,13 +446,12 @@ async fn delete_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Delete,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     let (report_id, version_id) = QueryReport::belonging_to(&query_project)
         .filter(schema::report::uuid.eq(path_params.report.to_string()))

--- a/lib/api_projects/src/testbeds.rs
+++ b/lib/api_projects/src/testbeds.rs
@@ -125,6 +125,11 @@ async fn get_ls_inner(
         api_actor,
     )?;
 
+    #[cfg(feature = "plus")]
+    if api_actor.is_auth() {
+        context.rate_limiting.project_request(query_project.uuid)?;
+    }
+
     actor_conn!(context, api_actor, |conn| {
         let testbeds = get_ls_query(&query_project, &pagination_params, &query_params)
             .offset(pagination_params.offset())
@@ -228,6 +233,9 @@ async fn post_inner(
         Permission::Create,
     )?;
 
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
+
     let testbed = QueryTestbed::create(context, query_project.id, json_testbed).await?;
     testbed.into_json_for_project(auth_conn!(context), &query_project)
 }
@@ -311,6 +319,11 @@ async fn get_one_inner(
         api_actor,
     )?;
 
+    #[cfg(feature = "plus")]
+    if api_actor.is_auth() {
+        context.rate_limiting.project_request(query_project.uuid)?;
+    }
+
     actor_conn!(context, api_actor, |conn| {
         let testbed = QueryTestbed::belonging_to(&query_project)
             .filter(QueryTestbed::eq_resource_id(&path_params.testbed))
@@ -374,6 +387,9 @@ async fn patch_inner(
         Permission::Edit,
     )?;
 
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
+
     let now = context.clock.now();
     let (query_testbed, update_testbed) = auth_conn!(context, |conn| {
         let query_testbed =
@@ -429,6 +445,9 @@ async fn delete_inner(
         auth_user,
         Permission::Delete,
     )?;
+
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_testbed = QueryTestbed::from_resource_id(
         auth_conn!(context),

--- a/lib/api_projects/src/testbeds.rs
+++ b/lib/api_projects/src/testbeds.rs
@@ -121,14 +121,11 @@ async fn get_ls_inner(
     let query_project = QueryProject::is_allowed_actor(
         actor_conn!(context, api_actor),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         api_actor,
     )?;
-
-    #[cfg(feature = "plus")]
-    if api_actor.is_auth() {
-        context.rate_limiting.project_request(query_project.uuid)?;
-    }
 
     actor_conn!(context, api_actor, |conn| {
         let testbeds = get_ls_query(&query_project, &pagination_params, &query_params)
@@ -228,13 +225,12 @@ async fn post_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Create,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     let testbed = QueryTestbed::create(context, query_project.id, json_testbed).await?;
     testbed.into_json_for_project(auth_conn!(context), &query_project)
@@ -315,14 +311,11 @@ async fn get_one_inner(
     let query_project = QueryProject::is_allowed_actor(
         actor_conn!(context, api_actor),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         api_actor,
     )?;
-
-    #[cfg(feature = "plus")]
-    if api_actor.is_auth() {
-        context.rate_limiting.project_request(query_project.uuid)?;
-    }
 
     actor_conn!(context, api_actor, |conn| {
         let testbed = QueryTestbed::belonging_to(&query_project)
@@ -382,13 +375,12 @@ async fn patch_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Edit,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     let now = context.clock.now();
     let (query_testbed, update_testbed) = auth_conn!(context, |conn| {
@@ -441,13 +433,12 @@ async fn delete_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Delete,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_testbed = QueryTestbed::from_resource_id(
         auth_conn!(context),

--- a/lib/api_projects/src/thresholds.rs
+++ b/lib/api_projects/src/thresholds.rs
@@ -130,6 +130,11 @@ async fn get_ls_inner(
         api_actor,
     )?;
 
+    #[cfg(feature = "plus")]
+    if api_actor.is_auth() {
+        context.rate_limiting.project_request(query_project.uuid)?;
+    }
+
     let thresholds = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
         .limit(pagination_params.limit())
@@ -284,6 +289,9 @@ async fn post_inner(
         Permission::Create,
     )?;
 
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
+
     let project_id = query_project.id;
     // Verify that the branch, testbed, and measure are part of the same project
     let branch_id =
@@ -389,6 +397,11 @@ async fn get_one_inner(
         let query_project =
             QueryProject::is_allowed_actor(conn, &context.rbac, &path_params.project, api_actor)?;
 
+        #[cfg(feature = "plus")]
+        if api_actor.is_auth() {
+            context.rate_limiting.project_request(query_project.uuid)?;
+        }
+
         let query_threshold =
             QueryThreshold::get_with_uuid(conn, &query_project, path_params.threshold)?;
 
@@ -468,6 +481,9 @@ async fn put_inner(
         Permission::Edit,
     )?;
 
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
+
     // Get the current threshold
     let query_threshold =
         QueryThreshold::get_with_uuid(auth_conn!(context), &query_project, path_params.threshold)?;
@@ -516,6 +532,9 @@ async fn delete_inner(
         auth_user,
         Permission::Delete,
     )?;
+
+    #[cfg(feature = "plus")]
+    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_threshold =
         QueryThreshold::get_with_uuid(auth_conn!(context), &query_project, path_params.threshold)?;

--- a/lib/api_projects/src/thresholds.rs
+++ b/lib/api_projects/src/thresholds.rs
@@ -126,14 +126,11 @@ async fn get_ls_inner(
     let query_project = QueryProject::is_allowed_actor(
         actor_conn!(context, api_actor),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         api_actor,
     )?;
-
-    #[cfg(feature = "plus")]
-    if api_actor.is_auth() {
-        context.rate_limiting.project_request(query_project.uuid)?;
-    }
 
     let thresholds = get_ls_query(&query_project, &pagination_params, &query_params)
         .offset(pagination_params.offset())
@@ -284,13 +281,12 @@ async fn post_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Create,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     let project_id = query_project.id;
     // Verify that the branch, testbed, and measure are part of the same project
@@ -394,13 +390,14 @@ async fn get_one_inner(
     api_actor: &ApiActor,
 ) -> Result<JsonThreshold, HttpError> {
     actor_conn!(context, api_actor, |conn| {
-        let query_project =
-            QueryProject::is_allowed_actor(conn, &context.rbac, &path_params.project, api_actor)?;
-
-        #[cfg(feature = "plus")]
-        if api_actor.is_auth() {
-            context.rate_limiting.project_request(query_project.uuid)?;
-        }
+        let query_project = QueryProject::is_allowed_actor(
+            conn,
+            &context.rbac,
+            #[cfg(feature = "plus")]
+            &context.rate_limiting,
+            &path_params.project,
+            api_actor,
+        )?;
 
         let query_threshold =
             QueryThreshold::get_with_uuid(conn, &query_project, path_params.threshold)?;
@@ -476,13 +473,12 @@ async fn put_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Edit,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     // Get the current threshold
     let query_threshold =
@@ -528,13 +524,12 @@ async fn delete_inner(
     let query_project = QueryProject::is_allowed(
         auth_conn!(context),
         &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
         &path_params.project,
         auth_user,
         Permission::Delete,
     )?;
-
-    #[cfg(feature = "plus")]
-    context.rate_limiting.project_request(query_project.uuid)?;
 
     let query_threshold =
         QueryThreshold::get_with_uuid(auth_conn!(context), &query_project, path_params.threshold)?;

--- a/lib/bencher_schema/src/model/project/mod.rs
+++ b/lib/bencher_schema/src/model/project/mod.rs
@@ -400,14 +400,18 @@ impl QueryProject {
     pub fn is_allowed(
         conn: &mut DbConnection,
         rbac: &Rbac,
+        #[cfg(feature = "plus")] rate_limiting: &crate::context::RateLimiting,
         project: &ProjectResourceId,
         auth_user: &AuthUser,
         permission: Permission,
     ) -> Result<Self, HttpError> {
-        // Do not leak information about private projects.
-        // Always return the same error.
-        Self::is_allowed_inner(conn, rbac, project, auth_user, permission)
-            .map_err(|_e| resource_not_found_error(BencherResource::Project, project, permission))
+        let query_project = Self::is_allowed_inner(conn, rbac, project, auth_user, permission)
+            .map_err(|_e| {
+                resource_not_found_error(BencherResource::Project, project, permission)
+            })?;
+        #[cfg(feature = "plus")]
+        rate_limiting.project_request(query_project.uuid)?;
+        Ok(query_project)
     }
 
     fn is_allowed_inner(
@@ -422,20 +426,7 @@ impl QueryProject {
         Ok(query_project)
     }
 
-    pub fn is_allowed_public(
-        conn: &mut DbConnection,
-        rbac: &Rbac,
-        project: &ProjectResourceId,
-        public_user: &PublicUser,
-    ) -> Result<Self, HttpError> {
-        // Do not leak information about private projects.
-        // Always return the same error.
-        Self::is_allowed_public_inner(conn, rbac, project, public_user).map_err(|_e| {
-            resource_not_found_error(BencherResource::Project, project, Permission::View)
-        })
-    }
-
-    fn is_allowed_public_inner(
+    fn is_allowed_public(
         conn: &mut DbConnection,
         rbac: &Rbac,
         project: &ProjectResourceId,
@@ -459,12 +450,19 @@ impl QueryProject {
     pub fn is_allowed_actor(
         conn: &mut DbConnection,
         rbac: &Rbac,
+        #[cfg(feature = "plus")] rate_limiting: &crate::context::RateLimiting,
         project: &ProjectResourceId,
         api_actor: &ApiActor,
     ) -> Result<Self, HttpError> {
-        Self::is_allowed_actor_inner(conn, rbac, project, api_actor).map_err(|_e| {
-            resource_not_found_error(BencherResource::Project, project, Permission::View)
-        })
+        let query_project =
+            Self::is_allowed_actor_inner(conn, rbac, project, api_actor).map_err(|_e| {
+                resource_not_found_error(BencherResource::Project, project, Permission::View)
+            })?;
+        #[cfg(feature = "plus")]
+        if api_actor.is_auth() {
+            rate_limiting.project_request(query_project.uuid)?;
+        }
+        Ok(query_project)
     }
 
     fn is_allowed_actor_inner(
@@ -475,7 +473,7 @@ impl QueryProject {
     ) -> Result<Self, HttpError> {
         match api_actor {
             ApiActor::Public(public_user) => {
-                Self::is_allowed_public_inner(conn, rbac, project, public_user)
+                Self::is_allowed_public(conn, rbac, project, public_user)
             },
             ApiActor::ProjectKey(project_key_actor) => {
                 let query_project = Self::from_resource_id(conn, project)?;


### PR DESCRIPTION
This changeset adds project based API rate limiting. For public routes, project based rate limiting is only applied for authenticated users and IP based rate limiting applied to unauthenticated requests.