### PR TITLE
Add a project key backend to the CLI

### DIFF
--- a/services/cli/src/bencher/backend.rs
+++ b/services/cli/src/bencher/backend.rs
@@ -3,7 +3,10 @@ use std::{fmt, ops::Deref, time::Duration};
 use bencher_json::{BENCHER_API_URL, BENCHER_URL, JsonApiVersion, JsonConsole};
 use serde::{Serialize, de::DeserializeOwned};
 
-use crate::{CLI_VERSION, cli_eprintln_quietable, parser::CliBackend};
+use crate::{
+    CLI_VERSION, cli_eprintln_quietable,
+    parser::{CliBackend, CliProjectBackend},
+};
 
 #[derive(Debug, Clone)]
 pub struct PubBackend {
@@ -20,6 +23,12 @@ pub struct Backend {
     client: bencher_client::BencherClient,
 }
 
+#[derive(Clone, Copy)]
+enum BackendKind {
+    Pub,
+    Auth,
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum BackendError {
     #[error("Failed to parse host URL: {0}")]
@@ -27,13 +36,13 @@ pub enum BackendError {
     #[error("Failed to parse API token: {0}")]
     ParseToken(bencher_json::ValidError),
     #[error(
+        "Failed to find Bencher API token, and this API endpoint requires authorization. Set `--token`/`BENCHER_API_TOKEN`."
+    )]
+    NoToken,
+    #[error(
         "Failed to find Bencher API credential, and this API endpoint requires authorization. Set `--token`/`BENCHER_API_TOKEN` or `--key`/`BENCHER_API_KEY`."
     )]
     NoCredential,
-    #[error(
-        "Both `--token`/`BENCHER_API_TOKEN` and `--key`/`BENCHER_API_KEY` are set. Only one credential may be provided."
-    )]
-    ConflictingCredentials,
     #[error("Failed to get API server version: {0}")]
     ApiVersion(bencher_client::ClientError),
     #[error("{err}\nHint: This may be due to a version mismatch. {mismatch}")]
@@ -51,7 +60,9 @@ impl TryFrom<CliBackend> for PubBackend {
     type Error = BackendError;
 
     fn try_from(backend: CliBackend) -> Result<Self, Self::Error> {
-        (backend, true).try_into().map(|inner| Self { inner })
+        (backend, BackendKind::Pub)
+            .try_into()
+            .map(|inner| Self { inner })
     }
 }
 
@@ -59,17 +70,39 @@ impl TryFrom<CliBackend> for AuthBackend {
     type Error = BackendError;
 
     fn try_from(backend: CliBackend) -> Result<Self, Self::Error> {
-        (backend, false).try_into().map(|inner| Self { inner })
+        (backend, BackendKind::Auth)
+            .try_into()
+            .map(|inner| Self { inner })
     }
 }
 
-impl TryFrom<(CliBackend, bool)> for Backend {
+impl TryFrom<CliProjectBackend> for PubBackend {
     type Error = BackendError;
 
-    fn try_from((backend, is_public): (CliBackend, bool)) -> Result<Self, Self::Error> {
+    fn try_from(project_backend: CliProjectBackend) -> Result<Self, Self::Error> {
+        (project_backend, BackendKind::Pub)
+            .try_into()
+            .map(|inner| Self { inner })
+    }
+}
+
+impl TryFrom<CliProjectBackend> for AuthBackend {
+    type Error = BackendError;
+
+    fn try_from(project_backend: CliProjectBackend) -> Result<Self, Self::Error> {
+        (project_backend, BackendKind::Auth)
+            .try_into()
+            .map(|inner| Self { inner })
+    }
+}
+
+impl TryFrom<(CliBackend, BackendKind)> for Backend {
+    type Error = BackendError;
+
+    fn try_from((backend, kind): (CliBackend, BackendKind)) -> Result<Self, Self::Error> {
         let CliBackend {
             host,
-            credential,
+            token,
             insecure_host,
             native_tls,
             timeout,
@@ -77,40 +110,102 @@ impl TryFrom<(CliBackend, bool)> for Backend {
             retry_after,
             strict,
         } = backend;
-        let host = host.try_into().map_err(BackendError::ParseHost)?;
-        let mut builder = bencher_client::BencherClient::builder().host(host);
-        builder = map_credential(builder, credential, is_public)?;
-        let client = builder
-            .insecure_host(insecure_host)
-            .native_tls(native_tls)
-            .timeout(Duration::from_secs(timeout))
-            .attempts(attempts)
-            .retry_after(retry_after)
-            .strict(strict)
-            .log(true)
-            .build();
-        Ok(Self { client })
+        let builder = build_client(
+            host,
+            insecure_host,
+            native_tls,
+            timeout,
+            attempts,
+            retry_after,
+            strict,
+        )?;
+        let builder = map_credential(builder, token, kind)?;
+        Ok(Self {
+            client: builder.build(),
+        })
     }
+}
+
+impl TryFrom<(CliProjectBackend, BackendKind)> for Backend {
+    type Error = BackendError;
+
+    fn try_from(
+        (project_backend, kind): (CliProjectBackend, BackendKind),
+    ) -> Result<Self, Self::Error> {
+        let CliProjectBackend { backend, key } = project_backend;
+        let CliBackend {
+            host,
+            token,
+            insecure_host,
+            native_tls,
+            timeout,
+            attempts,
+            retry_after,
+            strict,
+        } = backend;
+        let builder = build_client(
+            host,
+            insecure_host,
+            native_tls,
+            timeout,
+            attempts,
+            retry_after,
+            strict,
+        )?;
+        let builder = map_project_credential(builder, token, key, kind)?;
+        Ok(Self {
+            client: builder.build(),
+        })
+    }
+}
+
+fn build_client(
+    host: bencher_json::Url,
+    insecure_host: bool,
+    native_tls: bool,
+    timeout: u64,
+    attempts: usize,
+    retry_after: u64,
+    strict: bool,
+) -> Result<bencher_client::BencherClientBuilder, BackendError> {
+    let host = host.try_into().map_err(BackendError::ParseHost)?;
+    Ok(bencher_client::BencherClient::builder()
+        .host(host)
+        .insecure_host(insecure_host)
+        .native_tls(native_tls)
+        .timeout(Duration::from_secs(timeout))
+        .attempts(attempts)
+        .retry_after(retry_after)
+        .strict(strict)
+        .log(true))
 }
 
 fn map_credential(
     builder: bencher_client::BencherClientBuilder,
-    credential: crate::parser::CliCredential,
-    is_public: bool,
+    token: Option<bencher_json::Jwt>,
+    kind: BackendKind,
 ) -> Result<bencher_client::BencherClientBuilder, BackendError> {
-    let crate::parser::CliCredential { token, key } = credential;
-
-    if token.is_some() && key.is_some() {
-        return Err(BackendError::ConflictingCredentials);
+    if let Some(token) = token {
+        Ok(builder.token(token))
+    } else if matches!(kind, BackendKind::Pub) {
+        Ok(builder)
+    } else {
+        Err(BackendError::NoToken)
     }
+}
 
+fn map_project_credential(
+    builder: bencher_client::BencherClientBuilder,
+    token: Option<bencher_json::Jwt>,
+    key: Option<bencher_json::ProjectKey>,
+    kind: BackendKind,
+) -> Result<bencher_client::BencherClientBuilder, BackendError> {
     if let Some(key) = key {
         return Ok(builder.key(key));
     }
-
     if let Some(token) = token {
         Ok(builder.token(token))
-    } else if is_public {
+    } else if matches!(kind, BackendKind::Pub) {
         Ok(builder)
     } else {
         Err(BackendError::NoCredential)

--- a/services/cli/src/parser/mod.rs
+++ b/services/cli/src/parser/mod.rs
@@ -177,6 +177,7 @@ pub struct CliBackend {
 }
 
 #[derive(Args, Debug)]
+#[clap(group(ArgGroup::new("bencher_credential").args(["token", "key"]).multiple(false)))]
 pub struct CliProjectBackend {
     #[clap(flatten)]
     pub backend: CliBackend,

--- a/services/cli/src/parser/mod.rs
+++ b/services/cli/src/parser/mod.rs
@@ -147,8 +147,9 @@ pub struct CliBackend {
     #[clap(long, value_name = "URL", env = "BENCHER_HOST", default_value = BENCHER_API_URL_STR)]
     pub host: Url,
 
-    #[clap(flatten)]
-    pub credential: CliCredential,
+    /// User API token (JWT)
+    #[clap(long, env = "BENCHER_API_TOKEN")]
+    pub token: Option<Jwt>,
 
     /// Allow insecure connections to an HTTPS host
     #[clap(long)]
@@ -176,11 +177,9 @@ pub struct CliBackend {
 }
 
 #[derive(Args, Debug)]
-#[clap(group(ArgGroup::new("bencher_credential").args(["token", "key"]).multiple(false)))]
-pub struct CliCredential {
-    /// User API token (JWT)
-    #[clap(long, env = "BENCHER_API_TOKEN")]
-    pub token: Option<Jwt>,
+pub struct CliProjectBackend {
+    #[clap(flatten)]
+    pub backend: CliBackend,
 
     /// Project-scoped API key
     #[clap(long, env = "BENCHER_API_KEY")]

--- a/services/cli/src/parser/project/alert.rs
+++ b/services/cli/src/parser/project/alert.rs
@@ -1,7 +1,7 @@
 use bencher_json::{AlertUuid, ProjectResourceId};
 use clap::{Parser, Subcommand, ValueEnum};
 
-use crate::parser::{CliBackend, CliPagination};
+use crate::parser::{CliPagination, CliProjectBackend};
 
 #[derive(Subcommand, Debug)]
 pub enum CliAlert {
@@ -33,7 +33,7 @@ pub struct CliAlertList {
     pub archived: bool,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(ValueEnum, Debug, Clone)]
@@ -65,7 +65,7 @@ pub struct CliAlertView {
     pub alert: AlertUuid,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -81,7 +81,7 @@ pub struct CliAlertUpdate {
     pub status: Option<CliAlertStatusUpdate>,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(ValueEnum, Debug, Clone)]

--- a/services/cli/src/parser/project/archive.rs
+++ b/services/cli/src/parser/project/archive.rs
@@ -3,7 +3,7 @@ use bencher_json::{
 };
 use clap::{ArgGroup, Args, Parser};
 
-use crate::parser::CliBackend;
+use crate::parser::CliProjectBackend;
 
 #[derive(Parser, Debug)]
 pub struct CliArchive {
@@ -15,7 +15,7 @@ pub struct CliArchive {
     pub dimension: CliArchiveDimension,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Args, Debug)]

--- a/services/cli/src/parser/project/benchmark.rs
+++ b/services/cli/src/parser/project/benchmark.rs
@@ -1,7 +1,7 @@
 use bencher_json::{BenchmarkName, BenchmarkResourceId, BenchmarkSlug, ProjectResourceId};
 use clap::{Parser, Subcommand, ValueEnum};
 
-use crate::parser::{CliArchived, CliBackend, CliPagination};
+use crate::parser::{CliArchived, CliPagination, CliProjectBackend};
 
 #[derive(Subcommand, Debug)]
 pub enum CliBenchmark {
@@ -43,7 +43,7 @@ pub struct CliBenchmarkList {
     pub archived: bool,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(ValueEnum, Debug, Clone)]
@@ -67,7 +67,7 @@ pub struct CliBenchmarkCreate {
     pub slug: Option<BenchmarkSlug>,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -79,7 +79,7 @@ pub struct CliBenchmarkView {
     pub benchmark: BenchmarkResourceId,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -102,7 +102,7 @@ pub struct CliBenchmarkUpdate {
     pub archived: CliArchived,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -114,5 +114,5 @@ pub struct CliBenchmarkDelete {
     pub benchmark: BenchmarkResourceId,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }

--- a/services/cli/src/parser/project/branch.rs
+++ b/services/cli/src/parser/project/branch.rs
@@ -3,7 +3,7 @@ use bencher_json::{
 };
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
-use crate::parser::{CliArchived, CliBackend, CliPagination};
+use crate::parser::{CliArchived, CliPagination, CliProjectBackend};
 
 #[derive(Subcommand, Debug)]
 pub enum CliBranch {
@@ -45,7 +45,7 @@ pub struct CliBranchList {
     pub archived: bool,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(ValueEnum, Debug, Clone)]
@@ -72,7 +72,7 @@ pub struct CliBranchCreate {
     pub start_point: CliStartPointCreate,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[expect(clippy::doc_markdown, clippy::struct_field_names)]
@@ -114,7 +114,7 @@ pub struct CliBranchView {
     pub head: Option<HeadUuid>,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -140,7 +140,7 @@ pub struct CliBranchUpdate {
     pub archived: CliArchived,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[expect(clippy::struct_field_names)]
@@ -186,5 +186,5 @@ pub struct CliBranchDelete {
     pub branch: BranchResourceId,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }

--- a/services/cli/src/parser/project/job.rs
+++ b/services/cli/src/parser/project/job.rs
@@ -3,7 +3,7 @@
 use bencher_json::{JobUuid, ProjectResourceId};
 use clap::{Parser, Subcommand, ValueEnum};
 
-use crate::parser::{CliBackend, CliPagination};
+use crate::parser::{CliPagination, CliProjectBackend};
 
 #[derive(Subcommand, Debug)]
 pub enum CliJob {
@@ -28,7 +28,7 @@ pub struct CliJobList {
     pub pagination: CliPagination<CliJobsSort>,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(ValueEnum, Debug, Clone, Copy)]
@@ -59,5 +59,5 @@ pub struct CliJobView {
     pub job: JobUuid,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }

--- a/services/cli/src/parser/project/key.rs
+++ b/services/cli/src/parser/project/key.rs
@@ -1,7 +1,7 @@
 use bencher_json::{ProjectKeyUuid, ProjectResourceId, ResourceName};
 use clap::{Parser, Subcommand, ValueEnum};
 
-use crate::parser::{CliBackend, CliPagination};
+use crate::parser::{CliPagination, CliProjectBackend};
 
 #[derive(Subcommand, Debug)]
 pub enum CliProjectKey {
@@ -43,7 +43,7 @@ pub struct CliProjectKeyList {
     pub pagination: CliPagination<CliProjectKeysSort>,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(ValueEnum, Debug, Clone)]
@@ -67,7 +67,7 @@ pub struct CliProjectKeyCreate {
     pub ttl: Option<u32>,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -79,7 +79,7 @@ pub struct CliProjectKeyView {
     pub uuid: ProjectKeyUuid,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -95,7 +95,7 @@ pub struct CliProjectKeyUpdate {
     pub name: Option<ResourceName>,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -107,5 +107,5 @@ pub struct CliProjectKeyRevoke {
     pub uuid: ProjectKeyUuid,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }

--- a/services/cli/src/parser/project/measure.rs
+++ b/services/cli/src/parser/project/measure.rs
@@ -1,7 +1,7 @@
 use bencher_json::{MeasureResourceId, MeasureSlug, ProjectResourceId, ResourceName};
 use clap::{Parser, Subcommand, ValueEnum};
 
-use crate::parser::{CliArchived, CliBackend, CliPagination};
+use crate::parser::{CliArchived, CliPagination, CliProjectBackend};
 
 #[derive(Subcommand, Debug)]
 pub enum CliMeasure {
@@ -43,7 +43,7 @@ pub struct CliMeasureList {
     pub archived: bool,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(ValueEnum, Debug, Clone)]
@@ -71,7 +71,7 @@ pub struct CliMeasureCreate {
     pub units: ResourceName,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -83,7 +83,7 @@ pub struct CliMeasureView {
     pub measure: MeasureResourceId,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -110,7 +110,7 @@ pub struct CliMeasureUpdate {
     pub archived: CliArchived,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -122,5 +122,5 @@ pub struct CliMeasureDelete {
     pub measure: MeasureResourceId,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }

--- a/services/cli/src/parser/project/metric.rs
+++ b/services/cli/src/parser/project/metric.rs
@@ -1,7 +1,7 @@
 use bencher_json::{MetricUuid, ProjectResourceId};
 use clap::{Parser, Subcommand};
 
-use crate::parser::CliBackend;
+use crate::parser::CliProjectBackend;
 
 #[derive(Subcommand, Debug)]
 pub enum CliMetric {
@@ -19,5 +19,5 @@ pub struct CliMetricView {
     pub metric: MetricUuid,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }

--- a/services/cli/src/parser/project/mod.rs
+++ b/services/cli/src/parser/project/mod.rs
@@ -1,7 +1,7 @@
 use bencher_json::{OrganizationResourceId, ProjectResourceId, ProjectSlug, ResourceName, Url};
 use clap::{Parser, Subcommand, ValueEnum};
 
-use crate::parser::CliBackend;
+use crate::parser::CliProjectBackend;
 
 use super::{CliPagination, ElidedOption};
 
@@ -59,7 +59,7 @@ pub struct CliProjectList {
     pub pagination: CliPagination<CliProjectsSort>,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(ValueEnum, Debug, Clone, Copy)]
@@ -91,7 +91,7 @@ pub struct CliProjectCreate {
     pub visibility: CliProjectVisibility,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(ValueEnum, Debug, Clone)]
@@ -108,7 +108,7 @@ pub struct CliProjectView {
     pub project: ProjectResourceId,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -135,7 +135,7 @@ pub struct CliProjectUpdate {
     pub visibility: Option<CliProjectVisibility>,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -148,7 +148,7 @@ pub struct CliProjectDelete {
     pub hard: bool,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -161,7 +161,7 @@ pub struct CliProjectAllowed {
     pub perm: CliProjectPermission,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 /// Project permission

--- a/services/cli/src/parser/project/perf.rs
+++ b/services/cli/src/parser/project/perf.rs
@@ -5,7 +5,7 @@ use bencher_json::{
 };
 use clap::{Parser, ValueEnum};
 
-use crate::parser::{CliBackend, ElidedOption};
+use crate::parser::{CliProjectBackend, ElidedOption};
 
 #[derive(Parser, Debug)]
 #[expect(clippy::option_option)]
@@ -53,7 +53,7 @@ pub struct CliPerf {
     pub table: Option<Option<CliPerfTableStyle>>,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 /// Supported Table Formats

--- a/services/cli/src/parser/project/plot.rs
+++ b/services/cli/src/parser/project/plot.rs
@@ -4,7 +4,7 @@ use bencher_json::{
 };
 use clap::{Parser, Subcommand, ValueEnum};
 
-use crate::parser::{CliBackend, CliPagination, ElidedOption};
+use crate::parser::{CliPagination, CliProjectBackend, ElidedOption};
 
 #[derive(Subcommand, Debug)]
 pub enum CliPlot {
@@ -42,7 +42,7 @@ pub struct CliPlotList {
     pub pagination: CliPagination<CliPlotsSort>,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(ValueEnum, Debug, Clone)]
@@ -116,7 +116,7 @@ pub struct CliPlotCreate {
     pub measures: Vec<MeasureUuid>,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 /// Supported X-Axises
@@ -136,7 +136,7 @@ pub struct CliPlotView {
     pub plot: PlotUuid,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -164,7 +164,7 @@ pub struct CliPlotUpdate {
     pub window: Option<Window>,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -176,5 +176,5 @@ pub struct CliPlotDelete {
     pub plot: PlotUuid,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }

--- a/services/cli/src/parser/project/report.rs
+++ b/services/cli/src/parser/project/report.rs
@@ -5,7 +5,7 @@ use bencher_json::{
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
 use super::{branch::CliStartPointUpdate, threshold::CliModelTest};
-use crate::parser::{CliBackend, CliPagination, ElidedOption};
+use crate::parser::{CliPagination, CliProjectBackend, ElidedOption};
 
 #[derive(Subcommand, Debug)]
 pub enum CliReport {
@@ -52,7 +52,7 @@ pub struct CliReportList {
     pub archived: bool,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(ValueEnum, Debug, Clone)]
@@ -110,7 +110,7 @@ pub struct CliReportCreate {
     pub fold: Option<CliReportFold>,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Args, Debug)]
@@ -234,7 +234,7 @@ pub struct CliReportView {
     pub report: ReportUuid,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -246,5 +246,5 @@ pub struct CliReportDelete {
     pub report: ReportUuid,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }

--- a/services/cli/src/parser/project/testbed.rs
+++ b/services/cli/src/parser/project/testbed.rs
@@ -5,7 +5,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 
 #[cfg(feature = "plus")]
 use crate::parser::ElidedOption;
-use crate::parser::{CliArchived, CliBackend, CliPagination};
+use crate::parser::{CliArchived, CliPagination, CliProjectBackend};
 
 #[derive(Subcommand, Debug)]
 pub enum CliTestbed {
@@ -47,7 +47,7 @@ pub struct CliTestbedList {
     pub archived: bool,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(ValueEnum, Debug, Clone)]
@@ -76,7 +76,7 @@ pub struct CliTestbedCreate {
     pub spec: Option<SpecResourceId>,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -93,7 +93,7 @@ pub struct CliTestbedView {
     pub spec: Option<SpecUuid>,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -122,7 +122,7 @@ pub struct CliTestbedUpdate {
     pub archived: CliArchived,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -134,5 +134,5 @@ pub struct CliTestbedDelete {
     pub testbed: TestbedResourceId,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }

--- a/services/cli/src/parser/project/threshold.rs
+++ b/services/cli/src/parser/project/threshold.rs
@@ -4,7 +4,7 @@ use bencher_json::{
 };
 use clap::{ArgGroup, Parser, Subcommand, ValueEnum};
 
-use crate::parser::{CliBackend, CliPagination};
+use crate::parser::{CliPagination, CliProjectBackend};
 
 #[derive(Subcommand, Debug)]
 pub enum CliThreshold {
@@ -50,7 +50,7 @@ pub struct CliThresholdList {
     pub archived: bool,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(ValueEnum, Debug, Clone)]
@@ -83,7 +83,7 @@ pub struct CliThresholdCreate {
     pub model: CliModel,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -148,7 +148,7 @@ pub struct CliThresholdView {
     pub model: Option<ModelUuid>,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -163,7 +163,7 @@ pub struct CliThresholdUpdate {
     pub model: CliUpdateModel,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Parser, Debug)]
@@ -212,5 +212,5 @@ pub struct CliThresholdDelete {
     pub threshold: ThresholdUuid,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }

--- a/services/cli/src/parser/run.rs
+++ b/services/cli/src/parser/run.rs
@@ -8,7 +8,7 @@ use bencher_parser::check_env;
 use camino::Utf8PathBuf;
 use clap::{ArgGroup, Args, Parser, ValueEnum};
 
-use crate::parser::CliBackend;
+use crate::parser::CliProjectBackend;
 
 use super::project::report::{
     CliReportAdapter, CliReportAverage, CliReportFold, CliReportThresholds,
@@ -84,7 +84,7 @@ pub struct CliRun {
     pub job: CliRunJob,
 
     #[clap(flatten)]
-    pub backend: CliBackend,
+    pub backend: CliProjectBackend,
 }
 
 #[derive(Args, Debug)]


### PR DESCRIPTION
This changeset adds a project key specific backend to the CLI to only allow project keys for commands for API endpoints that support project keys.