### PR TITLE
Add context aware auth hints for 404s

### DIFF
--- a/lib/api_checkout/src/checkout.rs
+++ b/lib/api_checkout/src/checkout.rs
@@ -9,7 +9,7 @@ use bencher_rbac::organization::Permission;
 use bencher_schema::{
     auth_conn,
     context::ApiContext,
-    error::{bad_request_error, forbidden_error, issue_error},
+    error::{bad_request_error, forbidden_error, issue_error, with_token_hint},
     model::{
         organization::QueryOrganization,
         user::auth::{AuthUser, BearerToken},
@@ -46,7 +46,8 @@ pub async fn checkouts_post(
             sentry::capture_error(&e);
             #[cfg(not(feature = "sentry"))]
             let _ = e;
-        })?;
+        })
+        .map_err(with_token_hint)?;
     Ok(Post::auth_response_created(json))
 }
 

--- a/lib/api_projects/src/alerts.rs
+++ b/lib/api_projects/src/alerts.rs
@@ -7,7 +7,7 @@ use bencher_rbac::project::Permission;
 use bencher_schema::{
     actor_conn, auth_conn,
     context::ApiContext,
-    error::{resource_conflict_err, resource_not_found_err},
+    error::{resource_conflict_err, resource_not_found_err, with_auth_hint, with_token_hint},
     model::{
         project::{
             QueryProject,
@@ -98,7 +98,8 @@ pub async fn proj_alerts_get(
         pagination_params.into_inner(),
         query_params.into_inner(),
     )
-    .await?;
+    .await
+    .map_err(with_auth_hint)?;
     Ok(Get::response_ok_with_total_count(
         json,
         api_actor.is_auth(),
@@ -337,7 +338,9 @@ pub async fn proj_alert_get(
         bearer_token,
     )
     .await?;
-    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &api_actor).await?;
+    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &api_actor)
+        .await
+        .map_err(with_auth_hint)?;
     Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 
@@ -383,7 +386,8 @@ pub async fn proj_alert_patch(
         body.into_inner(),
         &auth_user,
     )
-    .await?;
+    .await
+    .map_err(with_token_hint)?;
     Ok(Patch::auth_response_ok(json))
 }
 

--- a/lib/api_projects/src/allowed.rs
+++ b/lib/api_projects/src/allowed.rs
@@ -3,6 +3,7 @@ use bencher_json::{JsonAllowed, ProjectResourceId, project::ProjectPermission};
 use bencher_schema::{
     auth_conn,
     context::ApiContext,
+    error::with_token_hint,
     model::{
         project::{QueryProject, project_role::Permission},
         user::auth::{AuthUser, BearerToken},
@@ -43,7 +44,9 @@ pub async fn proj_allowed_get(
     path_params: Path<ProjAllowedParams>,
 ) -> Result<ResponseOk<JsonAllowed>, HttpError> {
     let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
-    let json = get_inner(rqctx.context(), path_params.into_inner(), &auth_user).await?;
+    let json = get_inner(rqctx.context(), path_params.into_inner(), &auth_user)
+        .await
+        .map_err(with_token_hint)?;
     Ok(Get::auth_response_ok(json))
 }
 

--- a/lib/api_projects/src/benchmarks.rs
+++ b/lib/api_projects/src/benchmarks.rs
@@ -11,7 +11,7 @@ use bencher_rbac::project::Permission;
 use bencher_schema::{
     actor_conn, auth_conn,
     context::ApiContext,
-    error::{resource_conflict_err, resource_not_found_err},
+    error::{resource_conflict_err, resource_not_found_err, with_auth_hint, with_token_hint},
     model::{
         project::{
             QueryProject,
@@ -100,7 +100,8 @@ pub async fn proj_benchmarks_get(
         pagination_params.into_inner(),
         query_params.into_inner(),
     )
-    .await?;
+    .await
+    .map_err(with_auth_hint)?;
     Ok(Get::response_ok_with_total_count(
         json,
         api_actor.is_auth(),
@@ -206,7 +207,8 @@ pub async fn proj_benchmark_post(
         body.into_inner(),
         &auth_user,
     )
-    .await?;
+    .await
+    .map_err(with_token_hint)?;
     Ok(Post::auth_response_created(json))
 }
 
@@ -276,7 +278,9 @@ pub async fn proj_benchmark_get(
         bearer_token,
     )
     .await?;
-    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &api_actor).await?;
+    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &api_actor)
+        .await
+        .map_err(with_auth_hint)?;
     Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 
@@ -328,7 +332,8 @@ pub async fn proj_benchmark_patch(
         body.into_inner(),
         &auth_user,
     )
-    .await?;
+    .await
+    .map_err(with_token_hint)?;
     Ok(Patch::auth_response_ok(json))
 }
 
@@ -384,7 +389,9 @@ pub async fn proj_benchmark_delete(
     path_params: Path<ProjBenchmarkParams>,
 ) -> Result<ResponseDeleted, HttpError> {
     let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
-    delete_inner(rqctx.context(), path_params.into_inner(), &auth_user).await?;
+    delete_inner(rqctx.context(), path_params.into_inner(), &auth_user)
+        .await
+        .map_err(with_token_hint)?;
     Ok(Delete::auth_response_deleted())
 }
 

--- a/lib/api_projects/src/branches.rs
+++ b/lib/api_projects/src/branches.rs
@@ -12,6 +12,7 @@ use bencher_schema::{
     context::ApiContext,
     error::{
         BencherResource, resource_conflict_err, resource_not_found_err, resource_not_found_error,
+        with_auth_hint, with_token_hint,
     },
     model::{
         project::{
@@ -103,7 +104,8 @@ pub async fn proj_branches_get(
         pagination_params.into_inner(),
         query_params.into_inner(),
     )
-    .await?;
+    .await
+    .map_err(with_auth_hint)?;
     Ok(Get::response_ok_with_total_count(
         json,
         api_actor.is_auth(),
@@ -225,7 +227,8 @@ pub async fn proj_branch_post(
         body.into_inner(),
         &auth_user,
     )
-    .await?;
+    .await
+    .map_err(with_token_hint)?;
     Ok(Post::auth_response_created(json))
 }
 
@@ -313,7 +316,8 @@ pub async fn proj_branch_get(
         query_params.into_inner(),
         &api_actor,
     )
-    .await?;
+    .await
+    .map_err(with_auth_hint)?;
     Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 
@@ -383,7 +387,8 @@ pub async fn proj_branch_patch(
         body.into_inner(),
         &auth_user,
     )
-    .await?;
+    .await
+    .map_err(with_token_hint)?;
     Ok(Patch::auth_response_ok(json))
 }
 
@@ -449,7 +454,9 @@ pub async fn proj_branch_delete(
     path_params: Path<ProjBranchParams>,
 ) -> Result<ResponseDeleted, HttpError> {
     let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
-    delete_inner(rqctx.context(), path_params.into_inner(), &auth_user).await?;
+    delete_inner(rqctx.context(), path_params.into_inner(), &auth_user)
+        .await
+        .map_err(with_token_hint)?;
     Ok(Delete::auth_response_deleted())
 }
 

--- a/lib/api_projects/src/jobs.rs
+++ b/lib/api_projects/src/jobs.rs
@@ -7,7 +7,7 @@ use bencher_json::{
 use bencher_schema::{
     actor_conn,
     context::ApiContext,
-    error::resource_not_found_err,
+    error::{resource_not_found_err, with_auth_hint},
     model::{project::QueryProject, runner::QueryJob, user::actor::ApiActor},
     schema,
 };
@@ -80,7 +80,8 @@ pub async fn proj_jobs_get(
         query_params.into_inner(),
         &api_actor,
     )
-    .await?;
+    .await
+    .map_err(with_auth_hint)?;
     Ok(Get::response_ok_with_total_count(
         json,
         api_actor.is_auth(),
@@ -211,7 +212,8 @@ pub async fn proj_job_get(
         &api_actor,
         &rqctx.log,
     )
-    .await?;
+    .await
+    .map_err(with_auth_hint)?;
     Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 

--- a/lib/api_projects/src/keys.rs
+++ b/lib/api_projects/src/keys.rs
@@ -11,7 +11,7 @@ use bencher_rbac::project::Permission;
 use bencher_schema::{
     auth_conn,
     context::ApiContext,
-    error::{conflict_error, resource_conflict_err, resource_not_found_err},
+    error::{conflict_error, resource_conflict_err, resource_not_found_err, with_token_hint},
     model::{
         project::{
             ProjectId, QueryProject,
@@ -99,7 +99,8 @@ pub async fn proj_keys_get(
         query_params.into_inner(),
         &auth_user,
     )
-    .await?;
+    .await
+    .map_err(with_token_hint)?;
     Ok(Get::auth_response_ok_with_total_count(json, total_count))
 }
 
@@ -216,7 +217,8 @@ pub async fn proj_key_post(
         body.into_inner(),
         &auth_user,
     )
-    .await?;
+    .await
+    .map_err(with_token_hint)?;
     Ok(Post::auth_response_created(json))
 }
 
@@ -288,7 +290,9 @@ pub async fn proj_key_get(
     path_params: Path<ProjKeyParams>,
 ) -> Result<ResponseOk<JsonProjectKey>, HttpError> {
     let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
-    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &auth_user).await?;
+    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &auth_user)
+        .await
+        .map_err(with_token_hint)?;
     Ok(Get::auth_response_ok(json))
 }
 
@@ -334,7 +338,8 @@ pub async fn proj_key_patch(
         body.into_inner(),
         &auth_user,
     )
-    .await?;
+    .await
+    .map_err(with_token_hint)?;
     Ok(Patch::auth_response_ok(json))
 }
 
@@ -390,7 +395,9 @@ pub async fn proj_key_delete(
     path_params: Path<ProjKeyParams>,
 ) -> Result<ResponseDeleted, HttpError> {
     let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
-    delete_inner(rqctx.context(), path_params.into_inner(), &auth_user).await?;
+    delete_inner(rqctx.context(), path_params.into_inner(), &auth_user)
+        .await
+        .map_err(with_token_hint)?;
     Ok(Delete::auth_response_deleted())
 }
 

--- a/lib/api_projects/src/measures.rs
+++ b/lib/api_projects/src/measures.rs
@@ -10,7 +10,7 @@ use bencher_rbac::project::Permission;
 use bencher_schema::{
     actor_conn, auth_conn,
     context::ApiContext,
-    error::{resource_conflict_err, resource_not_found_err},
+    error::{resource_conflict_err, resource_not_found_err, with_auth_hint, with_token_hint},
     model::{
         project::{
             QueryProject,
@@ -99,7 +99,8 @@ pub async fn proj_measures_get(
         pagination_params.into_inner(),
         query_params.into_inner(),
     )
-    .await?;
+    .await
+    .map_err(with_auth_hint)?;
     Ok(Get::response_ok_with_total_count(
         json,
         api_actor.is_auth(),
@@ -205,7 +206,8 @@ pub async fn proj_measure_post(
         body.into_inner(),
         &auth_user,
     )
-    .await?;
+    .await
+    .map_err(with_token_hint)?;
     Ok(Post::auth_response_created(json))
 }
 
@@ -275,7 +277,9 @@ pub async fn proj_measure_get(
         bearer_token,
     )
     .await?;
-    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &api_actor).await?;
+    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &api_actor)
+        .await
+        .map_err(with_auth_hint)?;
     Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 
@@ -327,7 +331,8 @@ pub async fn proj_measure_patch(
         body.into_inner(),
         &auth_user,
     )
-    .await?;
+    .await
+    .map_err(with_token_hint)?;
     Ok(Patch::auth_response_ok(json))
 }
 
@@ -383,7 +388,9 @@ pub async fn proj_measure_delete(
     path_params: Path<ProjMeasureParams>,
 ) -> Result<ResponseDeleted, HttpError> {
     let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
-    delete_inner(rqctx.context(), path_params.into_inner(), &auth_user).await?;
+    delete_inner(rqctx.context(), path_params.into_inner(), &auth_user)
+        .await
+        .map_err(with_token_hint)?;
     Ok(Delete::auth_response_deleted())
 }
 

--- a/lib/api_projects/src/metrics.rs
+++ b/lib/api_projects/src/metrics.rs
@@ -6,7 +6,7 @@ use bencher_schema::model::spec::SpecId;
 use bencher_schema::{
     actor_conn,
     context::{ApiContext, DbConnection},
-    error::resource_not_found_err,
+    error::{resource_not_found_err, with_auth_hint},
     model::{
         project::{
             QueryProject,
@@ -77,7 +77,9 @@ pub async fn proj_metric_get(
         bearer_token,
     )
     .await?;
-    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &api_actor).await?;
+    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &api_actor)
+        .await
+        .map_err(with_auth_hint)?;
     Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 

--- a/lib/api_projects/src/perf/img.rs
+++ b/lib/api_projects/src/perf/img.rs
@@ -6,7 +6,7 @@ use bencher_json::{
 use bencher_plot::LinePlot;
 use bencher_schema::{
     context::ApiContext,
-    error::{bad_request_error, issue_error},
+    error::{bad_request_error, issue_error, with_auth_hint},
     model::user::actor::{ApiActor, PubProjectBearerToken},
 };
 use dropshot::{Body, HttpError, Path, Query, RequestContext, endpoint};
@@ -71,7 +71,8 @@ pub async fn proj_perf_img_get(
         json_perf_query,
         &api_actor,
     )
-    .await?;
+    .await
+    .map_err(with_auth_hint)?;
 
     Response::builder()
         .status(http::StatusCode::OK)

--- a/lib/api_projects/src/perf/mod.rs
+++ b/lib/api_projects/src/perf/mod.rs
@@ -18,7 +18,7 @@ use bencher_schema::model::spec::SpecId;
 use bencher_schema::{
     actor_conn,
     context::{ApiContext, DbConnection},
-    error::{bad_request_error, resource_not_found_err},
+    error::{bad_request_error, resource_not_found_err, with_auth_hint},
     model::{
         project::{
             QueryProject,
@@ -107,7 +107,8 @@ pub async fn proj_perf_get(
         json_perf_query,
         &api_actor,
     )
-    .await?;
+    .await
+    .map_err(with_auth_hint)?;
     Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 

--- a/lib/api_projects/src/plots.rs
+++ b/lib/api_projects/src/plots.rs
@@ -10,7 +10,7 @@ use bencher_rbac::project::Permission;
 use bencher_schema::{
     actor_conn, auth_conn,
     context::ApiContext,
-    error::{resource_conflict_err, resource_not_found_err},
+    error::{resource_conflict_err, resource_not_found_err, with_auth_hint, with_token_hint},
     model::{
         project::{
             QueryProject,
@@ -99,7 +99,8 @@ pub async fn proj_plots_get(
         pagination_params.into_inner(),
         query_params.into_inner(),
     )
-    .await?;
+    .await
+    .map_err(with_auth_hint)?;
     Ok(Get::response_ok_with_total_count(
         json,
         api_actor.is_auth(),
@@ -219,7 +220,8 @@ pub async fn proj_plot_post(
         body.into_inner(),
         &auth_user,
     )
-    .await?;
+    .await
+    .map_err(with_token_hint)?;
     Ok(Post::auth_response_created(json))
 }
 
@@ -291,7 +293,9 @@ pub async fn proj_plot_get(
         bearer_token,
     )
     .await?;
-    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &api_actor).await?;
+    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &api_actor)
+        .await
+        .map_err(with_auth_hint)?;
     Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 
@@ -338,7 +342,8 @@ pub async fn proj_plot_patch(
         body.into_inner(),
         &auth_user,
     )
-    .await?;
+    .await
+    .map_err(with_token_hint)?;
     Ok(Patch::auth_response_ok(json))
 }
 
@@ -390,7 +395,9 @@ pub async fn proj_plot_delete(
     path_params: Path<ProjPlotParams>,
 ) -> Result<ResponseDeleted, HttpError> {
     let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
-    delete_inner(rqctx.context(), path_params.into_inner(), &auth_user).await?;
+    delete_inner(rqctx.context(), path_params.into_inner(), &auth_user)
+        .await
+        .map_err(with_token_hint)?;
     Ok(Delete::auth_response_deleted())
 }
 

--- a/lib/api_projects/src/projects.rs
+++ b/lib/api_projects/src/projects.rs
@@ -12,7 +12,10 @@ use bencher_schema::model::organization::plan::PlanKind;
 use bencher_schema::{
     actor_conn, auth_conn,
     context::ApiContext,
-    error::{forbidden_error, resource_conflict_err, resource_not_found_err},
+    error::{
+        forbidden_error, resource_conflict_err, resource_not_found_err, with_auth_hint,
+        with_token_hint,
+    },
     model::{
         project::{QueryProject, UpdateProject},
         user::{
@@ -98,7 +101,8 @@ pub async fn projects_get(
         query_params.into_inner(),
         &api_actor,
     )
-    .await?;
+    .await
+    .map_err(with_auth_hint)?;
     Ok(Get::response_ok_with_total_count(
         json,
         api_actor.is_auth(),
@@ -245,7 +249,9 @@ pub async fn project_get(
         bearer_token,
     )
     .await?;
-    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &api_actor).await?;
+    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &api_actor)
+        .await
+        .map_err(with_auth_hint)?;
     Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 
@@ -292,7 +298,8 @@ pub async fn project_patch(
         body.into_inner(),
         auth_user,
     )
-    .await?;
+    .await
+    .map_err(with_token_hint)?;
     Ok(Patch::auth_response_ok(json))
 }
 
@@ -378,7 +385,8 @@ pub async fn project_delete(
         query_params.into_inner(),
         &auth_user,
     )
-    .await?;
+    .await
+    .map_err(with_token_hint)?;
     Ok(Delete::auth_response_deleted())
 }
 

--- a/lib/api_projects/src/reports.rs
+++ b/lib/api_projects/src/reports.rs
@@ -18,7 +18,10 @@ use bencher_schema::model::project::testbed::RunTestbed;
 use bencher_schema::{
     actor_conn, auth_conn,
     context::ApiContext,
-    error::{bad_request_error, resource_conflict_err, resource_not_found_err},
+    error::{
+        bad_request_error, resource_conflict_err, resource_not_found_err, with_auth_hint,
+        with_token_hint,
+    },
     model::{
         project::{
             QueryProject,
@@ -111,7 +114,8 @@ pub async fn proj_reports_get(
         json_report_query,
         &api_actor,
     )
-    .await?;
+    .await
+    .map_err(with_auth_hint)?;
     Ok(Get::response_ok_with_total_count(
         json,
         api_actor.is_auth(),
@@ -290,7 +294,8 @@ pub async fn proj_report_post(
         body.into_inner(),
         auth_user,
     )
-    .await?;
+    .await
+    .map_err(with_token_hint)?;
     Ok(Post::auth_response_created(json))
 }
 
@@ -385,7 +390,8 @@ pub async fn proj_report_get(
         path_params.into_inner(),
         &api_actor,
     )
-    .await?;
+    .await
+    .map_err(with_auth_hint)?;
     Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 
@@ -433,7 +439,9 @@ pub async fn proj_report_delete(
     path_params: Path<ProjReportParams>,
 ) -> Result<ResponseDeleted, HttpError> {
     let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
-    delete_inner(rqctx.context(), path_params.into_inner(), &auth_user).await?;
+    delete_inner(rqctx.context(), path_params.into_inner(), &auth_user)
+        .await
+        .map_err(with_token_hint)?;
     Ok(Delete::auth_response_deleted())
 }
 

--- a/lib/api_projects/src/testbeds.rs
+++ b/lib/api_projects/src/testbeds.rs
@@ -14,7 +14,7 @@ use bencher_schema::model::spec::QuerySpec;
 use bencher_schema::{
     actor_conn, auth_conn,
     context::ApiContext,
-    error::{resource_conflict_err, resource_not_found_err},
+    error::{resource_conflict_err, resource_not_found_err, with_auth_hint, with_token_hint},
     model::{
         project::{
             QueryProject,
@@ -103,7 +103,8 @@ pub async fn proj_testbeds_get(
         pagination_params.into_inner(),
         query_params.into_inner(),
     )
-    .await?;
+    .await
+    .map_err(with_auth_hint)?;
     Ok(Get::response_ok_with_total_count(
         json,
         api_actor.is_auth(),
@@ -211,7 +212,8 @@ pub async fn proj_testbed_post(
         body.into_inner(),
         &auth_user,
     )
-    .await?;
+    .await
+    .map_err(with_token_hint)?;
     Ok(Post::auth_response_created(json))
 }
 
@@ -298,7 +300,8 @@ pub async fn proj_testbed_get(
         query_params.into_inner(),
         &api_actor,
     )
-    .await?;
+    .await
+    .map_err(with_auth_hint)?;
     Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 
@@ -361,7 +364,8 @@ pub async fn proj_testbed_patch(
         body.into_inner(),
         &auth_user,
     )
-    .await?;
+    .await
+    .map_err(with_token_hint)?;
     Ok(Patch::auth_response_ok(json))
 }
 
@@ -420,7 +424,9 @@ pub async fn proj_testbed_delete(
     path_params: Path<ProjTestbedParams>,
 ) -> Result<ResponseDeleted, HttpError> {
     let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
-    delete_inner(rqctx.context(), path_params.into_inner(), &auth_user).await?;
+    delete_inner(rqctx.context(), path_params.into_inner(), &auth_user)
+        .await
+        .map_err(with_token_hint)?;
     Ok(Delete::auth_response_deleted())
 }
 

--- a/lib/api_projects/src/thresholds.rs
+++ b/lib/api_projects/src/thresholds.rs
@@ -15,7 +15,7 @@ use bencher_schema::{
     context::ApiContext,
     error::{
         BencherResource, bad_request_error, resource_conflict_err, resource_not_found_err,
-        resource_not_found_error,
+        resource_not_found_error, with_auth_hint, with_token_hint,
     },
     model::{
         project::{
@@ -108,7 +108,8 @@ pub async fn proj_thresholds_get(
         json_threshold_query,
         &api_actor,
     )
-    .await?;
+    .await
+    .map_err(with_auth_hint)?;
     Ok(Get::response_ok_with_total_count(
         json,
         api_actor.is_auth(),
@@ -264,7 +265,8 @@ pub async fn proj_threshold_post(
         &body.into_inner(),
         &auth_user,
     )
-    .await?;
+    .await
+    .map_err(with_token_hint)?;
     Ok(Post::auth_response_created(json))
 }
 
@@ -379,7 +381,8 @@ pub async fn proj_threshold_get(
         query_params.into_inner(),
         &api_actor,
     )
-    .await?;
+    .await
+    .map_err(with_auth_hint)?;
     Ok(Get::response_ok(json, api_actor.is_auth()))
 }
 
@@ -450,7 +453,8 @@ pub async fn proj_threshold_put(
         body.into_inner(),
         &auth_user,
     )
-    .await?;
+    .await
+    .map_err(with_token_hint)?;
     Ok(Put::auth_response_ok(json))
 }
 
@@ -511,7 +515,9 @@ pub async fn proj_threshold_delete(
     path_params: Path<ProjThresholdParams>,
 ) -> Result<ResponseDeleted, HttpError> {
     let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
-    delete_inner(rqctx.context(), path_params.into_inner(), &auth_user).await?;
+    delete_inner(rqctx.context(), path_params.into_inner(), &auth_user)
+        .await
+        .map_err(with_token_hint)?;
     Ok(Delete::auth_response_deleted())
 }
 

--- a/lib/api_run/src/run.rs
+++ b/lib/api_run/src/run.rs
@@ -4,7 +4,7 @@ use bencher_rbac::project::Permission;
 use bencher_schema::{
     auth_conn,
     context::ApiContext,
-    error::{bad_request_error, forbidden_error, unauthorized_error},
+    error::{bad_request_error, forbidden_error, unauthorized_error, with_auth_hint},
     model::{
         project::{
             QueryProject,
@@ -62,28 +62,26 @@ pub async fn run_post(
     .await?;
 
     let json = match api_actor {
-        ApiActor::ProjectKey(project_key_actor) => {
-            post_inner_project_key(
-                &rqctx.log,
-                rqctx.context(),
-                project_key_actor,
-                #[cfg(feature = "plus")]
-                rqctx.request.headers(),
-                body.into_inner(),
-            )
-            .await?
-        },
-        ApiActor::Public(public_user) => {
-            post_inner(
-                &rqctx.log,
-                rqctx.context(),
-                &public_user,
-                #[cfg(feature = "plus")]
-                rqctx.request.headers(),
-                body.into_inner(),
-            )
-            .await?
-        },
+        ApiActor::ProjectKey(project_key_actor) => post_inner_project_key(
+            &rqctx.log,
+            rqctx.context(),
+            project_key_actor,
+            #[cfg(feature = "plus")]
+            rqctx.request.headers(),
+            body.into_inner(),
+        )
+        .await
+        .map_err(with_auth_hint)?,
+        ApiActor::Public(public_user) => post_inner(
+            &rqctx.log,
+            rqctx.context(),
+            &public_user,
+            #[cfg(feature = "plus")]
+            rqctx.request.headers(),
+            body.into_inner(),
+        )
+        .await
+        .map_err(with_auth_hint)?,
     };
 
     Ok(Post::auth_response_created(json))

--- a/lib/bencher_schema/src/error.rs
+++ b/lib/bencher_schema/src/error.rs
@@ -5,6 +5,7 @@ use dropshot::{ClientErrorStatusCode, ErrorStatusCode, HttpError};
 use thiserror::Error;
 
 pub const BEARER_TOKEN_FORMAT: &str = "Expected format is `Authorization: Bearer <bencher.api.token>`. Where `<bencher.api.token>` is your Bencher API token.";
+pub const BEARER_AUTH_FORMAT: &str = "Expected format is `Authorization: Bearer <token>`. Where `<token>` is your Bencher API token or project API key (`bencher_run_...`).";
 
 #[derive(Debug, Clone, Copy)]
 pub enum BencherResource {
@@ -208,8 +209,24 @@ where
     E: fmt::Display,
 {
     not_found_error(format!(
-        "{resource} ({value:?}) not found: {error}\n{resource} may be private and require authentication or it may not exist.\n{BEARER_TOKEN_FORMAT}"
+        "{resource} ({value:?}) not found: {error}\n{resource} may be private and require authentication or it may not exist."
     ))
+}
+
+pub fn with_token_hint(mut err: HttpError) -> HttpError {
+    if err.status_code == ClientErrorStatusCode::NOT_FOUND {
+        err.external_message = format!("{}\n{BEARER_TOKEN_FORMAT}", err.external_message);
+        err.internal_message = format!("{}\n{BEARER_TOKEN_FORMAT}", err.internal_message);
+    }
+    err
+}
+
+pub fn with_auth_hint(mut err: HttpError) -> HttpError {
+    if err.status_code == ClientErrorStatusCode::NOT_FOUND {
+        err.external_message = format!("{}\n{BEARER_AUTH_FORMAT}", err.external_message);
+        err.internal_message = format!("{}\n{BEARER_AUTH_FORMAT}", err.internal_message);
+    }
+    err
 }
 
 pub fn resource_conflict_error<V, E>(resource: BencherResource, value: V, error: E) -> HttpError

--- a/services/console/CLAUDE.md
+++ b/services/console/CLAUDE.md
@@ -112,3 +112,9 @@ Pagefind runs as a post-build step against `dist/` and writes a static index int
 
 The changelog lives at [`services/console/src/chunks/docs-reference/changelog/en/changelog.mdx`](./src/chunks/docs-reference/changelog/en/changelog.mdx).
 It is imported by the content pages in [`services/console/src/content/docs-reference/{lang}/changelog.mdx`](./src/content/docs-reference/{lang}/changelog.mdx).
+There is also a symlink at the repo root (`changelog.md`) that points to this file.
+
+When adding a changelog entry:
+1. If no `## Pending` section exists at the top, add one (e.g. `## Pending \`vX.Y.Z\``) above the latest released version.
+2. Append your entry to the **bottom** of the `Pending` section so entries stay in chronological order.
+3. Do not remove or reorder existing entries.

--- a/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
+++ b/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
@@ -1,3 +1,6 @@
+## Pending `v0.6.6`
+- Show context-aware auth hints in API 404 errors: routes that accept project API keys now mention both API tokens and project keys, while token-only routes mention only API tokens
+
 ## `v0.6.5`
 - Add project scoped API keys
 - Add build time and file size tracking support for bare metal runs


### PR DESCRIPTION
This changeset adds context aware auth hints for API 404s, indicating whether a project key (`bencher_run_`) or user API token (JWT) can be used.