### PR TITLE
Add bare metal runner minutes to billing dashboard

### DIFF
--- a/lib/api_organizations/src/usage.rs
+++ b/lib/api_organizations/src/usage.rs
@@ -13,8 +13,9 @@ use bencher_schema::{
     context::{ApiContext, DbConnection},
     error::{forbidden_error, issue_error, payment_required_error, resource_not_found_err},
     model::{
-        organization::{QueryOrganization, plan::QueryPlan},
+        organization::{OrganizationId, QueryOrganization, plan::QueryPlan},
         project::metric::QueryMetric,
+        runner::job::QueryJob,
         user::auth::{AuthUser, BearerToken},
     },
 };
@@ -44,9 +45,9 @@ pub async fn org_usage_options(
     Ok(Endpoint::cors(&[Get.into()]))
 }
 
-/// View organization metrics usage
+/// View organization usage
 ///
-/// View the metrics usage of an organization.
+/// View the metrics and bare metal runner minutes usage of an organization.
 /// The user must have `manage` permissions for the organization.
 /// ➕ Bencher Plus: This endpoint offers an estimate of metered usage
 /// and exact usage for licensed organizations, both on Bencher Cloud and Bencher Self-Hosted.
@@ -99,7 +100,7 @@ async fn get_inner(
         if let Some(json_plan) = query_plan.to_metered_plan(biller).await? {
             let start_time = json_plan.current_period_start;
             let end_time = json_plan.current_period_end;
-            let usage = QueryMetric::usage(
+            let (metrics, runner_minutes) = query_usage(
                 auth_conn!(context),
                 query_organization.id,
                 start_time,
@@ -112,7 +113,8 @@ async fn get_inner(
                 license: None,
                 start_time,
                 end_time,
-                usage: Some(usage),
+                metrics: Some(metrics),
+                runner_minutes: Some(runner_minutes),
             })
         // Licensed plan
         } else if let Some(json_plan) = query_plan.to_licensed_plan(biller, licensor).await? {
@@ -134,7 +136,8 @@ async fn get_inner(
                 license: Some(json_license),
                 start_time,
                 end_time,
-                usage: None,
+                metrics: None,
+                runner_minutes: None,
             })
         } else {
             Err(issue_error(
@@ -152,7 +155,7 @@ async fn get_inner(
             .map_err(payment_required_error)?;
         let start_time = json_license.issued_at;
         let end_time = json_license.expiration;
-        let usage = QueryMetric::usage(
+        let (metrics, runner_minutes) = query_usage(
             auth_conn!(context),
             query_organization.id,
             start_time,
@@ -165,7 +168,8 @@ async fn get_inner(
             license: Some(json_license),
             start_time,
             end_time,
-            usage: Some(usage),
+            metrics: Some(metrics),
+            runner_minutes: Some(runner_minutes),
         })
     // Self-Hosted Free
     } else {
@@ -177,6 +181,18 @@ async fn get_inner(
     }
 }
 
+fn query_usage(
+    conn: &mut DbConnection,
+    organization_id: OrganizationId,
+    start_time: DateTime,
+    end_time: DateTime,
+) -> Result<(u32, u32), HttpError> {
+    let metrics = QueryMetric::usage(conn, organization_id, start_time, end_time)?;
+    let runner_minutes =
+        QueryJob::runner_minutes_usage(conn, organization_id, start_time, end_time)?;
+    Ok((metrics, runner_minutes))
+}
+
 fn free_plan_usage(
     conn: &mut DbConnection,
     query_organization: &QueryOrganization,
@@ -184,7 +200,7 @@ fn free_plan_usage(
 ) -> Result<JsonUsage, HttpError> {
     let end_time = DateTime::now();
     let start_time = (end_time.into_inner() - DEFAULT_USAGE_HISTORY).into();
-    let usage = QueryMetric::usage(conn, query_organization.id, start_time, end_time)?;
+    let (metrics, runner_minutes) = query_usage(conn, query_organization.id, start_time, end_time)?;
     Ok(JsonUsage {
         organization: query_organization.uuid,
         kind,
@@ -192,6 +208,7 @@ fn free_plan_usage(
         license: None,
         start_time,
         end_time,
-        usage: Some(usage),
+        metrics: Some(metrics),
+        runner_minutes: Some(runner_minutes),
     })
 }

--- a/lib/bencher_json/src/organization/usage.rs
+++ b/lib/bencher_json/src/organization/usage.rs
@@ -26,7 +26,9 @@ pub struct JsonUsage {
     /// The end time of the usage.
     pub end_time: DateTime,
     /// The metrics usage amount.
-    pub usage: Option<u32>,
+    pub metrics: Option<u32>,
+    /// The runner minutes usage amount.
+    pub runner_minutes: Option<u32>,
 }
 
 #[typeshare::typeshare]

--- a/lib/bencher_schema/src/model/project/metric.rs
+++ b/lib/bencher_schema/src/model/project/metric.rs
@@ -4,8 +4,6 @@ use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 use dropshot::HttpError;
 
 #[cfg(feature = "plus")]
-use crate::error::resource_not_found_err;
-#[cfg(feature = "plus")]
 use crate::model::organization::OrganizationId;
 #[cfg(feature = "plus")]
 use crate::schema;
@@ -56,7 +54,13 @@ impl QueryMetric {
             .filter(schema::report::end_time.le(end_time))
             .count()
             .get_result::<i64>(conn)
-            .map_err(resource_not_found_err!(Metric, (organization_id, start_time, end_time)))?
+            .map_err(|e| {
+                crate::error::issue_error(
+                    "Failed to count metric usage",
+                    &format!("Failed to count metric usage for organization ({organization_id}) between {start_time} and {end_time}."),
+                    e,
+                )
+            })?
             .try_into()
             .map_err(|e| {
                 crate::error::issue_error(

--- a/lib/bencher_schema/src/model/project/metric.rs
+++ b/lib/bencher_schema/src/model/project/metric.rs
@@ -66,9 +66,9 @@ impl QueryMetric {
                 crate::error::issue_error(
                     "Failed to count metric usage",
                     &format!("Failed to count metric usage for organization ({organization_id}) between {start_time} and {end_time}."),
-                e
-                )}
-            )
+                    e,
+                )
+            })
     }
 
     pub fn into_json(self) -> JsonMetric {

--- a/lib/bencher_schema/src/model/runner/job.rs
+++ b/lib/bencher_schema/src/model/runner/job.rs
@@ -89,16 +89,15 @@ impl QueryJob {
                     e,
                 )
             })?
-            .unwrap_or(0)
-            .max(0)
+            .unwrap_or_default()
             .try_into()
             .map_err(|e| {
-            issue_error(
-                "Failed to count runner minutes usage",
-                &format!("Failed to count runner minutes usage for organization ({organization_id}) between {start_time} and {end_time}."),
-                e,
-            )
-        })
+                issue_error(
+                    "Failed to count runner minutes usage",
+                    &format!("Failed to count runner minutes usage for organization ({organization_id}) between {start_time} and {end_time}."),
+                    e,
+                )
+            })
     }
 
     /// Process benchmark results from a completed job into the report.
@@ -702,8 +701,9 @@ mod tests {
         let mut conn = setup_test_db();
         let (report_id, org_id) = create_report_for_job_duration_test(&mut conn);
         insert_job_duration(&mut conn, report_id, 120).unwrap();
-        let after = DateTime::from(DateTime::TEST.into_inner() + chrono::Duration::seconds(100));
-        let result = QueryJob::runner_minutes_usage(&mut conn, org_id, after, after).unwrap();
+        let start = DateTime::from(DateTime::TEST.into_inner() + chrono::Duration::seconds(100));
+        let end = DateTime::from(DateTime::TEST.into_inner() + chrono::Duration::seconds(200));
+        let result = QueryJob::runner_minutes_usage(&mut conn, org_id, start, end).unwrap();
         assert_eq!(result, 0);
     }
 

--- a/lib/bencher_schema/src/model/runner/job.rs
+++ b/lib/bencher_schema/src/model/runner/job.rs
@@ -67,23 +67,19 @@ impl QueryJob {
     fn_from_uuid!(job, JobUuid, Job);
 
     #[cfg(feature = "plus")]
-    #[expect(
-        clippy::integer_division,
-        reason = "ceiling division: (secs + 59) / 60 converts seconds to minutes"
-    )]
     pub fn runner_minutes_usage(
         conn: &mut DbConnection,
         organization_id: OrganizationId,
         start_time: DateTime,
         end_time: DateTime,
     ) -> Result<u32, HttpError> {
-        let total_seconds: i64 = schema::job_duration_by_report::table
+        schema::job_duration_by_report::table
             .inner_join(schema::report::table.inner_join(schema::project::table))
             .filter(schema::project::organization_id.eq(organization_id))
             .filter(schema::report::end_time.ge(start_time))
             .filter(schema::report::end_time.le(end_time))
             .select(diesel::dsl::sum(
-                schema::job_duration_by_report::job_duration,
+                (schema::job_duration_by_report::job_duration + 59) / 60,
             ))
             .get_result::<Option<i64>>(conn)
             .map_err(|e| {
@@ -94,8 +90,9 @@ impl QueryJob {
                 )
             })?
             .unwrap_or(0)
-            .max(0);
-        ((total_seconds + 59) / 60).try_into().map_err(|e| {
+            .max(0)
+            .try_into()
+            .map_err(|e| {
             issue_error(
                 "Failed to count runner minutes usage",
                 &format!("Failed to count runner minutes usage for organization ({organization_id}) between {start_time} and {end_time}."),
@@ -659,14 +656,10 @@ mod tests {
     #[test]
     fn runner_minutes_exact_boundary() {
         let mut conn = setup_test_db();
-        let report_id = create_report_for_job_duration_test(&mut conn);
-        let base_org_id: OrganizationId = schema::project::table
-            .select(schema::project::organization_id)
-            .first(&mut conn)
-            .unwrap();
+        let (report_id, org_id) = create_report_for_job_duration_test(&mut conn);
         insert_job_duration(&mut conn, report_id, 60).unwrap();
         let result =
-            QueryJob::runner_minutes_usage(&mut conn, base_org_id, DateTime::TEST, DateTime::TEST)
+            QueryJob::runner_minutes_usage(&mut conn, org_id, DateTime::TEST, DateTime::TEST)
                 .unwrap();
         assert_eq!(result, 1);
     }
@@ -674,14 +667,10 @@ mod tests {
     #[test]
     fn runner_minutes_partial_minute() {
         let mut conn = setup_test_db();
-        let report_id = create_report_for_job_duration_test(&mut conn);
-        let base_org_id: OrganizationId = schema::project::table
-            .select(schema::project::organization_id)
-            .first(&mut conn)
-            .unwrap();
+        let (report_id, org_id) = create_report_for_job_duration_test(&mut conn);
         insert_job_duration(&mut conn, report_id, 61).unwrap();
         let result =
-            QueryJob::runner_minutes_usage(&mut conn, base_org_id, DateTime::TEST, DateTime::TEST)
+            QueryJob::runner_minutes_usage(&mut conn, org_id, DateTime::TEST, DateTime::TEST)
                 .unwrap();
         assert_eq!(result, 2);
     }
@@ -689,14 +678,10 @@ mod tests {
     #[test]
     fn runner_minutes_one_second() {
         let mut conn = setup_test_db();
-        let report_id = create_report_for_job_duration_test(&mut conn);
-        let base_org_id: OrganizationId = schema::project::table
-            .select(schema::project::organization_id)
-            .first(&mut conn)
-            .unwrap();
+        let (report_id, org_id) = create_report_for_job_duration_test(&mut conn);
         insert_job_duration(&mut conn, report_id, 1).unwrap();
         let result =
-            QueryJob::runner_minutes_usage(&mut conn, base_org_id, DateTime::TEST, DateTime::TEST)
+            QueryJob::runner_minutes_usage(&mut conn, org_id, DateTime::TEST, DateTime::TEST)
                 .unwrap();
         assert_eq!(result, 1);
     }
@@ -704,22 +689,27 @@ mod tests {
     #[test]
     fn runner_minutes_zero_seconds() {
         let mut conn = setup_test_db();
-        let report_id = create_report_for_job_duration_test(&mut conn);
-        let base_org_id: OrganizationId = schema::project::table
-            .select(schema::project::organization_id)
-            .first(&mut conn)
-            .unwrap();
+        let (report_id, org_id) = create_report_for_job_duration_test(&mut conn);
         insert_job_duration(&mut conn, report_id, 0).unwrap();
         let result =
-            QueryJob::runner_minutes_usage(&mut conn, base_org_id, DateTime::TEST, DateTime::TEST)
+            QueryJob::runner_minutes_usage(&mut conn, org_id, DateTime::TEST, DateTime::TEST)
                 .unwrap();
+        assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn runner_minutes_outside_range() {
+        let mut conn = setup_test_db();
+        let (report_id, org_id) = create_report_for_job_duration_test(&mut conn);
+        insert_job_duration(&mut conn, report_id, 120).unwrap();
+        let after = DateTime::from(DateTime::TEST.into_inner() + chrono::Duration::seconds(100));
+        let result = QueryJob::runner_minutes_usage(&mut conn, org_id, after, after).unwrap();
         assert_eq!(result, 0);
     }
 
     // --- insert_job_duration tests ---
 
-    /// Helper to create a report and return its `ReportId` for `job_duration` tests.
-    fn create_report_for_job_duration_test(conn: &mut DbConnection) -> ReportId {
+    fn create_report_for_job_duration_test(conn: &mut DbConnection) -> (ReportId, OrganizationId) {
         let base = create_base_entities(conn);
         let branch = create_branch_with_head(
             conn,
@@ -762,13 +752,14 @@ mod tests {
 
             diesel::select(last_insert_rowid()).get_result::<ReportId>(conn)
         })
+        .map(|report_id| (report_id, base.organization_id))
         .expect("Failed to insert report")
     }
 
     #[test]
     fn insert_job_duration_basic() {
         let mut conn = setup_test_db();
-        let report_id = create_report_for_job_duration_test(&mut conn);
+        let (report_id, _) = create_report_for_job_duration_test(&mut conn);
 
         insert_job_duration(&mut conn, report_id, 42).expect("Insert failed");
 
@@ -783,7 +774,7 @@ mod tests {
     #[test]
     fn insert_job_duration_idempotent() {
         let mut conn = setup_test_db();
-        let report_id = create_report_for_job_duration_test(&mut conn);
+        let (report_id, _) = create_report_for_job_duration_test(&mut conn);
 
         // First insert
         insert_job_duration(&mut conn, report_id, 100).expect("First insert failed");

--- a/lib/bencher_schema/src/model/runner/job.rs
+++ b/lib/bencher_schema/src/model/runner/job.rs
@@ -698,6 +698,21 @@ mod tests {
         assert_eq!(result, 1);
     }
 
+    #[test]
+    fn runner_minutes_zero_seconds() {
+        let mut conn = setup_test_db();
+        let report_id = create_report_for_job_duration_test(&mut conn);
+        let base_org_id: OrganizationId = schema::project::table
+            .select(schema::project::organization_id)
+            .first(&mut conn)
+            .unwrap();
+        insert_job_duration(&mut conn, report_id, 0).unwrap();
+        let result =
+            QueryJob::runner_minutes_usage(&mut conn, base_org_id, DateTime::TEST, DateTime::TEST)
+                .unwrap();
+        assert_eq!(result, 0);
+    }
+
     // --- insert_job_duration tests ---
 
     /// Helper to create a report and return its `ReportId` for `job_duration` tests.

--- a/lib/bencher_schema/src/model/runner/job.rs
+++ b/lib/bencher_schema/src/model/runner/job.rs
@@ -86,10 +86,13 @@ impl QueryJob {
                 schema::job_duration_by_report::job_duration,
             ))
             .get_result::<Option<i64>>(conn)
-            .map_err(resource_not_found_err!(
-                Job,
-                (organization_id, start_time, end_time)
-            ))?
+            .map_err(|e| {
+                issue_error(
+                    "Failed to query runner minutes usage",
+                    &format!("Failed to query runner minutes usage for organization ({organization_id}) between {start_time} and {end_time}."),
+                    e,
+                )
+            })?
             .unwrap_or(0)
             .max(0);
         ((total_seconds + 59) / 60).try_into().map_err(|e| {

--- a/lib/bencher_schema/src/model/runner/job.rs
+++ b/lib/bencher_schema/src/model/runner/job.rs
@@ -66,6 +66,41 @@ impl QueryJob {
     fn_get_uuid!(job, JobId, JobUuid);
     fn_from_uuid!(job, JobUuid, Job);
 
+    #[cfg(feature = "plus")]
+    #[expect(
+        clippy::integer_division,
+        reason = "ceiling division: (secs + 59) / 60 converts seconds to minutes"
+    )]
+    pub fn runner_minutes_usage(
+        conn: &mut DbConnection,
+        organization_id: OrganizationId,
+        start_time: DateTime,
+        end_time: DateTime,
+    ) -> Result<u32, HttpError> {
+        let total_seconds: i64 = schema::job_duration_by_report::table
+            .inner_join(schema::report::table.inner_join(schema::project::table))
+            .filter(schema::project::organization_id.eq(organization_id))
+            .filter(schema::report::end_time.ge(start_time))
+            .filter(schema::report::end_time.le(end_time))
+            .select(diesel::dsl::sum(
+                schema::job_duration_by_report::job_duration,
+            ))
+            .get_result::<Option<i64>>(conn)
+            .map_err(resource_not_found_err!(
+                Job,
+                (organization_id, start_time, end_time)
+            ))?
+            .unwrap_or(0)
+            .max(0);
+        ((total_seconds + 59) / 60).try_into().map_err(|e| {
+            issue_error(
+                "Failed to count runner minutes usage",
+                &format!("Failed to count runner minutes usage for organization ({organization_id}) between {start_time} and {end_time}."),
+                e,
+            )
+        })
+    }
+
     /// Process benchmark results from a completed job into the report.
     ///
     /// Looks up the report and branch, parses benchmark output via the adapter,
@@ -600,6 +635,67 @@ mod tests {
             licensed_plan(PlanLevel::Enterprise).priority(true),
             Priority::Plus
         );
+    }
+
+    // --- runner_minutes_usage tests ---
+
+    #[test]
+    fn runner_minutes_no_jobs() {
+        let mut conn = setup_test_db();
+        let base = create_base_entities(&mut conn);
+        let result = QueryJob::runner_minutes_usage(
+            &mut conn,
+            base.organization_id,
+            DateTime::TEST,
+            DateTime::TEST,
+        )
+        .unwrap();
+        assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn runner_minutes_exact_boundary() {
+        let mut conn = setup_test_db();
+        let report_id = create_report_for_job_duration_test(&mut conn);
+        let base_org_id: OrganizationId = schema::project::table
+            .select(schema::project::organization_id)
+            .first(&mut conn)
+            .unwrap();
+        insert_job_duration(&mut conn, report_id, 60).unwrap();
+        let result =
+            QueryJob::runner_minutes_usage(&mut conn, base_org_id, DateTime::TEST, DateTime::TEST)
+                .unwrap();
+        assert_eq!(result, 1);
+    }
+
+    #[test]
+    fn runner_minutes_partial_minute() {
+        let mut conn = setup_test_db();
+        let report_id = create_report_for_job_duration_test(&mut conn);
+        let base_org_id: OrganizationId = schema::project::table
+            .select(schema::project::organization_id)
+            .first(&mut conn)
+            .unwrap();
+        insert_job_duration(&mut conn, report_id, 61).unwrap();
+        let result =
+            QueryJob::runner_minutes_usage(&mut conn, base_org_id, DateTime::TEST, DateTime::TEST)
+                .unwrap();
+        assert_eq!(result, 2);
+    }
+
+    #[test]
+    fn runner_minutes_one_second() {
+        let mut conn = setup_test_db();
+        let report_id = create_report_for_job_duration_test(&mut conn);
+        let base_org_id: OrganizationId = schema::project::table
+            .select(schema::project::organization_id)
+            .first(&mut conn)
+            .unwrap();
+        insert_job_duration(&mut conn, report_id, 1).unwrap();
+        let result =
+            QueryJob::runner_minutes_usage(&mut conn, base_org_id, DateTime::TEST, DateTime::TEST)
+                .unwrap();
+        assert_eq!(result, 1);
     }
 
     // --- insert_job_duration tests ---

--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -2767,8 +2767,8 @@
           "organizations",
           "usage"
         ],
-        "summary": "View organization metrics usage",
-        "description": "View the metrics usage of an organization. The user must have `manage` permissions for the organization. ➕ Bencher Plus: This endpoint offers an estimate of metered usage and exact usage for licensed organizations, both on Bencher Cloud and Bencher Self-Hosted.",
+        "summary": "View organization usage",
+        "description": "View the metrics and bare metal runner minutes usage of an organization. The user must have `manage` permissions for the organization. ➕ Bencher Plus: This endpoint offers an estimate of metered usage and exact usage for licensed organizations, both on Bencher Cloud and Bencher Self-Hosted.",
         "operationId": "org_usage_get",
         "parameters": [
           {
@@ -17072,6 +17072,13 @@
               }
             ]
           },
+          "metrics": {
+            "nullable": true,
+            "description": "The metrics usage amount.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
           "organization": {
             "description": "The organization UUID.",
             "allOf": [
@@ -17089,6 +17096,13 @@
               }
             ]
           },
+          "runner_minutes": {
+            "nullable": true,
+            "description": "The runner minutes usage amount.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
           "start_time": {
             "description": "The start time of the usage.",
             "allOf": [
@@ -17096,13 +17110,6 @@
                 "$ref": "#/components/schemas/DateTime"
               }
             ]
-          },
-          "usage": {
-            "nullable": true,
-            "description": "The metrics usage amount.",
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0
           }
         },
         "required": [

--- a/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
+++ b/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
@@ -1,5 +1,6 @@
 ## Pending `v0.6.6`
 - Show context-aware auth hints in API 404 errors: routes that accept project API keys now mention both API tokens and project keys, while token-only routes mention only API tokens
+- **BREAKING CHANGE** Rename `usage` to `metrics` in the organization usage API response and add `runner_minutes` field for bare metal runner minutes usage
 
 ## `v0.6.5`
 - Add project scoped API keys

--- a/services/console/src/components/console/billing/BillingPanel.tsx
+++ b/services/console/src/components/console/billing/BillingPanel.tsx
@@ -22,6 +22,7 @@ import { authUser } from "../../../util/auth";
 import {
 	fmtDate,
 	fmtUsd,
+	fmtUsdPrecise,
 	planLevel,
 	planLevelPrice,
 	runnerMinutePrice,
@@ -217,7 +218,7 @@ const CloudMeteredPanel = (props: {
 			</h4>
 			<h4>Estimated Metrics Cost: {fmtUsd(estMetricsCost())}</h4>
 			<br />
-			<h4>Cost per Runner Minute: ${minutePrice().toFixed(5)} / min</h4>
+			<h4>Cost per Runner Minute: {fmtUsdPrecise(minutePrice())} / min</h4>
 			<h4>
 				Estimated Runner Minutes Used:{" "}
 				{props.usage()?.runner_minutes?.toLocaleString() ?? 0}

--- a/services/console/src/components/console/billing/BillingPanel.tsx
+++ b/services/console/src/components/console/billing/BillingPanel.tsx
@@ -24,6 +24,7 @@ import {
 	fmtUsd,
 	planLevel,
 	planLevelPrice,
+	runnerMinutePrice,
 	suggestedMetrics,
 } from "../../../util/convert";
 import { httpGet, httpPatch } from "../../../util/http";
@@ -187,8 +188,19 @@ const manageSubscription = (
 const CloudMeteredPanel = (props: {
 	usage: Resource<null | JsonUsage>;
 }) => {
-	const price = createMemo(() => planLevelPrice(props.usage()?.plan?.level));
-	const estCost = createMemo(() => (props.usage()?.usage ?? 0) * price());
+	const metricPrice = createMemo(() =>
+		planLevelPrice(props.usage()?.plan?.level),
+	);
+	const estMetricsCost = createMemo(
+		() => (props.usage()?.metrics ?? 0) * metricPrice(),
+	);
+	const minutePrice = createMemo(() =>
+		runnerMinutePrice(props.usage()?.plan?.level),
+	);
+	const estRunnerCost = createMemo(
+		() => (props.usage()?.runner_minutes ?? 0) * minutePrice(),
+	);
+	const estTotalCost = createMemo(() => estMetricsCost() + estRunnerCost());
 
 	return (
 		<div class="content">
@@ -199,11 +211,20 @@ const CloudMeteredPanel = (props: {
 				{fmtDate(props.usage()?.start_time)} -{" "}
 				{fmtDate(props.usage()?.end_time)}
 			</h3>
-			<h4>Cost per Metric: {fmtUsd(price())}</h4>
+			<h4>Cost per Metric: {fmtUsd(metricPrice())}</h4>
 			<h4>
-				Estimated Metrics Used: {props.usage()?.usage?.toLocaleString() ?? 0}
+				Estimated Metrics Used: {props.usage()?.metrics?.toLocaleString() ?? 0}
 			</h4>
-			<h4>Current Estimated Cost: {fmtUsd(estCost())}</h4>
+			<h4>Estimated Metrics Cost: {fmtUsd(estMetricsCost())}</h4>
+			<br />
+			<h4>Cost per Runner Minute: {fmtUsd(minutePrice())}</h4>
+			<h4>
+				Estimated Runner Minutes Used:{" "}
+				{props.usage()?.runner_minutes?.toLocaleString() ?? 0}
+			</h4>
+			<h4>Estimated Runner Cost: {fmtUsd(estRunnerCost())}</h4>
+			<br />
+			<h4>Current Estimated Total: {fmtUsd(estTotalCost())}</h4>
 			<br />
 			<PaymentMethod usage={props.usage} />
 			<br />
@@ -345,7 +366,11 @@ const SelfHostedFreePanel = (props: {
 					{fmtDate(props.usage()?.start_time)} -{" "}
 					{fmtDate(props.usage()?.end_time)}
 				</h3>
-				<h4>Metrics Used: {props.usage()?.usage?.toLocaleString() ?? 0}</h4>
+				<h4>Metrics Used: {props.usage()?.metrics?.toLocaleString() ?? 0}</h4>
+				<h4>
+					Runner Minutes Used:{" "}
+					{props.usage()?.runner_minutes?.toLocaleString() ?? 0}
+				</h4>
 				<br />
 			</Show>
 			<h2 class="title is-2">How to get a Bencher Self-Hosted License Key</h2>
@@ -373,7 +398,7 @@ const SelfHostedFreePanel = (props: {
 					<li>Select "Self-Hosted License"</li>
 					<li>
 						Enter your desired number of metrics for the <i>year</i> (Suggested:{" "}
-						{suggestedMetrics(props.usage()?.usage).toLocaleString()})
+						{suggestedMetrics(props.usage()?.metrics).toLocaleString()})
 					</li>
 					<li>
 						Enter your "Self-Hosted Organization UUID":{" "}
@@ -459,12 +484,16 @@ const SelfHostedLicensedPanel = (props: {
 				Entitlements:{" "}
 				{props.usage()?.license?.entitlements?.toLocaleString() ?? 0}
 			</h4>
-			<h4>Metrics Used: {props.usage()?.usage?.toLocaleString() ?? 0}</h4>
+			<h4>Metrics Used: {props.usage()?.metrics?.toLocaleString() ?? 0}</h4>
+			<h4>
+				Runner Minutes Used:{" "}
+				{props.usage()?.runner_minutes?.toLocaleString() ?? 0}
+			</h4>
 			<h4>
 				Metrics Remaining:{" "}
 				{(
 					(props.usage()?.license?.entitlements ?? 0) -
-					(props.usage()?.usage ?? 0)
+					(props.usage()?.metrics ?? 0)
 				).toLocaleString()}
 			</h4>
 			<br />

--- a/services/console/src/components/console/billing/BillingPanel.tsx
+++ b/services/console/src/components/console/billing/BillingPanel.tsx
@@ -217,7 +217,7 @@ const CloudMeteredPanel = (props: {
 			</h4>
 			<h4>Estimated Metrics Cost: {fmtUsd(estMetricsCost())}</h4>
 			<br />
-			<h4>Cost per Runner Minute: {fmtUsd(minutePrice())}</h4>
+			<h4>Cost per Runner Minute: ${minutePrice().toFixed(5)} / min</h4>
 			<h4>
 				Estimated Runner Minutes Used:{" "}
 				{props.usage()?.runner_minutes?.toLocaleString() ?? 0}

--- a/services/console/src/components/console/billing/plan/BillingForm.tsx
+++ b/services/console/src/components/console/billing/plan/BillingForm.tsx
@@ -193,7 +193,11 @@ const FreeUsage = (props: { usage: Resource<null | JsonUsage> }) => {
 						{fmtDate(props.usage()?.start_time)} -{" "}
 						{fmtDate(props.usage()?.end_time)}
 					</h3>
-					<h4>Metrics Used: {props.usage()?.usage?.toLocaleString() ?? 0}</h4>
+					<h4>Metrics Used: {props.usage()?.metrics?.toLocaleString() ?? 0}</h4>
+					<h4>
+						Runner Minutes Used:{" "}
+						{props.usage()?.runner_minutes?.toLocaleString() ?? 0}
+					</h4>
 				</div>
 			</div>
 		</div>

--- a/services/console/src/types/bencher.ts
+++ b/services/console/src/types/bencher.ts
@@ -1136,7 +1136,9 @@ export interface JsonUsage {
 	/** The end time of the usage. */
 	end_time: string;
 	/** The metrics usage amount. */
-	usage?: number;
+	metrics?: number;
+	/** The runner minutes usage amount. */
+	runner_minutes?: number;
 }
 
 export enum OrganizationPermission {

--- a/services/console/src/util/convert.ts
+++ b/services/console/src/util/convert.ts
@@ -151,11 +151,21 @@ export const suggestedMetrics = (metrics: undefined | number) =>
 	(Math.round((metrics ?? 1) / 1_000) + 1) * 12_000;
 
 export const fmtUsd = (usd: undefined | number) => {
-	const numberFmd = new Intl.NumberFormat("en-US", {
+	const numberFmt = new Intl.NumberFormat("en-US", {
 		style: "currency",
 		currency: "USD",
 	});
-	return numberFmd.format(usd ?? 0);
+	return numberFmt.format(usd ?? 0);
+};
+
+export const fmtUsdPrecise = (usd: undefined | number) => {
+	const numberFmt = new Intl.NumberFormat("en-US", {
+		style: "currency",
+		currency: "USD",
+		minimumFractionDigits: 5,
+		maximumFractionDigits: 5,
+	});
+	return numberFmt.format(usd ?? 0);
 };
 
 // https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem

--- a/services/console/src/util/convert.ts
+++ b/services/console/src/util/convert.ts
@@ -137,8 +137,18 @@ export const planLevelPrice = (level: undefined | PlanLevel) => {
 	}
 };
 
-export const suggestedMetrics = (usage: undefined | number) =>
-	(Math.round((usage ?? 1) / 1_000) + 1) * 12_000;
+export const runnerMinutePrice = (level: undefined | PlanLevel) => {
+	switch (level) {
+		case PlanLevel.Team:
+		case PlanLevel.Enterprise:
+			return 0.01666;
+		default:
+			return 0.0;
+	}
+};
+
+export const suggestedMetrics = (metrics: undefined | number) =>
+	(Math.round((metrics ?? 1) / 1_000) + 1) * 12_000;
 
 export const fmtUsd = (usd: undefined | number) => {
 	const numberFmd = new Intl.NumberFormat("en-US", {


### PR DESCRIPTION
This changeset adds the bare metal runner minutes to the billing dashboard.

A breaking change was made to [the organization usage API endpoint](https://bencher.dev/docs/api/organizations/usage/#get-v0organizationsorganizationusage) to rename `usage` to `metrics`. This is acceptable given the API is still `v0`.