### PR TITLE
Add OCI bandwidth rate limit otel counter

### DIFF
--- a/lib/bencher_schema/src/context/rate_limiting/bandwidth.rs
+++ b/lib/bencher_schema/src/context/rate_limiting/bandwidth.rs
@@ -100,6 +100,8 @@ impl BandwidthRateLimiter {
         if self.limiter.check_at(&org_uuid, limit, now) {
             Ok(())
         } else {
+            #[cfg(feature = "otel")]
+            bencher_otel::ApiMeter::increment(bencher_otel::ApiCounter::OciBandwidthMax(priority));
             Err(too_many_requests(RateLimitingError::OciBandwidth {
                 organization: organization.clone(),
                 limit_gib: limit.saturating_div(BYTES_PER_GIB),

--- a/plus/bencher_otel/src/api_meter.rs
+++ b/plus/bencher_otel/src/api_meter.rs
@@ -128,6 +128,7 @@ pub enum ApiCounter {
     OciManifestPush,
     OciManifestPull,
     OciTagsList,
+    OciBandwidthMax(Priority),
 
     RunnerRequestMax(IntervalKind),
 
@@ -192,6 +193,7 @@ impl ApiCounter {
 
             Self::OciBlobPush | Self::OciBlobPull => "{blob}",
             Self::OciManifestPush | Self::OciManifestPull => "{manifest}",
+            Self::OciBandwidthMax(_) => "{bandwidth}",
 
             Self::RunnerCreate | Self::RunnerUpdate => "{runner}",
             Self::RunnerJobClaim | Self::RunnerJobUpdate(_) => "{job}",
@@ -258,6 +260,7 @@ impl ApiCounter {
             Self::OciManifestPush => "oci.manifest.push",
             Self::OciManifestPull => "oci.manifest.pull",
             Self::OciTagsList => "oci.tags.list",
+            Self::OciBandwidthMax(_) => "oci.bandwidth.max",
 
             Self::RunnerRequestMax(_) => "runner.request.max",
 
@@ -345,6 +348,7 @@ impl ApiCounter {
             Self::OciManifestPush => "Counts the number of OCI manifest pushes",
             Self::OciManifestPull => "Counts the number of OCI manifest pulls",
             Self::OciTagsList => "Counts the number of OCI tags list requests",
+            Self::OciBandwidthMax(_) => "Counts the number of OCI bandwidth limit hits",
 
             Self::RunnerRequestMax(_) => "Counts the number of runner request maximums reached",
 
@@ -412,7 +416,9 @@ impl ApiCounter {
             | Self::RunnerHeartbeatTimeout
             | Self::RunnerJobTimeout
             | Self::RunnerDisconnect => Vec::new(),
-            Self::Run(priority) | Self::MetricsCreate(priority) => {
+            Self::Run(priority)
+            | Self::MetricsCreate(priority)
+            | Self::OciBandwidthMax(priority) => {
                 vec![priority_attribute(priority)]
             },
             Self::UserSignup(auth_method)


### PR DESCRIPTION
## Summary
- Add `OciBandwidthMax(Priority)` counter to `ApiCounter` enum with `oci.bandwidth.max` metric name
- Increment the counter in `BandwidthRateLimiter::check_at()` when the daily OCI bandwidth limit is hit
- Follows the same pattern used by every other rate limit check in the codebase

## Test plan
- [x] `cargo check --no-default-features` passes (non-Plus builds)
- [x] `cargo clippy --no-deps --all-targets --all-features -- -Dwarnings` passes
- [x] `cargo fmt` clean