### PR TITLE
Fix update_sandbox kernel version comparison

### DIFF
--- a/tasks/update_sandbox/src/task/mod.rs
+++ b/tasks/update_sandbox/src/task/mod.rs
@@ -64,14 +64,27 @@ impl Task {
         };
 
         let fc_changed = current.firecracker_version != new.firecracker_version;
-        let kern_changed = current.kernel_url_x86_64 != new.kernel_url_x86_64;
+        let current_kernel_version = current
+            .kernel_url_x86_64
+            .rsplit('/')
+            .next()
+            .and_then(|f| f.strip_prefix("vmlinux-"))
+            .unwrap_or("unknown");
+        let kern_changed = current_kernel_version != kern.version;
 
         if !fc_changed && !kern_changed {
             println!("Already up to date");
             return Ok(());
         }
 
-        let summary = format_summary(&current, &new, &kern.version, fc_changed, kern_changed);
+        let summary = format_summary(
+            &current,
+            &new,
+            current_kernel_version,
+            &kern.version,
+            fc_changed,
+            kern_changed,
+        );
 
         if self.dry_run {
             println!("[dry run] {summary}");
@@ -88,6 +101,7 @@ impl Task {
 fn format_summary(
     current: &BuildRsValues,
     new: &BuildRsValues,
+    current_kernel_version: &str,
     new_kernel_version: &str,
     fc_changed: bool,
     kern_changed: bool,
@@ -102,13 +116,9 @@ fn format_summary(
     }
 
     if kern_changed {
-        let current_kernel = current
-            .kernel_url_x86_64
-            .rsplit('/')
-            .next()
-            .and_then(|f| f.strip_prefix("vmlinux-"))
-            .unwrap_or("unknown");
-        parts.push(format!("kernel {current_kernel} -> {new_kernel_version}"));
+        parts.push(format!(
+            "kernel {current_kernel_version} -> {new_kernel_version}"
+        ));
     }
 
     format!("Update {}", parts.join(", "))

--- a/tasks/update_sandbox/src/task/mod.rs
+++ b/tasks/update_sandbox/src/task/mod.rs
@@ -1,3 +1,4 @@
+use anyhow::Context as _;
 use camino::Utf8PathBuf;
 use clap::Parser as _;
 
@@ -69,7 +70,7 @@ impl Task {
             .rsplit('/')
             .next()
             .and_then(|f| f.strip_prefix("vmlinux-"))
-            .unwrap_or("unknown");
+            .context("failed to parse kernel version from current URL")?;
         let kern_changed = current_kernel_version != kern.version;
 
         if !fc_changed && !kern_changed {


### PR DESCRIPTION
## Summary
- Compare extracted kernel version numbers instead of full S3 URLs for change detection in `update_sandbox`
- Previously, a new Firecracker CI build directory with the same kernel version would trigger a PR titled "Update kernel 6.1.168 -> 6.1.168"
- Now, kernel updates are only detected when the version actually changes

## Test plan
- [x] `cargo clippy` passes
- [x] `cargo fmt` passes
- [x] Crate compiles successfully