### PR TITLE
Skip formatting Report date time when undefined

### DIFF
--- a/services/console/src/components/console/deck/header/DeckHeader.tsx
+++ b/services/console/src/components/console/deck/header/DeckHeader.tsx
@@ -45,8 +45,10 @@ const DeckHeader = (props: Props) => {
 			return;
 		}
 		switch (props.config?.display) {
-			case Display.DATE_TIME:
-				return fmtDateTime(data?.[props.config?.key] ?? "");
+			case Display.DATE_TIME: {
+				const value = data?.[props.config?.key];
+				return value ? fmtDateTime(value) : undefined;
+			}
 			default:
 				return fmtValues(data, props.config?.key, props.config?.keys, " | ");
 		}


### PR DESCRIPTION
This changeset skips formatting the Report date time header when it is undefined, usually while waiting for the data to load.