### PR TITLE
Set `bencher` CLI binary as default member

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "tasks/*",
     "xtask",
 ]
+default-members = ["services/cli"]
 exclude = ["services/benchers", "services/cargo-bencher"]
 resolver = "3"
 


### PR DESCRIPTION
Set the `bencher` CLI binary as the default Cargo workspace member. This allows one to run `cargo run -- [bencher subcommand` from the workspace root without specifying the `bencher_cli` package.