### PR TITLE
Remove Partytown wrapper from Google Analytics

### DIFF
--- a/services/console/astro.config.mjs
+++ b/services/console/astro.config.mjs
@@ -1,7 +1,6 @@
 // import node from "@astrojs/node";
 // import netlify from "@astrojs/netlify";
 import mdx from "@astrojs/mdx";
-import partytown from "@astrojs/partytown";
 import sitemap from "@astrojs/sitemap";
 import solidJs from "@astrojs/solid-js";
 import sentry from "@sentry/astro";
@@ -185,14 +184,6 @@ export default defineConfig({
 		expressiveCode(),
 		// https://docs.astro.build/en/guides/integrations-guide/mdx
 		mdx(),
-		// https://docs.astro.build/en/guides/integrations-guide/partytown
-		partytown({
-			config: {
-				// https://www.kevinzunigacuellar.com/blog/google-analytics-in-astro/
-				// https://partytown.builder.io/google-tag-manager#forward-events
-				forward: ["dataLayer.push"],
-			},
-		}),
 		// https://docs.astro.build/en/guides/integrations-guide/solid-js/
 		solidJs({
 			// https://docs.astro.build/en/guides/integrations-guide/solid-js/#devtools

--- a/services/console/package-lock.json
+++ b/services/console/package-lock.json
@@ -12,7 +12,6 @@
 				"@astrojs/mdx": "^4.0.8",
 				"@astrojs/netlify": "^6.1.0",
 				"@astrojs/node": "^9.0.3",
-				"@astrojs/partytown": "^2.1.3",
 				"@astrojs/sitemap": "^3.2.1",
 				"@astrojs/solid-js": "^5.0.4",
 				"@observablehq/plot": "^0.6.16",
@@ -244,15 +243,6 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.5.1.tgz",
 			"integrity": "sha512-M7rAge1n2+aOSxNvKUFa0u/KFn0W+sZy7EW91KOSERotm2Ti8qs+1K0xx3zbOxtAVrmJb5/J98eohVvvEqtNkw=="
-		},
-		"node_modules/@astrojs/partytown": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@astrojs/partytown/-/partytown-2.1.3.tgz",
-			"integrity": "sha512-pkGsV6/GUTph4oLgvrpbrGnu4+9JuG8fOCzBCI2dQKtpBYQ6XAZKHrPA3evQoB5vDbfUZGVCoWe95MnSoPbVtQ==",
-			"dependencies": {
-				"@qwik.dev/partytown": "^0.11.0",
-				"mrmime": "^2.0.0"
-			}
 		},
 		"node_modules/@astrojs/prism": {
 			"version": "3.2.0",
@@ -3045,20 +3035,6 @@
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/@qwik.dev/partytown": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/@qwik.dev/partytown/-/partytown-0.11.0.tgz",
-			"integrity": "sha512-MHime7cxj7KGrapGZ1VqLkXXq5BLNqvjNZndRJVvMkUWn92F2bsezlWW1lKDoFaKCKu2xv9LRUZL99RYOs+ccA==",
-			"dependencies": {
-				"dotenv": "^16.4.7"
-			},
-			"bin": {
-				"partytown": "bin/partytown.cjs"
-			},
-			"engines": {
-				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@react-aria/focus": {

--- a/services/console/package.json
+++ b/services/console/package.json
@@ -32,7 +32,6 @@
 		"@astrojs/mdx": "^4.0.8",
 		"@astrojs/netlify": "^6.1.0",
 		"@astrojs/node": "^9.0.3",
-		"@astrojs/partytown": "^2.1.3",
 		"@astrojs/sitemap": "^3.2.1",
 		"@astrojs/solid-js": "^5.0.4",
 		"@observablehq/plot": "^0.6.16",

--- a/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
+++ b/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
@@ -1,3 +1,6 @@
+## Pending `v0.6.7`
+- Fix Google Analytics not tracking pageviews on static pages (homepage, `/learn/*`, `/docs/*`) by removing the Partytown wrapper around `gtag.js` so the GA snippet runs on the main thread
+
 ## `v0.6.6`
 - Show context-aware auth hints in API 404 errors: routes that accept project API keys now mention both API tokens and project keys, while token-only routes mention only API tokens
 - **BREAKING CHANGE** Rename `usage` to `metrics` in the organization usage API response and add `runner_minutes` field for bare metal runner minutes usage

--- a/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
+++ b/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
@@ -1,6 +1,3 @@
-## Pending `v0.6.7`
-- Fix Google Analytics not tracking pageviews on static pages (homepage, `/learn/*`, `/docs/*`) by removing the Partytown wrapper around `gtag.js` so the GA snippet runs on the main thread
-
 ## `v0.6.6`
 - Show context-aware auth hints in API 404 errors: routes that accept project API keys now mention both API tokens and project keys, while token-only routes mention only API tokens
 - **BREAKING CHANGE** Rename `usage` to `metrics` in the organization usage API response and add `runner_minutes` field for bare metal runner minutes usage

--- a/services/console/src/layouts/BaseLayout.astro
+++ b/services/console/src/layouts/BaseLayout.astro
@@ -175,10 +175,10 @@ const article = () => {
     ></script>
     <!-- Google tag (gtag.js) -->
     <script
-      type="text/partytown"
+      async
       src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_ID}`}
     ></script>
-    <script type="text/partytown" define:vars={{ GOOGLE_ANALYTICS_ID }}>
+    <script define:vars={{ GOOGLE_ANALYTICS_ID }}>
       window.dataLayer = window.dataLayer || [];
       function gtag() {
         dataLayer.push(arguments);


### PR DESCRIPTION
Static pages on bencher.dev (homepage, /learn/*, plain /docs/*) had
stopped registering pageviews in GA4 because the gtag scripts were
wrapped in `type="text/partytown"`. Partytown's worker / service-worker
bootstrap only completes on pages that keep the main thread busy with a
substantial Solid island (e.g. BenchmarkHarness on /docs/tutorial/quickstart,
PublicProject on /perf/[project], the console SPA). Pages whose only
client:only components are no-op `<Show when={!isBencherCloud}>`
wrappers finish hydration immediately and Partytown never proxies the
gtag.js fetch, so no hit is sent.

The August 2024 fix (commit 5626581c "gtag_rm_partytown") removed
Partytown from the gtag config script for exactly this reason. It was
reverted on Feb 11, 2025 (commit 22a8b7af "partytown") alongside the
Astro 4 -> 5 upgrade, which is what triggered the static-page tracking
collapse observed between June and July 2025.

- BaseLayout.astro: load gtag.js with `async` and run the config snippet
  on the main thread.
- astro.config.mjs: drop the @astrojs/partytown integration.
- package.json / package-lock.json: drop the @astrojs/partytown
  dependency.
- changelog: note the GA tracking fix in Pending v0.6.7.