### PR TITLE
Add `version` subcommand to Runner Ops

### DIFF
--- a/tasks/runner_ops/src/parser/mod.rs
+++ b/tasks/runner_ops/src/parser/mod.rs
@@ -16,6 +16,8 @@ pub enum TaskSub {
     Provision(TaskProvision),
     /// Download latest runner binary from CI and deploy to server
     Deploy(TaskDeploy),
+    /// Show runner binary version
+    Version(TaskVersion),
     /// Start the runner service
     Start(TaskStart),
     /// Stop the runner service
@@ -74,6 +76,24 @@ pub struct TaskDeploy {
     /// GitHub Actions run ID (defaults to latest successful `devel` run)
     #[clap(long)]
     pub run_id: Option<u64>,
+}
+
+#[derive(Parser, Debug)]
+pub struct TaskVersion {
+    /// Runner slug or UUID (for runners.json lookup)
+    pub runner: Option<RunnerResourceId>,
+
+    /// IP address or hostname of the server
+    #[clap(long, required_unless_present = "runner")]
+    pub server: Option<String>,
+
+    /// Path to SSH private key
+    #[clap(long, required_unless_present = "runner")]
+    pub ssh: Option<Utf8PathBuf>,
+
+    /// SSH user
+    #[clap(long)]
+    pub user: Option<String>,
 }
 
 #[derive(Parser, Debug)]

--- a/tasks/runner_ops/src/task/mod.rs
+++ b/tasks/runner_ops/src/task/mod.rs
@@ -8,6 +8,7 @@ mod provision;
 pub mod ssh;
 mod start;
 pub mod stop;
+mod version;
 
 use bencher_json::{RunnerResourceId, Secret};
 use camino::Utf8PathBuf;
@@ -21,6 +22,7 @@ use provision::Provision;
 use ssh::Ssh;
 use start::Start;
 use stop::Stop;
+use version::Version;
 
 const DEFAULT_USER: &str = "root";
 #[expect(clippy::expect_used, reason = "known-valid constant URL")]
@@ -36,6 +38,7 @@ pub struct Task {
 enum Sub {
     Provision(Provision),
     Deploy(Deploy),
+    Version(Version),
     Start(Start),
     Stop(Stop),
     Logs(Logs),
@@ -58,6 +61,7 @@ impl TryFrom<TaskSub> for Sub {
         Ok(match sub {
             TaskSub::Provision(provision) => Self::Provision(provision.try_into()?),
             TaskSub::Deploy(deploy) => Self::Deploy(deploy.try_into()?),
+            TaskSub::Version(version) => Self::Version(version.try_into()?),
             TaskSub::Start(start) => Self::Start(start.try_into()?),
             TaskSub::Stop(stop) => Self::Stop(stop.try_into()?),
             TaskSub::Logs(logs) => Self::Logs(logs.try_into()?),
@@ -80,6 +84,7 @@ impl Sub {
         match self {
             Self::Provision(provision) => provision.exec(),
             Self::Deploy(deploy) => deploy.exec(),
+            Self::Version(version) => version.exec(),
             Self::Start(start) => start.exec(),
             Self::Stop(stop) => stop.exec(),
             Self::Logs(logs) => logs.exec(),

--- a/tasks/runner_ops/src/task/version.rs
+++ b/tasks/runner_ops/src/task/version.rs
@@ -1,0 +1,35 @@
+use super::merge_ssh;
+use super::ssh::Ssh;
+use crate::parser::TaskVersion;
+use crate::parser::server::load_server;
+
+#[derive(Debug)]
+pub struct Version {
+    ssh: Ssh,
+}
+
+impl TryFrom<TaskVersion> for Version {
+    type Error = anyhow::Error;
+
+    fn try_from(task: TaskVersion) -> anyhow::Result<Self> {
+        let TaskVersion {
+            runner,
+            server,
+            ssh,
+            user,
+        } = task;
+        let file = runner.as_ref().map(load_server).transpose()?.flatten();
+        let (server, ssh, user) = merge_ssh(file.as_ref(), server, ssh, user)?;
+        Ok(Self {
+            ssh: Ssh::new(server, ssh, user),
+        })
+    }
+}
+
+impl Version {
+    pub fn exec(self) -> anyhow::Result<()> {
+        let Self { ssh } = self;
+        ssh.run("/usr/local/bin/runner --version")?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
This changeset adds a `version` subcommand to make it easy to check the current version of a runner.