### PR TITLE
Install `mold` for the Sandbox update check job

### DIFF
--- a/.github/workflows/update_sandbox.yml
+++ b/.github/workflows/update_sandbox.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           ref: devel
       - uses: dtolnay/rust-toolchain@stable
+      - uses: rui314/setup-mold@v1
+        with:
+          mold-version: "2.34.1"
       - name: Update sandbox dependencies
         id: update
         env:


### PR DESCRIPTION
This changeset installs `mold` so that the Sandbox update check job can run.