### PR TITLE
Allow project key to be used for `bencher run` like API calls

### DIFF
--- a/lib/api_projects/src/alerts.rs
+++ b/lib/api_projects/src/alerts.rs
@@ -7,16 +7,13 @@ use bencher_rbac::project::Permission;
 use bencher_schema::{
     actor_conn, auth_conn,
     context::ApiContext,
-    error::{resource_conflict_err, resource_not_found_err, with_auth_hint, with_token_hint},
+    error::{forbidden_error, resource_conflict_err, resource_not_found_err, with_auth_hint},
     model::{
         project::{
             QueryProject,
             threshold::alert::{QueryAlert, UpdateAlert},
         },
-        user::{
-            actor::{ApiActor, PubProjectBearerToken},
-            auth::{AuthUser, BearerToken},
-        },
+        user::actor::{ApiActor, PubProjectBearerToken},
     },
     schema, write_conn,
 };
@@ -366,8 +363,9 @@ async fn get_one_inner(
 /// Update an alert
 ///
 /// Update an alert for a project.
-/// The user must have `edit` permissions for the project.
-/// Use this endpoint to dismiss an alert.
+/// The user must have `edit` permissions for the project,
+/// or provide a valid project key for the project (status only).
+/// Use this endpoint to dismiss or reactivate an alert.
 #[endpoint {
     method = PATCH,
     path =  "/v0/projects/{project}/alerts/{alert}",
@@ -375,42 +373,52 @@ async fn get_one_inner(
 }]
 pub async fn proj_alert_patch(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: BearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjAlertParams>,
     body: TypedBody<JsonUpdateAlert>,
 ) -> Result<ResponseOk<JsonAlert>, HttpError> {
-    let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
+    let api_actor = ApiActor::from_token(
+        &rqctx.log,
+        rqctx.context(),
+        #[cfg(feature = "plus")]
+        rqctx.request.headers(),
+        bearer_token,
+    )
+    .await?;
     let json = patch_inner(
         rqctx.context(),
+        &api_actor,
         path_params.into_inner(),
         body.into_inner(),
-        &auth_user,
     )
     .await
-    .map_err(with_token_hint)?;
+    .map_err(with_auth_hint)?;
     Ok(Patch::auth_response_ok(json))
 }
 
 async fn patch_inner(
     context: &ApiContext,
+    api_actor: &ApiActor,
     path_params: ProjAlertParams,
     json_alert: JsonUpdateAlert,
-    auth_user: &AuthUser,
 ) -> Result<JsonAlert, HttpError> {
-    // Verify that the user is allowed
-    let query_project = QueryProject::is_allowed(
+    if matches!(api_actor, ApiActor::ProjectKey(_)) && !json_alert.is_status_only() {
+        return Err(forbidden_error("Project keys can only update alert status"));
+    }
+    let query_project = QueryProject::is_allowed_actor_auth(
         auth_conn!(context),
         &context.rbac,
         #[cfg(feature = "plus")]
         &context.rate_limiting,
         &path_params.project,
-        auth_user,
+        api_actor,
         Permission::Edit,
     )?;
-
     let query_alert =
         QueryAlert::from_uuid(auth_conn!(context), query_project.id, path_params.alert)?;
-    let update_alert = UpdateAlert::from(json_alert.clone());
+
+    let now = context.clock.now();
+    let update_alert = UpdateAlert::status_change(json_alert.status, now);
     diesel::update(schema::alert::table.filter(schema::alert::id.eq(query_alert.id)))
         .set(&update_alert)
         .execute(write_conn!(context))

--- a/lib/api_projects/src/alerts.rs
+++ b/lib/api_projects/src/alerts.rs
@@ -111,7 +111,7 @@ async fn get_ls_inner(
     pagination_params: ProjAlertsPagination,
     query_params: ProjAlertsQuery,
 ) -> Result<(JsonAlerts, TotalCount), HttpError> {
-    let query_project = QueryProject::is_allowed_actor(
+    let query_project = QueryProject::is_allowed_actor_pub(
         actor_conn!(context, api_actor),
         &context.rbac,
         #[cfg(feature = "plus")]
@@ -346,7 +346,7 @@ async fn get_one_inner(
     path_params: ProjAlertParams,
     api_actor: &ApiActor,
 ) -> Result<JsonAlert, HttpError> {
-    let query_project = QueryProject::is_allowed_actor(
+    let query_project = QueryProject::is_allowed_actor_pub(
         actor_conn!(context, api_actor),
         &context.rbac,
         #[cfg(feature = "plus")]

--- a/lib/api_projects/src/benchmarks.rs
+++ b/lib/api_projects/src/benchmarks.rs
@@ -11,7 +11,10 @@ use bencher_rbac::project::Permission;
 use bencher_schema::{
     actor_conn, auth_conn,
     context::ApiContext,
-    error::{resource_conflict_err, resource_not_found_err, with_auth_hint, with_token_hint},
+    error::{
+        forbidden_error, resource_conflict_err, resource_not_found_err, with_auth_hint,
+        with_token_hint,
+    },
     model::{
         project::{
             QueryProject,
@@ -188,7 +191,8 @@ fn get_ls_query<'q>(
 /// Create a benchmark
 ///
 /// Create a benchmark for a project.
-/// The user must have `create` permissions for the project.
+/// The user must have `create` permissions for the project,
+/// or provide a valid project key for the project.
 #[endpoint {
     method = POST,
     path =  "/v0/projects/{project}/benchmarks",
@@ -196,19 +200,26 @@ fn get_ls_query<'q>(
 }]
 pub async fn proj_benchmark_post(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: BearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjBenchmarksParams>,
     body: TypedBody<JsonNewBenchmark>,
 ) -> Result<ResponseCreated<JsonBenchmark>, HttpError> {
-    let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
+    let api_actor = ApiActor::from_token(
+        &rqctx.log,
+        rqctx.context(),
+        #[cfg(feature = "plus")]
+        rqctx.request.headers(),
+        bearer_token,
+    )
+    .await?;
     let json = post_inner(
         rqctx.context(),
         path_params.into_inner(),
         body.into_inner(),
-        &auth_user,
+        &api_actor,
     )
     .await
-    .map_err(with_token_hint)?;
+    .map_err(with_auth_hint)?;
     Ok(Post::auth_response_created(json))
 }
 
@@ -216,16 +227,16 @@ async fn post_inner(
     context: &ApiContext,
     path_params: ProjBenchmarksParams,
     json_benchmark: JsonNewBenchmark,
-    auth_user: &AuthUser,
+    api_actor: &ApiActor,
 ) -> Result<JsonBenchmark, HttpError> {
     // Verify that the user is allowed
-    let query_project = QueryProject::is_allowed(
+    let query_project = QueryProject::is_allowed_actor_auth(
         auth_conn!(context),
         &context.rbac,
         #[cfg(feature = "plus")]
         &context.rate_limiting,
         &path_params.project,
-        auth_user,
+        api_actor,
         Permission::Create,
     )?;
 
@@ -313,7 +324,8 @@ async fn get_one_inner(
 /// Update a benchmark
 ///
 /// Update a benchmark for a project.
-/// The user must have `edit` permissions for the project.
+/// The user must have `edit` permissions for the project,
+/// or provide a valid project key for the project (no rename).
 #[endpoint {
     method = PATCH,
     path =  "/v0/projects/{project}/benchmarks/{benchmark}",
@@ -321,39 +333,47 @@ async fn get_one_inner(
 }]
 pub async fn proj_benchmark_patch(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: BearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjBenchmarkParams>,
     body: TypedBody<JsonUpdateBenchmark>,
 ) -> Result<ResponseOk<JsonBenchmark>, HttpError> {
-    let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
+    let api_actor = ApiActor::from_token(
+        &rqctx.log,
+        rqctx.context(),
+        #[cfg(feature = "plus")]
+        rqctx.request.headers(),
+        bearer_token,
+    )
+    .await?;
     let json = patch_inner(
         rqctx.context(),
+        &api_actor,
         path_params.into_inner(),
         body.into_inner(),
-        &auth_user,
     )
     .await
-    .map_err(with_token_hint)?;
+    .map_err(with_auth_hint)?;
     Ok(Patch::auth_response_ok(json))
 }
 
 async fn patch_inner(
     context: &ApiContext,
+    api_actor: &ApiActor,
     path_params: ProjBenchmarkParams,
     json_benchmark: JsonUpdateBenchmark,
-    auth_user: &AuthUser,
 ) -> Result<JsonBenchmark, HttpError> {
-    // Verify that the user is allowed
-    let query_project = QueryProject::is_allowed(
+    if matches!(api_actor, ApiActor::ProjectKey(_)) && json_benchmark.is_rename() {
+        return Err(forbidden_error("Project keys cannot rename benchmarks"));
+    }
+    let query_project = QueryProject::is_allowed_actor_auth(
         auth_conn!(context),
         &context.rbac,
         #[cfg(feature = "plus")]
         &context.rate_limiting,
         &path_params.project,
-        auth_user,
+        api_actor,
         Permission::Edit,
     )?;
-
     let query_benchmark = QueryBenchmark::from_resource_id(
         auth_conn!(context),
         query_project.id,

--- a/lib/api_projects/src/benchmarks.rs
+++ b/lib/api_projects/src/benchmarks.rs
@@ -119,7 +119,7 @@ async fn get_ls_inner(
     pagination_params: ProjBenchmarksPagination,
     query_params: ProjBenchmarksQuery,
 ) -> Result<(JsonBenchmarks, TotalCount), HttpError> {
-    let query_project = QueryProject::is_allowed_actor(
+    let query_project = QueryProject::is_allowed_actor_pub(
         actor_conn!(context, api_actor),
         &context.rbac,
         #[cfg(feature = "plus")]
@@ -301,7 +301,7 @@ async fn get_one_inner(
     api_actor: &ApiActor,
 ) -> Result<JsonBenchmark, HttpError> {
     actor_conn!(context, api_actor, |conn| {
-        let query_project = QueryProject::is_allowed_actor(
+        let query_project = QueryProject::is_allowed_actor_pub(
             conn,
             &context.rbac,
             #[cfg(feature = "plus")]

--- a/lib/api_projects/src/branches.rs
+++ b/lib/api_projects/src/branches.rs
@@ -11,8 +11,8 @@ use bencher_schema::{
     actor_conn, auth_conn,
     context::ApiContext,
     error::{
-        BencherResource, resource_conflict_err, resource_not_found_err, resource_not_found_error,
-        with_auth_hint, with_token_hint,
+        BencherResource, forbidden_error, resource_conflict_err, resource_not_found_err,
+        resource_not_found_error, with_auth_hint, with_token_hint,
     },
     model::{
         project::{
@@ -207,7 +207,8 @@ fn get_ls_query<'q>(
 /// Create a branch
 ///
 /// Create a branch for a project.
-/// The user must have `create` permissions for the project.
+/// The user must have `create` permissions for the project,
+/// or provide a valid project key for the project.
 #[endpoint {
     method = POST,
     path =  "/v0/projects/{project}/branches",
@@ -215,20 +216,27 @@ fn get_ls_query<'q>(
 }]
 pub async fn proj_branch_post(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: BearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjBranchesParams>,
     body: TypedBody<JsonNewBranch>,
 ) -> Result<ResponseCreated<JsonBranch>, HttpError> {
-    let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
+    let api_actor = ApiActor::from_token(
+        &rqctx.log,
+        rqctx.context(),
+        #[cfg(feature = "plus")]
+        rqctx.request.headers(),
+        bearer_token,
+    )
+    .await?;
     let json = post_inner(
         &rqctx.log,
         rqctx.context(),
         path_params.into_inner(),
         body.into_inner(),
-        &auth_user,
+        &api_actor,
     )
     .await
-    .map_err(with_token_hint)?;
+    .map_err(with_auth_hint)?;
     Ok(Post::auth_response_created(json))
 }
 
@@ -237,16 +245,16 @@ async fn post_inner(
     context: &ApiContext,
     path_params: ProjBranchesParams,
     json_branch: JsonNewBranch,
-    auth_user: &AuthUser,
+    api_actor: &ApiActor,
 ) -> Result<JsonBranch, HttpError> {
     // Verify that the user is allowed
-    let query_project = QueryProject::is_allowed(
+    let query_project = QueryProject::is_allowed_actor_auth(
         auth_conn!(context),
         &context.rbac,
         #[cfg(feature = "plus")]
         &context.rate_limiting,
         &path_params.project,
-        auth_user,
+        api_actor,
         Permission::Create,
     )?;
 
@@ -367,7 +375,8 @@ async fn get_one_inner(
 /// Update a branch
 ///
 /// Update a branch for a project.
-/// The user must have `edit` permissions for the project.
+/// The user must have `edit` permissions for the project,
+/// or provide a valid project key for the project (no rename).
 #[endpoint {
     method = PATCH,
     path =  "/v0/projects/{project}/branches/{branch}",
@@ -375,41 +384,49 @@ async fn get_one_inner(
 }]
 pub async fn proj_branch_patch(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: BearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjBranchParams>,
     body: TypedBody<JsonUpdateBranch>,
 ) -> Result<ResponseOk<JsonBranch>, HttpError> {
-    let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
+    let api_actor = ApiActor::from_token(
+        &rqctx.log,
+        rqctx.context(),
+        #[cfg(feature = "plus")]
+        rqctx.request.headers(),
+        bearer_token,
+    )
+    .await?;
     let json = patch_inner(
         &rqctx.log,
         rqctx.context(),
+        &api_actor,
         path_params.into_inner(),
         body.into_inner(),
-        &auth_user,
     )
     .await
-    .map_err(with_token_hint)?;
+    .map_err(with_auth_hint)?;
     Ok(Patch::auth_response_ok(json))
 }
 
 async fn patch_inner(
     log: &Logger,
     context: &ApiContext,
+    api_actor: &ApiActor,
     path_params: ProjBranchParams,
     json_branch: JsonUpdateBranch,
-    auth_user: &AuthUser,
 ) -> Result<JsonBranch, HttpError> {
-    // Verify that the user is allowed
-    let query_project = QueryProject::is_allowed(
+    if matches!(api_actor, ApiActor::ProjectKey(_)) && json_branch.is_rename() {
+        return Err(forbidden_error("Project keys cannot rename branches"));
+    }
+    let query_project = QueryProject::is_allowed_actor_auth(
         auth_conn!(context),
         &context.rbac,
         #[cfg(feature = "plus")]
         &context.rate_limiting,
         &path_params.project,
-        auth_user,
+        api_actor,
         Permission::Edit,
     )?;
-
     let query_branch =
         QueryBranch::from_resource_id(auth_conn!(context), query_project.id, &path_params.branch)?;
 

--- a/lib/api_projects/src/branches.rs
+++ b/lib/api_projects/src/branches.rs
@@ -120,7 +120,7 @@ async fn get_ls_inner(
     pagination_params: ProjBranchesPagination,
     query_params: ProjBranchesQuery,
 ) -> Result<(JsonBranches, TotalCount), HttpError> {
-    let query_project = QueryProject::is_allowed_actor(
+    let query_project = QueryProject::is_allowed_actor_pub(
         actor_conn!(context, api_actor),
         &context.rbac,
         #[cfg(feature = "plus")]
@@ -336,7 +336,7 @@ async fn get_one_inner(
     api_actor: &ApiActor,
 ) -> Result<JsonBranch, HttpError> {
     actor_conn!(context, api_actor, |conn| {
-        let query_project = QueryProject::is_allowed_actor(
+        let query_project = QueryProject::is_allowed_actor_pub(
             conn,
             &context.rbac,
             #[cfg(feature = "plus")]

--- a/lib/api_projects/src/jobs.rs
+++ b/lib/api_projects/src/jobs.rs
@@ -100,7 +100,7 @@ async fn get_ls_inner(
     query_params: ProjJobsQuery,
     api_actor: &ApiActor,
 ) -> Result<(JsonJobs, TotalCount), HttpError> {
-    let query_project = QueryProject::is_allowed_actor(
+    let query_project = QueryProject::is_allowed_actor_pub(
         actor_conn!(context, api_actor),
         &context.rbac,
         &context.rate_limiting,
@@ -223,7 +223,7 @@ async fn get_one_inner(
     api_actor: &ApiActor,
     log: &slog::Logger,
 ) -> Result<JsonJob, HttpError> {
-    let query_project = QueryProject::is_allowed_actor(
+    let query_project = QueryProject::is_allowed_actor_pub(
         actor_conn!(context, api_actor),
         &context.rbac,
         &context.rate_limiting,

--- a/lib/api_projects/src/measures.rs
+++ b/lib/api_projects/src/measures.rs
@@ -118,7 +118,7 @@ async fn get_ls_inner(
     pagination_params: ProjMeasuresPagination,
     query_params: ProjMeasuresQuery,
 ) -> Result<(JsonMeasures, TotalCount), HttpError> {
-    let query_project = QueryProject::is_allowed_actor(
+    let query_project = QueryProject::is_allowed_actor_pub(
         actor_conn!(context, api_actor),
         &context.rbac,
         #[cfg(feature = "plus")]
@@ -300,7 +300,7 @@ async fn get_one_inner(
     api_actor: &ApiActor,
 ) -> Result<JsonMeasure, HttpError> {
     actor_conn!(context, api_actor, |conn| {
-        let query_project = QueryProject::is_allowed_actor(
+        let query_project = QueryProject::is_allowed_actor_pub(
             conn,
             &context.rbac,
             #[cfg(feature = "plus")]

--- a/lib/api_projects/src/measures.rs
+++ b/lib/api_projects/src/measures.rs
@@ -10,7 +10,10 @@ use bencher_rbac::project::Permission;
 use bencher_schema::{
     actor_conn, auth_conn,
     context::ApiContext,
-    error::{resource_conflict_err, resource_not_found_err, with_auth_hint, with_token_hint},
+    error::{
+        forbidden_error, resource_conflict_err, resource_not_found_err, with_auth_hint,
+        with_token_hint,
+    },
     model::{
         project::{
             QueryProject,
@@ -187,7 +190,8 @@ fn get_ls_query<'q>(
 /// Create a measure
 ///
 /// Create a measure for a project.
-/// The user must have `create` permissions for the project.
+/// The user must have `create` permissions for the project,
+/// or provide a valid project key for the project.
 #[endpoint {
     method = POST,
     path =  "/v0/projects/{project}/measures",
@@ -195,19 +199,26 @@ fn get_ls_query<'q>(
 }]
 pub async fn proj_measure_post(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: BearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjMeasuresParams>,
     body: TypedBody<JsonNewMeasure>,
 ) -> Result<ResponseCreated<JsonMeasure>, HttpError> {
-    let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
+    let api_actor = ApiActor::from_token(
+        &rqctx.log,
+        rqctx.context(),
+        #[cfg(feature = "plus")]
+        rqctx.request.headers(),
+        bearer_token,
+    )
+    .await?;
     let json = post_inner(
         rqctx.context(),
         path_params.into_inner(),
         body.into_inner(),
-        &auth_user,
+        &api_actor,
     )
     .await
-    .map_err(with_token_hint)?;
+    .map_err(with_auth_hint)?;
     Ok(Post::auth_response_created(json))
 }
 
@@ -215,16 +226,16 @@ async fn post_inner(
     context: &ApiContext,
     path_params: ProjMeasuresParams,
     json_measure: JsonNewMeasure,
-    auth_user: &AuthUser,
+    api_actor: &ApiActor,
 ) -> Result<JsonMeasure, HttpError> {
     // Verify that the user is allowed
-    let query_project = QueryProject::is_allowed(
+    let query_project = QueryProject::is_allowed_actor_auth(
         auth_conn!(context),
         &context.rbac,
         #[cfg(feature = "plus")]
         &context.rate_limiting,
         &path_params.project,
-        auth_user,
+        api_actor,
         Permission::Create,
     )?;
 
@@ -312,7 +323,8 @@ async fn get_one_inner(
 /// Update a measure
 ///
 /// Update a measure for a project.
-/// The user must have `edit` permissions for the project.
+/// The user must have `edit` permissions for the project,
+/// or provide a valid project key for the project (no rename).
 #[endpoint {
     method = PATCH,
     path =  "/v0/projects/{project}/measures/{measure}",
@@ -320,39 +332,47 @@ async fn get_one_inner(
 }]
 pub async fn proj_measure_patch(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: BearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjMeasureParams>,
     body: TypedBody<JsonUpdateMeasure>,
 ) -> Result<ResponseOk<JsonMeasure>, HttpError> {
-    let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
+    let api_actor = ApiActor::from_token(
+        &rqctx.log,
+        rqctx.context(),
+        #[cfg(feature = "plus")]
+        rqctx.request.headers(),
+        bearer_token,
+    )
+    .await?;
     let json = patch_inner(
         rqctx.context(),
+        &api_actor,
         path_params.into_inner(),
         body.into_inner(),
-        &auth_user,
     )
     .await
-    .map_err(with_token_hint)?;
+    .map_err(with_auth_hint)?;
     Ok(Patch::auth_response_ok(json))
 }
 
 async fn patch_inner(
     context: &ApiContext,
+    api_actor: &ApiActor,
     path_params: ProjMeasureParams,
     json_measure: JsonUpdateMeasure,
-    auth_user: &AuthUser,
 ) -> Result<JsonMeasure, HttpError> {
-    // Verify that the user is allowed
-    let query_project = QueryProject::is_allowed(
+    if matches!(api_actor, ApiActor::ProjectKey(_)) && json_measure.is_rename() {
+        return Err(forbidden_error("Project keys cannot rename measures"));
+    }
+    let query_project = QueryProject::is_allowed_actor_auth(
         auth_conn!(context),
         &context.rbac,
         #[cfg(feature = "plus")]
         &context.rate_limiting,
         &path_params.project,
-        auth_user,
+        api_actor,
         Permission::Edit,
     )?;
-
     let query_measure = QueryMeasure::from_resource_id(
         auth_conn!(context),
         query_project.id,

--- a/lib/api_projects/src/metrics.rs
+++ b/lib/api_projects/src/metrics.rs
@@ -88,7 +88,7 @@ async fn get_one_inner(
     path_params: ProjMetricParams,
     api_actor: &ApiActor,
 ) -> Result<JsonOneMetric, HttpError> {
-    let query_project = QueryProject::is_allowed_actor(
+    let query_project = QueryProject::is_allowed_actor_pub(
         actor_conn!(context, api_actor),
         &context.rbac,
         #[cfg(feature = "plus")]

--- a/lib/api_projects/src/perf/mod.rs
+++ b/lib/api_projects/src/perf/mod.rs
@@ -119,7 +119,7 @@ async fn get_inner(
     json_perf_query: JsonPerfQuery,
     api_actor: &ApiActor,
 ) -> Result<JsonPerf, HttpError> {
-    let project = QueryProject::is_allowed_actor(
+    let project = QueryProject::is_allowed_actor_pub(
         actor_conn!(context, api_actor),
         &context.rbac,
         #[cfg(feature = "plus")]

--- a/lib/api_projects/src/plots.rs
+++ b/lib/api_projects/src/plots.rs
@@ -115,7 +115,7 @@ async fn get_ls_inner(
     pagination_params: ProjPlotsPagination,
     query_params: ProjPlotsQuery,
 ) -> Result<(JsonPlots, TotalCount), HttpError> {
-    let query_project = QueryProject::is_allowed_actor(
+    let query_project = QueryProject::is_allowed_actor_pub(
         actor_conn!(context, api_actor),
         &context.rbac,
         #[cfg(feature = "plus")]
@@ -304,7 +304,7 @@ async fn get_one_inner(
     path_params: ProjPlotParams,
     api_actor: &ApiActor,
 ) -> Result<JsonPlot, HttpError> {
-    let query_project = QueryProject::is_allowed_actor(
+    let query_project = QueryProject::is_allowed_actor_pub(
         actor_conn!(context, api_actor),
         &context.rbac,
         #[cfg(feature = "plus")]

--- a/lib/api_projects/src/projects.rs
+++ b/lib/api_projects/src/projects.rs
@@ -261,7 +261,7 @@ async fn get_one_inner(
     api_actor: &ApiActor,
 ) -> Result<JsonProject, HttpError> {
     actor_conn!(context, api_actor, |conn| {
-        QueryProject::is_allowed_actor(
+        QueryProject::is_allowed_actor_pub(
             conn,
             &context.rbac,
             #[cfg(feature = "plus")]

--- a/lib/api_projects/src/reports.rs
+++ b/lib/api_projects/src/reports.rs
@@ -268,7 +268,8 @@ type BoxedQuery<'q> = diesel::internal::table_macro::BoxedSelectStatement<
 /// Create a report
 ///
 /// Create a report for a project.
-/// The user must have `create` permissions for the project.
+/// The user must have `create` permissions for the project,
+/// or provide a valid project key for the project.
 /// If using the Bencher CLI, it is recommended to use the `bencher run` subcommand
 /// instead of trying to create a report manually.
 #[endpoint {
@@ -282,20 +283,27 @@ type BoxedQuery<'q> = diesel::internal::table_macro::BoxedSelectStatement<
 // bisect more complex logic will be required.
 pub async fn proj_report_post(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: BearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjReportsParams>,
     body: TypedBody<JsonNewReport>,
 ) -> Result<ResponseCreated<JsonReport>, HttpError> {
-    let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
+    let api_actor = ApiActor::from_token(
+        &rqctx.log,
+        rqctx.context(),
+        #[cfg(feature = "plus")]
+        rqctx.request.headers(),
+        bearer_token,
+    )
+    .await?;
     let json = post_inner(
         &rqctx.log,
         rqctx.context(),
         path_params.into_inner(),
         body.into_inner(),
-        auth_user,
+        api_actor,
     )
     .await
-    .map_err(with_token_hint)?;
+    .map_err(with_auth_hint)?;
     Ok(Post::auth_response_created(json))
 }
 
@@ -304,16 +312,16 @@ async fn post_inner(
     context: &ApiContext,
     path_params: ProjReportsParams,
     json_report: JsonNewReport,
-    auth_user: AuthUser,
+    api_actor: ApiActor,
 ) -> Result<JsonReport, HttpError> {
     // Verify that the user is allowed
-    let query_project = QueryProject::is_allowed(
+    let query_project = QueryProject::is_allowed_actor_auth(
         auth_conn!(context),
         &context.rbac,
         #[cfg(feature = "plus")]
         &context.rate_limiting,
         &path_params.project,
-        &auth_user,
+        &api_actor,
         Permission::Create,
     )?;
 
@@ -330,14 +338,7 @@ async fn post_inner(
         job: None,
     };
 
-    QueryReport::create(
-        log,
-        context,
-        &query_project,
-        new_run_report,
-        &auth_user.into(),
-    )
-    .await
+    QueryReport::create(log, context, &query_project, new_run_report, &api_actor).await
 }
 
 #[derive(Deserialize, JsonSchema)]

--- a/lib/api_projects/src/reports.rs
+++ b/lib/api_projects/src/reports.rs
@@ -131,7 +131,7 @@ async fn get_ls_inner(
     query_params: JsonReportQuery,
     api_actor: &ApiActor,
 ) -> Result<(JsonReports, TotalCount), HttpError> {
-    let query_project = QueryProject::is_allowed_actor(
+    let query_project = QueryProject::is_allowed_actor_pub(
         actor_conn!(context, api_actor),
         &context.rbac,
         #[cfg(feature = "plus")]
@@ -402,7 +402,7 @@ async fn get_one_inner(
     path_params: ProjReportParams,
     api_actor: &ApiActor,
 ) -> Result<JsonReport, HttpError> {
-    let query_project = QueryProject::is_allowed_actor(
+    let query_project = QueryProject::is_allowed_actor_pub(
         actor_conn!(context, api_actor),
         &context.rbac,
         #[cfg(feature = "plus")]

--- a/lib/api_projects/src/testbeds.rs
+++ b/lib/api_projects/src/testbeds.rs
@@ -122,7 +122,7 @@ async fn get_ls_inner(
     pagination_params: ProjTestbedsPagination,
     query_params: ProjTestbedsQuery,
 ) -> Result<(JsonTestbeds, TotalCount), HttpError> {
-    let query_project = QueryProject::is_allowed_actor(
+    let query_project = QueryProject::is_allowed_actor_pub(
         actor_conn!(context, api_actor),
         &context.rbac,
         #[cfg(feature = "plus")]
@@ -322,7 +322,7 @@ async fn get_one_inner(
     query_params: ProjTestbedQuery,
     api_actor: &ApiActor,
 ) -> Result<JsonTestbed, HttpError> {
-    let query_project = QueryProject::is_allowed_actor(
+    let query_project = QueryProject::is_allowed_actor_pub(
         actor_conn!(context, api_actor),
         &context.rbac,
         #[cfg(feature = "plus")]

--- a/lib/api_projects/src/testbeds.rs
+++ b/lib/api_projects/src/testbeds.rs
@@ -14,7 +14,10 @@ use bencher_schema::model::spec::QuerySpec;
 use bencher_schema::{
     actor_conn, auth_conn,
     context::ApiContext,
-    error::{resource_conflict_err, resource_not_found_err, with_auth_hint, with_token_hint},
+    error::{
+        forbidden_error, resource_conflict_err, resource_not_found_err, with_auth_hint,
+        with_token_hint,
+    },
     model::{
         project::{
             QueryProject,
@@ -193,7 +196,8 @@ fn get_ls_query<'q>(
 /// Create a testbed
 ///
 /// Create a testbed for a project.
-/// The user must have `create` permissions for the project.
+/// The user must have `create` permissions for the project,
+/// or provide a valid project key for the project.
 #[endpoint {
     method = POST,
     path =  "/v0/projects/{project}/testbeds",
@@ -201,19 +205,26 @@ fn get_ls_query<'q>(
 }]
 pub async fn proj_testbed_post(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: BearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjTestbedsParams>,
     body: TypedBody<JsonNewTestbed>,
 ) -> Result<ResponseCreated<JsonTestbed>, HttpError> {
-    let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
+    let api_actor = ApiActor::from_token(
+        &rqctx.log,
+        rqctx.context(),
+        #[cfg(feature = "plus")]
+        rqctx.request.headers(),
+        bearer_token,
+    )
+    .await?;
     let json = post_inner(
         rqctx.context(),
         path_params.into_inner(),
         body.into_inner(),
-        &auth_user,
+        &api_actor,
     )
     .await
-    .map_err(with_token_hint)?;
+    .map_err(with_auth_hint)?;
     Ok(Post::auth_response_created(json))
 }
 
@@ -221,16 +232,16 @@ async fn post_inner(
     context: &ApiContext,
     path_params: ProjTestbedsParams,
     json_testbed: JsonNewTestbed,
-    auth_user: &AuthUser,
+    api_actor: &ApiActor,
 ) -> Result<JsonTestbed, HttpError> {
     // Verify that the user is allowed
-    let query_project = QueryProject::is_allowed(
+    let query_project = QueryProject::is_allowed_actor_auth(
         auth_conn!(context),
         &context.rbac,
         #[cfg(feature = "plus")]
         &context.rate_limiting,
         &path_params.project,
-        auth_user,
+        api_actor,
         Permission::Create,
     )?;
 
@@ -344,7 +355,8 @@ async fn get_one_inner(
 /// Update a testbed
 ///
 /// Update a testbed for a project.
-/// The user must have `edit` permissions for the project.
+/// The user must have `edit` permissions for the project,
+/// or provide a valid project key for the project (no rename).
 #[endpoint {
     method = PATCH,
     path =  "/v0/projects/{project}/testbeds/{testbed}",
@@ -352,40 +364,47 @@ async fn get_one_inner(
 }]
 pub async fn proj_testbed_patch(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: BearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjTestbedParams>,
     body: TypedBody<JsonUpdateTestbed>,
 ) -> Result<ResponseOk<JsonTestbed>, HttpError> {
-    let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
-    let context = rqctx.context();
+    let api_actor = ApiActor::from_token(
+        &rqctx.log,
+        rqctx.context(),
+        #[cfg(feature = "plus")]
+        rqctx.request.headers(),
+        bearer_token,
+    )
+    .await?;
     let json = patch_inner(
-        context,
+        rqctx.context(),
+        &api_actor,
         path_params.into_inner(),
         body.into_inner(),
-        &auth_user,
     )
     .await
-    .map_err(with_token_hint)?;
+    .map_err(with_auth_hint)?;
     Ok(Patch::auth_response_ok(json))
 }
 
 async fn patch_inner(
     context: &ApiContext,
+    api_actor: &ApiActor,
     path_params: ProjTestbedParams,
     json_testbed: JsonUpdateTestbed,
-    auth_user: &AuthUser,
 ) -> Result<JsonTestbed, HttpError> {
-    // Verify that the user is allowed
-    let query_project = QueryProject::is_allowed(
+    if matches!(api_actor, ApiActor::ProjectKey(_)) && json_testbed.is_rename() {
+        return Err(forbidden_error("Project keys cannot rename testbeds"));
+    }
+    let query_project = QueryProject::is_allowed_actor_auth(
         auth_conn!(context),
         &context.rbac,
         #[cfg(feature = "plus")]
         &context.rate_limiting,
         &path_params.project,
-        auth_user,
+        api_actor,
         Permission::Edit,
     )?;
-
     let now = context.clock.now();
     let (query_testbed, update_testbed) = auth_conn!(context, |conn| {
         let query_testbed =

--- a/lib/api_projects/src/thresholds.rs
+++ b/lib/api_projects/src/thresholds.rs
@@ -124,7 +124,7 @@ async fn get_ls_inner(
     query_params: JsonThresholdQuery,
     api_actor: &ApiActor,
 ) -> Result<(JsonThresholds, TotalCount), HttpError> {
-    let query_project = QueryProject::is_allowed_actor(
+    let query_project = QueryProject::is_allowed_actor_pub(
         actor_conn!(context, api_actor),
         &context.rbac,
         #[cfg(feature = "plus")]
@@ -401,7 +401,7 @@ async fn get_one_inner(
     api_actor: &ApiActor,
 ) -> Result<JsonThreshold, HttpError> {
     actor_conn!(context, api_actor, |conn| {
-        let query_project = QueryProject::is_allowed_actor(
+        let query_project = QueryProject::is_allowed_actor_pub(
             conn,
             &context.rbac,
             #[cfg(feature = "plus")]

--- a/lib/api_projects/src/thresholds.rs
+++ b/lib/api_projects/src/thresholds.rs
@@ -245,7 +245,8 @@ type BoxedQuery<'q> = diesel::internal::table_macro::BoxedSelectStatement<
 /// Create a threshold
 ///
 /// Create a threshold for a project.
-/// The user must have `create` permissions for the project.
+/// The user must have `create` permissions for the project,
+/// or provide a valid project key for the project.
 /// There can only be one threshold for any unique combination of: branch, testbed, and measure.
 #[endpoint {
     method = POST,
@@ -254,19 +255,26 @@ type BoxedQuery<'q> = diesel::internal::table_macro::BoxedSelectStatement<
 }]
 pub async fn proj_threshold_post(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: BearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjThresholdsParams>,
     body: TypedBody<JsonNewThreshold>,
 ) -> Result<ResponseCreated<JsonThreshold>, HttpError> {
-    let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
+    let api_actor = ApiActor::from_token(
+        &rqctx.log,
+        rqctx.context(),
+        #[cfg(feature = "plus")]
+        rqctx.request.headers(),
+        bearer_token,
+    )
+    .await?;
     let json = post_inner(
         rqctx.context(),
         path_params.into_inner(),
         &body.into_inner(),
-        &auth_user,
+        &api_actor,
     )
     .await
-    .map_err(with_token_hint)?;
+    .map_err(with_auth_hint)?;
     Ok(Post::auth_response_created(json))
 }
 
@@ -274,19 +282,19 @@ async fn post_inner(
     context: &ApiContext,
     path_params: ProjThresholdsParams,
     json_threshold: &JsonNewThreshold,
-    auth_user: &AuthUser,
+    api_actor: &ApiActor,
 ) -> Result<JsonThreshold, HttpError> {
     // Validate the new model
     json_threshold.model.validate().map_err(bad_request_error)?;
 
     // Verify that the user is allowed
-    let query_project = QueryProject::is_allowed(
+    let query_project = QueryProject::is_allowed_actor_auth(
         auth_conn!(context),
         &context.rbac,
         #[cfg(feature = "plus")]
         &context.rate_limiting,
         &path_params.project,
-        auth_user,
+        api_actor,
         Permission::Create,
     )?;
 
@@ -432,7 +440,8 @@ async fn get_one_inner(
 /// Update a threshold
 ///
 /// Update a threshold for a project.
-/// The user must have `edit` permissions for the project.
+/// The user must have `edit` permissions for the project,
+/// or provide a valid project key for the project.
 /// The new model will be added to the threshold and used going forward.
 /// The old model will be replaced but still show up in the report history and alerts created when it was active.
 #[endpoint {
@@ -442,19 +451,26 @@ async fn get_one_inner(
 }]
 pub async fn proj_threshold_put(
     rqctx: RequestContext<ApiContext>,
-    bearer_token: BearerToken,
+    bearer_token: PubProjectBearerToken,
     path_params: Path<ProjThresholdParams>,
     body: TypedBody<JsonUpdateThreshold>,
 ) -> Result<ResponseOk<JsonThreshold>, HttpError> {
-    let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
+    let api_actor = ApiActor::from_token(
+        &rqctx.log,
+        rqctx.context(),
+        #[cfg(feature = "plus")]
+        rqctx.request.headers(),
+        bearer_token,
+    )
+    .await?;
     let json = put_inner(
         rqctx.context(),
         path_params.into_inner(),
         body.into_inner(),
-        &auth_user,
+        &api_actor,
     )
     .await
-    .map_err(with_token_hint)?;
+    .map_err(with_auth_hint)?;
     Ok(Put::auth_response_ok(json))
 }
 
@@ -462,7 +478,7 @@ async fn put_inner(
     context: &ApiContext,
     path_params: ProjThresholdParams,
     json_threshold: JsonUpdateThreshold,
-    auth_user: &AuthUser,
+    api_actor: &ApiActor,
 ) -> Result<JsonThreshold, HttpError> {
     // Validate the new model
     let model = match json_threshold {
@@ -474,13 +490,13 @@ async fn put_inner(
     };
 
     // Verify that the user is allowed
-    let query_project = QueryProject::is_allowed(
+    let query_project = QueryProject::is_allowed_actor_auth(
         auth_conn!(context),
         &context.rbac,
         #[cfg(feature = "plus")]
         &context.rate_limiting,
         &path_params.project,
-        auth_user,
+        api_actor,
         Permission::Edit,
     )?;
 

--- a/lib/api_projects/tests/project_key_auth.rs
+++ b/lib/api_projects/tests/project_key_auth.rs
@@ -6,11 +6,12 @@
     clippy::tests_outside_test_module,
     clippy::uninlined_format_args
 )]
-//! Integration tests for project key authentication on GET endpoints.
+//! Integration tests for project key authentication.
 
 use bencher_api_tests::TestServer;
 use bencher_json::{
-    JsonBranch, JsonBranches, JsonProject, JsonProjectKeyCreated, JsonProjects, ProjectKey,
+    JsonBenchmark, JsonBranch, JsonBranches, JsonMeasure, JsonProject, JsonProjectKeyCreated,
+    JsonProjects, JsonTestbed, JsonThreshold, ProjectKey,
 };
 use http::StatusCode;
 
@@ -342,9 +343,9 @@ async fn project_key_cannot_list_keys() {
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }
 
-// Negative: project key cannot write (POST requires user auth)
+// POST /v0/projects/{project}/branches - create branch with key
 #[tokio::test]
-async fn project_key_cannot_write() {
+async fn project_key_can_create_branch() {
     let (server, project_slug, _token, key) = setup().await;
 
     let resp = server
@@ -354,12 +355,196 @@ async fn project_key_cannot_write() {
             bencher_json::AUTHORIZATION,
             bencher_json::bearer_header(key.as_ref()),
         )
-        .json(&serde_json::json!({"name": "new-branch"}))
+        .json(&serde_json::json!({"name": "key-branch"}))
         .send()
         .await
         .expect("Request failed");
 
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let branch: JsonBranch = resp.json().await.expect("Failed to parse response");
+    let name: &str = branch.name.as_ref();
+    assert_eq!(name, "key-branch");
+}
+
+// POST /v0/projects/{project}/testbeds - create testbed with key
+#[tokio::test]
+async fn project_key_can_create_testbed() {
+    let (server, project_slug, _token, key) = setup().await;
+
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/testbeds", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .json(&serde_json::json!({"name": "key-testbed"}))
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let testbed: JsonTestbed = resp.json().await.expect("Failed to parse response");
+    let name: &str = testbed.name.as_ref();
+    assert_eq!(name, "key-testbed");
+}
+
+// POST /v0/projects/{project}/benchmarks - create benchmark with key
+#[tokio::test]
+async fn project_key_can_create_benchmark() {
+    let (server, project_slug, _token, key) = setup().await;
+
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/benchmarks", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .json(&serde_json::json!({"name": "key-benchmark"}))
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let benchmark: JsonBenchmark = resp.json().await.expect("Failed to parse response");
+    let name: &str = benchmark.name.as_ref();
+    assert_eq!(name, "key-benchmark");
+}
+
+// POST /v0/projects/{project}/measures - create measure with key
+#[tokio::test]
+async fn project_key_can_create_measure() {
+    let (server, project_slug, _token, key) = setup().await;
+
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/measures", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .json(&serde_json::json!({"name": "key-measure", "units": "ns/iter"}))
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let measure: JsonMeasure = resp.json().await.expect("Failed to parse response");
+    let name: &str = measure.name.as_ref();
+    assert_eq!(name, "key-measure");
+}
+
+// POST /v0/projects/{project}/thresholds - create threshold with key
+#[tokio::test]
+async fn project_key_can_create_threshold() {
+    let (server, project_slug, token, key) = setup().await;
+
+    // Create branch, testbed, and measure using JWT auth
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/branches", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&token),
+        )
+        .json(&serde_json::json!({"name": "threshold-branch"}))
+        .send()
+        .await
+        .expect("Failed to create branch");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/testbeds", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&token),
+        )
+        .json(&serde_json::json!({"name": "threshold-testbed"}))
+        .send()
+        .await
+        .expect("Failed to create testbed");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/measures", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&token),
+        )
+        .json(&serde_json::json!({"name": "threshold-measure", "units": "ns/iter"}))
+        .send()
+        .await
+        .expect("Failed to create measure");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    // Create threshold using project key
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/thresholds", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .json(&serde_json::json!({
+            "branch": "threshold-branch",
+            "testbed": "threshold-testbed",
+            "measure": "threshold-measure",
+            "test": "percentage",
+            "upper_boundary": 0.25
+        }))
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let _threshold: JsonThreshold = resp.json().await.expect("Failed to parse response");
+}
+
+// Negative: project key cannot create in wrong project
+#[tokio::test]
+async fn project_key_cannot_create_in_wrong_project() {
+    let server = TestServer::new().await;
+    let user = server
+        .signup("Key User", "keycrosscreate@example.com")
+        .await;
+    let org = server.create_org(&user, "Cross Create Org").await;
+    let project_a = server.create_project(&user, &org, "Create A").await;
+    let project_b = server.create_project(&user, &org, "Create B").await;
+
+    let slug_a: &str = project_a.slug.as_ref();
+    let slug_b: &str = project_b.slug.as_ref();
+
+    // Create key for project A
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/keys", slug_a)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(&serde_json::json!({"name": "cross-key"}))
+        .send()
+        .await
+        .expect("Failed to create key");
+    let key_created: JsonProjectKeyCreated = resp.json().await.expect("Failed to parse key");
+
+    // Try to create a branch in project B with project A's key
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/branches", slug_b)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key_created.key.as_ref()),
+        )
+        .json(&serde_json::json!({"name": "cross-branch"}))
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
 
 // Negative: revoked project key is rejected

--- a/lib/api_projects/tests/project_key_auth.rs
+++ b/lib/api_projects/tests/project_key_auth.rs
@@ -11,7 +11,7 @@
 use bencher_api_tests::TestServer;
 use bencher_json::{
     JsonBenchmark, JsonBranch, JsonBranches, JsonMeasure, JsonProject, JsonProjectKeyCreated,
-    JsonProjects, JsonTestbed, JsonThreshold, ProjectKey,
+    JsonProjects, JsonReport, JsonTestbed, JsonThreshold, ProjectKey,
 };
 use http::StatusCode;
 
@@ -503,6 +503,33 @@ async fn project_key_can_create_threshold() {
     let _threshold: JsonThreshold = resp.json().await.expect("Failed to parse response");
 }
 
+// POST /v0/projects/{project}/reports - project key CAN create report
+#[tokio::test]
+async fn project_key_can_create_report() {
+    let (server, project_slug, _token, key) = setup().await;
+
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/reports", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .json(&serde_json::json!({
+            "branch": "main",
+            "testbed": "localhost",
+            "start_time": "2024-01-01T00:00:00Z",
+            "end_time": "2024-01-01T00:01:00Z",
+            "results": ["{\"bench_name\": {\"latency\": {\"value\": 100.0}}}"]
+        }))
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let _report: JsonReport = resp.json().await.expect("Failed to parse response");
+}
+
 // Negative: project key cannot create in wrong project
 #[tokio::test]
 async fn project_key_cannot_create_in_wrong_project() {
@@ -878,6 +905,107 @@ async fn project_key_can_update_threshold() {
             "test": "percentage",
             "upper_boundary": 0.50
         }))
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+// PATCH /v0/projects/{project}/alerts/{alert} - project key CAN dismiss alert
+#[tokio::test]
+async fn project_key_can_dismiss_alert() {
+    let (server, project_slug, _token, key) = setup().await;
+
+    // Submit a run with a tight threshold to generate an alert.
+    // First, submit a baseline run to establish metrics.
+    server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/reports", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .json(&serde_json::json!({
+            "branch": "main",
+            "testbed": "localhost",
+            "thresholds": {
+                "models": {
+                    "latency": {
+                        "test": "percentage",
+                        "min_sample_size": 2,
+                        "upper_boundary": 0.01
+                    }
+                }
+            },
+            "start_time": "2024-01-01T00:00:00Z",
+            "end_time": "2024-01-01T00:01:00Z",
+            "results": ["{\"bench\": {\"latency\": {\"value\": 100.0}}}"]
+        }))
+        .send()
+        .await
+        .expect("Failed to submit baseline");
+
+    // Submit a second run with a much higher value to trigger an alert
+    server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/reports", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .json(&serde_json::json!({
+            "branch": "main",
+            "testbed": "localhost",
+            "start_time": "2024-01-01T00:02:00Z",
+            "end_time": "2024-01-01T00:03:00Z",
+            "results": ["{\"bench\": {\"latency\": {\"value\": 100.0}}}"]
+        }))
+        .send()
+        .await
+        .expect("Failed to submit second run");
+
+    // Submit a third run with a spike to trigger an alert (need min_sample_size of 2)
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/reports", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .json(&serde_json::json!({
+            "branch": "main",
+            "testbed": "localhost",
+            "start_time": "2024-01-01T00:04:00Z",
+            "end_time": "2024-01-01T00:05:00Z",
+            "results": ["{\"bench\": {\"latency\": {\"value\": 999999.0}}}"]
+        }))
+        .send()
+        .await
+        .expect("Failed to submit spike run");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let report: JsonReport = resp.json().await.expect("Failed to parse report");
+
+    // Check that an alert was generated
+    assert!(
+        !report.alerts.is_empty(),
+        "Expected at least one alert from the spike run"
+    );
+
+    let alert_uuid = report.alerts[0].uuid;
+
+    // Dismiss the alert with the project key
+    let resp = server
+        .client
+        .patch(server.api_url(&format!(
+            "/v0/projects/{}/alerts/{}",
+            project_slug, alert_uuid
+        )))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .json(&serde_json::json!({"status": "dismissed"}))
         .send()
         .await
         .expect("Request failed");

--- a/lib/api_projects/tests/project_key_auth.rs
+++ b/lib/api_projects/tests/project_key_auth.rs
@@ -615,3 +615,272 @@ async fn project_key_revoked() {
         .expect("Request failed");
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
+
+// PATCH /v0/projects/{project}/branches/{branch} - project key cannot rename
+#[tokio::test]
+async fn project_key_cannot_rename_branch() {
+    let (server, project_slug, token, key) = setup().await;
+
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/branches", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&token),
+        )
+        .json(&serde_json::json!({"name": "rename-branch"}))
+        .send()
+        .await
+        .expect("Failed to create branch");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let branch: JsonBranch = resp.json().await.expect("Failed to parse branch");
+
+    let resp = server
+        .client
+        .patch(server.api_url(&format!(
+            "/v0/projects/{}/branches/{}",
+            project_slug, branch.slug
+        )))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .json(&serde_json::json!({"name": "new-name"}))
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+// PATCH /v0/projects/{project}/branches/{branch} - project key CAN archive
+#[tokio::test]
+async fn project_key_can_archive_branch() {
+    let (server, project_slug, token, key) = setup().await;
+
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/branches", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&token),
+        )
+        .json(&serde_json::json!({"name": "archive-branch"}))
+        .send()
+        .await
+        .expect("Failed to create branch");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let branch: JsonBranch = resp.json().await.expect("Failed to parse branch");
+
+    let resp = server
+        .client
+        .patch(server.api_url(&format!(
+            "/v0/projects/{}/branches/{}",
+            project_slug, branch.slug
+        )))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .json(&serde_json::json!({"archived": true}))
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+// PATCH /v0/projects/{project}/benchmarks/{benchmark} - project key cannot rename
+#[tokio::test]
+async fn project_key_cannot_rename_benchmark() {
+    let (server, project_slug, token, key) = setup().await;
+
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/benchmarks", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&token),
+        )
+        .json(&serde_json::json!({"name": "rename-benchmark"}))
+        .send()
+        .await
+        .expect("Failed to create benchmark");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let benchmark: JsonBenchmark = resp.json().await.expect("Failed to parse benchmark");
+
+    let resp = server
+        .client
+        .patch(server.api_url(&format!(
+            "/v0/projects/{}/benchmarks/{}",
+            project_slug, benchmark.slug
+        )))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .json(&serde_json::json!({"name": "new-name"}))
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+// PATCH /v0/projects/{project}/testbeds/{testbed} - project key cannot rename
+#[tokio::test]
+async fn project_key_cannot_rename_testbed() {
+    let (server, project_slug, token, key) = setup().await;
+
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/testbeds", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&token),
+        )
+        .json(&serde_json::json!({"name": "rename-testbed"}))
+        .send()
+        .await
+        .expect("Failed to create testbed");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let testbed: JsonTestbed = resp.json().await.expect("Failed to parse testbed");
+
+    let resp = server
+        .client
+        .patch(server.api_url(&format!(
+            "/v0/projects/{}/testbeds/{}",
+            project_slug, testbed.slug
+        )))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .json(&serde_json::json!({"name": "new-name"}))
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+// PATCH /v0/projects/{project}/measures/{measure} - project key cannot rename
+#[tokio::test]
+async fn project_key_cannot_rename_measure() {
+    let (server, project_slug, token, key) = setup().await;
+
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/measures", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&token),
+        )
+        .json(&serde_json::json!({"name": "rename-measure", "units": "ns/iter"}))
+        .send()
+        .await
+        .expect("Failed to create measure");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let measure: JsonMeasure = resp.json().await.expect("Failed to parse measure");
+
+    let resp = server
+        .client
+        .patch(server.api_url(&format!(
+            "/v0/projects/{}/measures/{}",
+            project_slug, measure.slug
+        )))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .json(&serde_json::json!({"name": "new-name"}))
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+// PUT /v0/projects/{project}/thresholds/{threshold} - project key CAN update model
+#[tokio::test]
+async fn project_key_can_update_threshold() {
+    let (server, project_slug, token, key) = setup().await;
+
+    // Create branch, testbed, measure, and threshold with user token
+    server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/branches", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&token),
+        )
+        .json(&serde_json::json!({"name": "thresh-branch"}))
+        .send()
+        .await
+        .expect("Failed to create branch");
+
+    server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/testbeds", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&token),
+        )
+        .json(&serde_json::json!({"name": "thresh-testbed"}))
+        .send()
+        .await
+        .expect("Failed to create testbed");
+
+    server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/measures", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&token),
+        )
+        .json(&serde_json::json!({"name": "thresh-measure", "units": "ns/iter"}))
+        .send()
+        .await
+        .expect("Failed to create measure");
+
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/thresholds", project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&token),
+        )
+        .json(&serde_json::json!({
+            "branch": "thresh-branch",
+            "testbed": "thresh-testbed",
+            "measure": "thresh-measure",
+            "test": "percentage",
+            "upper_boundary": 0.25
+        }))
+        .send()
+        .await
+        .expect("Failed to create threshold");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let threshold: JsonThreshold = resp.json().await.expect("Failed to parse threshold");
+
+    // PUT with project key to update model
+    let resp = server
+        .client
+        .put(server.api_url(&format!(
+            "/v0/projects/{}/thresholds/{}",
+            project_slug, threshold.uuid
+        )))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(key.as_ref()),
+        )
+        .json(&serde_json::json!({
+            "test": "percentage",
+            "upper_boundary": 0.50
+        }))
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}

--- a/lib/api_run/src/run.rs
+++ b/lib/api_run/src/run.rs
@@ -4,7 +4,7 @@ use bencher_rbac::project::Permission;
 use bencher_schema::{
     auth_conn,
     context::ApiContext,
-    error::{bad_request_error, forbidden_error, unauthorized_error, with_auth_hint},
+    error::{bad_request_error, unauthorized_error, with_auth_hint},
     model::{
         project::{
             QueryProject,
@@ -176,11 +176,7 @@ async fn post_inner_project_key(
     // Verify the run targets this project (if explicitly specified)
     if let Some(project_rid) = json_run.project.as_ref() {
         let target = QueryProject::from_resource_id(auth_conn!(context), project_rid)?;
-        if target.id != project_key_actor.project_id {
-            return Err(forbidden_error(
-                "Project key is not authorized for the specified project",
-            ));
-        }
+        project_key_actor.verify_project(target.id)?;
     }
 
     slog::info!(log, "New run via project key"; "project" => ?query_project.uuid);

--- a/lib/bencher_json/src/project/alert.rs
+++ b/lib/bencher_json/src/project/alert.rs
@@ -114,6 +114,13 @@ pub struct JsonUpdateAlert {
     pub status: Option<UpdateAlertStatus>,
 }
 
+impl JsonUpdateAlert {
+    pub fn is_status_only(&self) -> bool {
+        let Self { status: _ } = self;
+        true
+    }
+}
+
 #[typeshare::typeshare]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]

--- a/lib/bencher_json/src/project/benchmark.rs
+++ b/lib/bencher_json/src/project/benchmark.rs
@@ -68,3 +68,14 @@ pub struct JsonUpdateBenchmark {
     /// Set whether the benchmark is archived.
     pub archived: Option<bool>,
 }
+
+impl JsonUpdateBenchmark {
+    pub fn is_rename(&self) -> bool {
+        let Self {
+            name,
+            slug,
+            archived: _,
+        } = self;
+        name.is_some() || slug.is_some()
+    }
+}

--- a/lib/bencher_json/src/project/branch.rs
+++ b/lib/bencher_json/src/project/branch.rs
@@ -133,6 +133,18 @@ pub struct JsonUpdateBranch {
     pub archived: Option<bool>,
 }
 
+impl JsonUpdateBranch {
+    pub fn is_rename(&self) -> bool {
+        let Self {
+            name,
+            slug,
+            start_point: _,
+            archived: _,
+        } = self;
+        name.is_some() || slug.is_some()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct JsonUpdateStartPoint {

--- a/lib/bencher_json/src/project/measure/mod.rs
+++ b/lib/bencher_json/src/project/measure/mod.rs
@@ -90,3 +90,15 @@ pub struct JsonUpdateMeasure {
     /// Set whether the measure is archived.
     pub archived: Option<bool>,
 }
+
+impl JsonUpdateMeasure {
+    pub fn is_rename(&self) -> bool {
+        let Self {
+            name,
+            slug,
+            units: _,
+            archived: _,
+        } = self;
+        name.is_some() || slug.is_some()
+    }
+}

--- a/lib/bencher_json/src/project/testbed.rs
+++ b/lib/bencher_json/src/project/testbed.rs
@@ -108,6 +108,33 @@ pub enum JsonUpdateTestbed {
     Null(JsonTestbedPatchNull),
 }
 
+impl JsonUpdateTestbed {
+    pub fn is_rename(&self) -> bool {
+        match self {
+            Self::Patch(patch) => {
+                let JsonTestbedPatch {
+                    name,
+                    slug,
+                    #[cfg(feature = "plus")]
+                        spec: _,
+                    archived: _,
+                } = patch;
+                name.is_some() || slug.is_some()
+            },
+            Self::Null(patch_null) => {
+                let JsonTestbedPatchNull {
+                    name,
+                    slug,
+                    #[cfg(feature = "plus")]
+                        spec: (),
+                    archived: _,
+                } = patch_null;
+                name.is_some() || slug.is_some()
+            },
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct JsonTestbedPatch {

--- a/lib/bencher_schema/src/model/project/branch/head.rs
+++ b/lib/bencher_schema/src/model/project/branch/head.rs
@@ -295,7 +295,7 @@ impl InsertHead {
                     .set(&update_head)
                     .execute(conn)?;
 
-                QueryAlert::silence_all(conn, old_head_id)?
+                QueryAlert::silence_all(conn, old_head_id, context.clock.now())?
             } else {
                 0
             };
@@ -1308,7 +1308,7 @@ mod tests {
                 .load::<AlertId>(conn)?;
 
             if !alerts.is_empty() {
-                let silenced_alert = UpdateAlert::silence();
+                let silenced_alert = UpdateAlert::silence(DateTime::TEST);
                 diesel::update(schema::alert::table.filter(schema::alert::id.eq_any(&alerts)))
                     .set(&silenced_alert)
                     .execute(conn)?;

--- a/lib/bencher_schema/src/model/project/mod.rs
+++ b/lib/bencher_schema/src/model/project/mod.rs
@@ -477,11 +477,39 @@ impl QueryProject {
             },
             ApiActor::ProjectKey(project_key_actor) => {
                 let query_project = Self::from_resource_id(conn, project)?;
-                if query_project.id == project_key_actor.project_id {
-                    Ok(query_project)
-                } else {
-                    Err(unauthorized_error(project))
-                }
+                project_key_actor.verify_project(query_project.id)?;
+                Ok(query_project)
+            },
+        }
+    }
+
+    pub fn is_allowed_actor_auth(
+        conn: &mut DbConnection,
+        rbac: &Rbac,
+        #[cfg(feature = "plus")] rate_limiting: &crate::context::RateLimiting,
+        project: &ProjectResourceId,
+        api_actor: &ApiActor,
+        permission: Permission,
+    ) -> Result<Self, HttpError> {
+        match api_actor {
+            ApiActor::Public(PublicUser::Public(_)) => {
+                Err(unauthorized_error("Authentication required"))
+            },
+            ApiActor::Public(PublicUser::Auth(auth_user)) => Self::is_allowed(
+                conn,
+                rbac,
+                #[cfg(feature = "plus")]
+                rate_limiting,
+                project,
+                auth_user,
+                permission,
+            ),
+            ApiActor::ProjectKey(project_key_actor) => {
+                let query_project = Self::from_resource_id(conn, project)?;
+                project_key_actor.verify_project(query_project.id)?;
+                #[cfg(feature = "plus")]
+                rate_limiting.project_request(query_project.uuid)?;
+                Ok(query_project)
             },
         }
     }

--- a/lib/bencher_schema/src/model/project/mod.rs
+++ b/lib/bencher_schema/src/model/project/mod.rs
@@ -447,7 +447,7 @@ impl QueryProject {
         }
     }
 
-    pub fn is_allowed_actor(
+    pub fn is_allowed_actor_pub(
         conn: &mut DbConnection,
         rbac: &Rbac,
         #[cfg(feature = "plus")] rate_limiting: &crate::context::RateLimiting,

--- a/lib/bencher_schema/src/model/project/threshold/alert.rs
+++ b/lib/bencher_schema/src/model/project/threshold/alert.rs
@@ -65,7 +65,11 @@ impl QueryAlert {
             .map_err(resource_not_found_err!(Alert, (project_id, uuid)))
     }
 
-    pub fn silence_all(conn: &mut DbConnection, head_id: HeadId) -> diesel::QueryResult<usize> {
+    pub fn silence_all(
+        conn: &mut DbConnection,
+        head_id: HeadId,
+        now: DateTime,
+    ) -> diesel::QueryResult<usize> {
         let alerts =
             schema::alert::table
                 .inner_join(schema::boundary::table.inner_join(
@@ -81,7 +85,7 @@ impl QueryAlert {
             return Ok(0);
         }
 
-        let silenced_alert = UpdateAlert::silence();
+        let silenced_alert = UpdateAlert::silence(now);
         diesel::update(schema::alert::table.filter(schema::alert::id.eq_any(&alerts)))
             .set(&silenced_alert)
             .execute(conn)
@@ -259,17 +263,20 @@ impl UpdateAlert {
         }
     }
 
-    pub fn silence() -> Self {
+    pub fn silence(now: DateTime) -> Self {
         Self {
             status: Some(AlertStatus::Silenced),
-            modified: DateTime::now(),
+            modified: now,
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use bencher_json::project::{alert::AlertStatus, boundary::BoundaryLimit};
+    use bencher_json::{
+        DateTime,
+        project::{alert::AlertStatus, boundary::BoundaryLimit},
+    };
     use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 
     #[cfg(feature = "plus")]
@@ -507,7 +514,7 @@ mod tests {
         assert_eq!(alert_ids.len(), 3);
 
         // Bulk silence using eq_any
-        let silenced_alert = UpdateAlert::silence();
+        let silenced_alert = UpdateAlert::silence(DateTime::TEST);
         diesel::update(schema::alert::table.filter(schema::alert::id.eq_any(&alert_ids)))
             .set(&silenced_alert)
             .execute(&mut conn)
@@ -630,7 +637,7 @@ mod tests {
                 .load::<AlertId>(&mut conn)
                 .expect("Failed to query alerts");
 
-        let silenced_alert = UpdateAlert::silence();
+        let silenced_alert = UpdateAlert::silence(DateTime::TEST);
         diesel::update(schema::alert::table.filter(schema::alert::id.eq_any(&head1_alert_ids)))
             .set(&silenced_alert)
             .execute(&mut conn)
@@ -677,7 +684,7 @@ mod tests {
 
         // Replicate the silence_all early-return logic:
         // When alert_ids is empty, the update should affect 0 rows.
-        let silenced_alert = UpdateAlert::silence();
+        let silenced_alert = UpdateAlert::silence(DateTime::TEST);
         let updated =
             diesel::update(schema::alert::table.filter(schema::alert::id.eq_any(&alert_ids)))
                 .set(&silenced_alert)

--- a/lib/bencher_schema/src/model/project/threshold/alert.rs
+++ b/lib/bencher_schema/src/model/project/threshold/alert.rs
@@ -1,7 +1,7 @@
 use bencher_json::{
     AlertUuid, DateTime, ReportUuid,
     project::{
-        alert::{AlertStatus, JsonAlert, JsonPerfAlert, JsonUpdateAlert},
+        alert::{AlertStatus, JsonAlert, JsonPerfAlert, JsonUpdateAlert, UpdateAlertStatus},
         boundary::BoundaryLimit,
         report::Iteration,
     },
@@ -262,6 +262,13 @@ impl From<JsonUpdateAlert> for UpdateAlert {
 }
 
 impl UpdateAlert {
+    pub fn status_change(status: Option<UpdateAlertStatus>, now: DateTime) -> Self {
+        Self {
+            status: status.map(Into::into),
+            modified: now,
+        }
+    }
+
     pub fn silence() -> Self {
         Self {
             status: Some(AlertStatus::Silenced),

--- a/lib/bencher_schema/src/model/project/threshold/alert.rs
+++ b/lib/bencher_schema/src/model/project/threshold/alert.rs
@@ -1,7 +1,7 @@
 use bencher_json::{
     AlertUuid, DateTime, ReportUuid,
     project::{
-        alert::{AlertStatus, JsonAlert, JsonPerfAlert, JsonUpdateAlert, UpdateAlertStatus},
+        alert::{AlertStatus, JsonAlert, JsonPerfAlert, UpdateAlertStatus},
         boundary::BoundaryLimit,
         report::Iteration,
     },
@@ -249,16 +249,6 @@ impl InsertAlert {
 pub struct UpdateAlert {
     pub status: Option<AlertStatus>,
     pub modified: DateTime,
-}
-
-impl From<JsonUpdateAlert> for UpdateAlert {
-    fn from(update: JsonUpdateAlert) -> Self {
-        let JsonUpdateAlert { status } = update;
-        Self {
-            status: status.map(Into::into),
-            modified: DateTime::now(),
-        }
-    }
 }
 
 impl UpdateAlert {

--- a/lib/bencher_schema/src/model/user/actor.rs
+++ b/lib/bencher_schema/src/model/user/actor.rs
@@ -33,6 +33,16 @@ pub struct ProjectKeyActor {
     pub project_id: ProjectId,
 }
 
+impl ProjectKeyActor {
+    pub fn verify_project(&self, project_id: ProjectId) -> Result<(), HttpError> {
+        if project_id == self.project_id {
+            Ok(())
+        } else {
+            Err(unauthorized_error(INVALID_PROJECT_KEY))
+        }
+    }
+}
+
 impl From<super::auth::AuthUser> for ApiActor {
     fn from(auth_user: super::auth::AuthUser) -> Self {
         Self::Public(PublicUser::from(auth_user))

--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -3418,7 +3418,7 @@
           "alerts"
         ],
         "summary": "Update an alert",
-        "description": "Update an alert for a project. The user must have `edit` permissions for the project. Use this endpoint to dismiss an alert.",
+        "description": "Update an alert for a project. The user must have `edit` permissions for the project, or provide a valid project key for the project (status only). Use this endpoint to dismiss or reactivate an alert.",
         "operationId": "proj_alert_patch",
         "parameters": [
           {
@@ -3736,7 +3736,7 @@
           "benchmarks"
         ],
         "summary": "Create a benchmark",
-        "description": "Create a benchmark for a project. The user must have `create` permissions for the project.",
+        "description": "Create a benchmark for a project. The user must have `create` permissions for the project, or provide a valid project key for the project.",
         "operationId": "proj_benchmark_post",
         "parameters": [
           {
@@ -3984,7 +3984,7 @@
           "benchmarks"
         ],
         "summary": "Update a benchmark",
-        "description": "Update a benchmark for a project. The user must have `edit` permissions for the project.",
+        "description": "Update a benchmark for a project. The user must have `edit` permissions for the project, or provide a valid project key for the project (no rename).",
         "operationId": "proj_benchmark_patch",
         "parameters": [
           {
@@ -4218,7 +4218,7 @@
           "branches"
         ],
         "summary": "Create a branch",
-        "description": "Create a branch for a project. The user must have `create` permissions for the project.",
+        "description": "Create a branch for a project. The user must have `create` permissions for the project, or provide a valid project key for the project.",
         "operationId": "proj_branch_post",
         "parameters": [
           {
@@ -4474,7 +4474,7 @@
           "branches"
         ],
         "summary": "Update a branch",
-        "description": "Update a branch for a project. The user must have `edit` permissions for the project.",
+        "description": "Update a branch for a project. The user must have `edit` permissions for the project, or provide a valid project key for the project (no rename).",
         "operationId": "proj_branch_patch",
         "parameters": [
           {
@@ -5399,7 +5399,7 @@
           "measures"
         ],
         "summary": "Create a measure",
-        "description": "Create a measure for a project. The user must have `create` permissions for the project.",
+        "description": "Create a measure for a project. The user must have `create` permissions for the project, or provide a valid project key for the project.",
         "operationId": "proj_measure_post",
         "parameters": [
           {
@@ -5647,7 +5647,7 @@
           "measures"
         ],
         "summary": "Update a measure",
-        "description": "Update a measure for a project. The user must have `edit` permissions for the project.",
+        "description": "Update a measure for a project. The user must have `edit` permissions for the project, or provide a valid project key for the project (no rename).",
         "operationId": "proj_measure_patch",
         "parameters": [
           {
@@ -6716,7 +6716,7 @@
           "reports"
         ],
         "summary": "Create a report",
-        "description": "Create a report for a project. The user must have `create` permissions for the project. If using the Bencher CLI, it is recommended to use the `bencher run` subcommand instead of trying to create a report manually.",
+        "description": "Create a report for a project. The user must have `create` permissions for the project, or provide a valid project key for the project. If using the Bencher CLI, it is recommended to use the `bencher run` subcommand instead of trying to create a report manually.",
         "operationId": "proj_report_post",
         "parameters": [
           {
@@ -7104,7 +7104,7 @@
           "testbeds"
         ],
         "summary": "Create a testbed",
-        "description": "Create a testbed for a project. The user must have `create` permissions for the project.",
+        "description": "Create a testbed for a project. The user must have `create` permissions for the project, or provide a valid project key for the project.",
         "operationId": "proj_testbed_post",
         "parameters": [
           {
@@ -7360,7 +7360,7 @@
           "testbeds"
         ],
         "summary": "Update a testbed",
-        "description": "Update a testbed for a project. The user must have `edit` permissions for the project.",
+        "description": "Update a testbed for a project. The user must have `edit` permissions for the project, or provide a valid project key for the project (no rename).",
         "operationId": "proj_testbed_patch",
         "parameters": [
           {
@@ -7605,7 +7605,7 @@
           "thresholds"
         ],
         "summary": "Create a threshold",
-        "description": "Create a threshold for a project. The user must have `create` permissions for the project. There can only be one threshold for any unique combination of: branch, testbed, and measure.",
+        "description": "Create a threshold for a project. The user must have `create` permissions for the project, or provide a valid project key for the project. There can only be one threshold for any unique combination of: branch, testbed, and measure.",
         "operationId": "proj_threshold_post",
         "parameters": [
           {
@@ -7784,7 +7784,7 @@
           "thresholds"
         ],
         "summary": "Update a threshold",
-        "description": "Update a threshold for a project. The user must have `edit` permissions for the project. The new model will be added to the threshold and used going forward. The old model will be replaced but still show up in the report history and alerts created when it was active.",
+        "description": "Update a threshold for a project. The user must have `edit` permissions for the project, or provide a valid project key for the project. The new model will be added to the threshold and used going forward. The old model will be replaced but still show up in the report history and alerts created when it was active.",
         "operationId": "proj_threshold_put",
         "parameters": [
           {


### PR DESCRIPTION
This changeset updates API endpoints that have the same capabilities as a call to `bencher run` to accept a project key. For example, the `/v0/run` endpoint can create benchmarks. Therefore the endpoint to create a benchmark (POST) has been updated to accept a project key.

All operations permitted with a project key are non-destructive. Archiving is reversible. Branch Start Points, Testbed Specs, and Threshold Models are all stored for historical reference with their prior Reports. Dimension renames are not allowed with the project key.