### PR TITLE
Run zizmor in CI and harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     target-branch: devel
     labels:
       - dependencies
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: npm
     directory: /
@@ -18,6 +20,8 @@ updates:
     target-branch: devel
     labels:
       - dependencies
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: /
@@ -27,3 +31,5 @@ updates:
     target-branch: devel
     labels:
       - dependencies
+    cooldown:
+      default-days: 7

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -10,10 +10,14 @@ env:
 jobs:
   backup_database:
     name: Backup Database
+    permissions:
+      contents: read
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
         with:
           mold-version: ${{ env.MOLD_VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install Dependencies
         working-directory: ./services/action
         run: npm install --include=dev
@@ -58,12 +60,16 @@ jobs:
       WASM_PACK_BUILD: "wasm-pack build --target web --no-default-features --features wasm,plus"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-rust
         with:
           cache-key: wasm
           mold-version: ${{ inputs.mold-version }}
       - name: Install `wasm-pack`
-        run: cargo install wasm-pack --version ${{ inputs.wasm-pack-version }} --locked --force
+        env:
+          INPUTS_WASM_PACK_VERSION: ${{ inputs.wasm-pack-version }}
+        run: cargo install wasm-pack --version "$INPUTS_WASM_PACK_VERSION" --locked --force
       - name: WASM pack `bencher_valid`
         working-directory: ./lib/bencher_valid
         run: |
@@ -86,6 +92,8 @@ jobs:
     needs: build_wasm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-rust
         with:
           cache-key: wasm
@@ -101,6 +109,8 @@ jobs:
     needs: build_wasm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Download `bencher_valid` Artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -119,6 +129,8 @@ jobs:
     if: ${{ !startsWith(github.ref, 'refs/tags/') && !inputs.deploy-only }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Download `bencher_valid` Artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -134,6 +146,8 @@ jobs:
     if: ${{ inputs.build-docker }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Log in to the Container registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Determine what changed
   changes:
@@ -32,6 +35,8 @@ jobs:
       nix: ${{ steps.filter.outputs.nix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
@@ -93,6 +98,7 @@ jobs:
     with:
       mold-version: "2.34.1"
       typeshare-version: "1.13.2"
+      zizmor-version: "v1.25.2"
 
   cli:
     name: CLI
@@ -125,6 +131,9 @@ jobs:
 
   test:
     name: Test
+    permissions:
+      contents: read
+      checks: write
     needs: changes
     if: ${{ github.ref != 'refs/heads/cloud' && (needs.changes.outputs.rust == 'true' || github.ref == 'refs/heads/devel' || startsWith(github.ref, 'refs/tags/')) }}
     uses: ./.github/workflows/test.yml
@@ -139,6 +148,9 @@ jobs:
 
   build:
     name: Build
+    permissions:
+      contents: read
+      packages: write
     needs: changes
     uses: ./.github/workflows/build.yml
     with:
@@ -151,6 +163,9 @@ jobs:
 
   docker:
     name: Docker
+    permissions:
+      contents: read
+      packages: write
     if: ${{ github.ref != 'refs/heads/cloud' && (github.ref == 'refs/heads/devel' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'docker'))) }}
     uses: ./.github/workflows/docker.yml
     with:
@@ -168,6 +183,9 @@ jobs:
 
   deploy:
     name: Deploy
+    permissions:
+      contents: write
+      packages: read
     needs: [lint, cli, test, build]
     if: ${{ !failure() && !cancelled() && (github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/cloud' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy'))) }}
     uses: ./.github/workflows/deploy.yml
@@ -187,6 +205,9 @@ jobs:
 
   release:
     name: Release
+    permissions:
+      contents: write
+      packages: write
     if: ${{ !failure() && !cancelled() && github.ref != 'refs/heads/cloud' && (needs.changes.outputs.rust == 'true' || github.ref == 'refs/heads/devel' || startsWith(github.ref, 'refs/tags/')) }}
     needs: [changes, lint, cli, runner, test, build, docker, nix]
     uses: ./.github/workflows/release.yml
@@ -241,10 +262,15 @@ jobs:
 
   build_dev_container:
     name: Build dev container
+    permissions:
+      contents: read
+      packages: write
     if: ${{ github.ref == 'refs/heads/devel' }}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Setup Docker buildx

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Fetch base branch
         env:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -45,7 +45,7 @@ jobs:
         os: [ubuntu-22.04, macos-14, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: bencherdev/bencher@main
+      - uses: bencherdev/bencher@main # zizmor: ignore[unpinned-uses] first-party action; intentionally tracks @main to exercise the latest released CLI
       - name: Run Bencher CLI
         run: bencher run --project bencher --token ${{ secrets.BENCHER_API_TOKEN }} --dry-run "bencher mock"
 
@@ -60,7 +60,7 @@ jobs:
     # This is expected to fail when tagging a new release
     continue-on-error: ${{ startsWith(github.ref, 'refs/tags/') }}
     steps:
-      - uses: bencherdev/bencher@devel
+      - uses: bencherdev/bencher@devel # zizmor: ignore[unpinned-uses] first-party action; intentionally tracks @devel to exercise the unreleased CLI
       - name: Run Bencher CLI
         run: bencher run --project bencher --token ${{ secrets.BENCHER_API_TOKEN }} --dry-run "bencher mock"
 
@@ -94,6 +94,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Unix CLI Install Script
         if: matrix.os != 'windows-2022'
         run: cat services/cli/templates/output/install-cli.sh | sh
@@ -115,12 +117,18 @@ jobs:
     continue-on-error: ${{ startsWith(github.ref, 'refs/tags/') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Unix CLI Install Script Version
         if: matrix.os != 'windows-2022'
-        run: export BENCHER_VERSION=${{ inputs.bencher-version }}; cat services/cli/templates/output/install-cli.sh | sh
+        env:
+          BENCHER_VERSION: ${{ inputs.bencher-version }}
+        run: cat services/cli/templates/output/install-cli.sh | sh
       - name: Windows CLI Install Script Version
         if: matrix.os == 'windows-2022'
-        run: $env:BENCHER_VERSION="${{ inputs.bencher-version }}"; powershell -c "gc -Raw services/cli/templates/output/install-cli.ps1 | iex"
+        env:
+          BENCHER_VERSION: ${{ inputs.bencher-version }}
+        run: powershell -c "gc -Raw services/cli/templates/output/install-cli.ps1 | iex"
       - name: Run Bencher CLI
         run: bencher run --project bencher --token ${{ secrets.BENCHER_API_TOKEN }} --dry-run "bencher mock"
 
@@ -184,11 +192,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set CLI version
         shell: bash
+        env:
+          HEAD_REF: ${{ github.head_ref || github.ref_name }}
         run: |
-          VERSION="${{ github.head_ref || github.ref_name }}"
-          echo "CLI_VERSION=${VERSION//\//-}" >> $GITHUB_ENV
+          VERSION="$HEAD_REF"
+          echo "CLI_VERSION=${VERSION//\//-}" >> "$GITHUB_ENV"
       - name: Install Rust target
         run: rustup target add ${{ matrix.target }}
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
@@ -197,11 +209,16 @@ jobs:
           version: ${{ inputs.zig-version }}
       - name: Install zigbuild
         if: startsWith(matrix.build, 'linux')
-        run: cargo install --version ${{ inputs.zig-build-version }} --locked --force cargo-zigbuild
+        env:
+          INPUTS_ZIG_BUILD_VERSION: ${{ inputs.zig-build-version }}
+        run: cargo install --version "$INPUTS_ZIG_BUILD_VERSION" --locked --force cargo-zigbuild
       - name: cargo zigbuild Linux CLI
         if: startsWith(matrix.build, 'linux')
         working-directory: ./services/cli
-        run: cargo zigbuild --profile release-small --target ${{ matrix.target }}.${{ inputs.glibc-version }}
+        env:
+          MATRIX_TARGET: ${{ matrix.target }}
+          INPUTS_GLIBC_VERSION: ${{ inputs.glibc-version }}
+        run: cargo zigbuild --profile release-small --target "$MATRIX_TARGET.$INPUTS_GLIBC_VERSION"
       - name: cargo build macOS CLI
         if: startsWith(matrix.build, 'macos')
         working-directory: ./services/cli
@@ -212,13 +229,13 @@ jobs:
         run: cargo build --profile release-small --target ${{ matrix.target }}
       - name: Rename Unix CLI bin
         if: (!startsWith(matrix.build, 'windows'))
-        run: mv ./target/${{ matrix.target }}/release-small/${{ env.CLI_BIN_NAME }} ${{ env.CLI_BIN_NAME }}-${{ env.CLI_VERSION }}-${{ matrix.build }}
+        run: mv ./target/${{ matrix.target }}/release-small/${{ env.CLI_BIN_NAME }} ${{ env.CLI_BIN_NAME }}-${CLI_VERSION}-${{ matrix.build }}
       - name: Rename Windows CLI bin
         if: startsWith(matrix.build, 'windows')
-        run: mv ./target/${{ matrix.target }}/release-small/${{ env.CLI_BIN_NAME }}.exe ${{ env.CLI_BIN_NAME }}-${{ env.CLI_VERSION }}-${{ matrix.build }}.exe
+        run: mv ./target/${{ matrix.target }}/release-small/${{ env.CLI_BIN_NAME }}.exe ${{ env.CLI_BIN_NAME }}-${CLI_VERSION}-${{ matrix.build }}.exe
       - name: Generate Unix SHA256 checksum
         if: (!startsWith(matrix.build, 'windows'))
-        run: shasum -a 256 ${{ env.CLI_BIN_NAME }}-${{ env.CLI_VERSION }}-${{ matrix.build }} > ${{ env.CLI_BIN_NAME }}-${{ env.CLI_VERSION }}-${{ matrix.build }}.sha256
+        run: shasum -a 256 ${{ env.CLI_BIN_NAME }}-${CLI_VERSION}-${{ matrix.build }} > ${{ env.CLI_BIN_NAME }}-${CLI_VERSION}-${{ matrix.build }}.sha256
       - name: Upload Unix CLI Artifact
         if: (!startsWith(matrix.build, 'windows'))
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -231,7 +248,7 @@ jobs:
       - name: Generate Windows SHA256 checksum
         if: startsWith(matrix.build, 'windows')
         shell: bash
-        run: sha256sum ${{ env.CLI_BIN_NAME }}-${{ env.CLI_VERSION }}-${{ matrix.build }}.exe > ${{ env.CLI_BIN_NAME }}-${{ env.CLI_VERSION }}-${{ matrix.build }}.exe.sha256
+        run: sha256sum ${{ env.CLI_BIN_NAME }}-${CLI_VERSION}-${{ matrix.build }}.exe > ${{ env.CLI_BIN_NAME }}-${CLI_VERSION}-${{ matrix.build }}.exe.sha256
       - name: Upload Windows CLI Artifact
         if: startsWith(matrix.build, 'windows')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -261,11 +278,15 @@ jobs:
       CLI_DEB_DIR: deb
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set CLI version
         shell: bash
+        env:
+          HEAD_REF: ${{ github.head_ref || github.ref_name }}
         run: |
-          VERSION="${{ github.head_ref || github.ref_name }}"
-          echo "CLI_VERSION=${VERSION//\//-}" >> $GITHUB_ENV
+          VERSION="$HEAD_REF"
+          echo "CLI_VERSION=${VERSION//\//-}" >> "$GITHUB_ENV"
       - name: Download CLI Artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -274,10 +295,10 @@ jobs:
         with:
           mold-version: ${{ inputs.mold-version }}
       - name: Build .deb package
-        run: cargo gen-pkg deb --dir ${{ env.CLI_DEB_DIR }} --arch ${{ matrix.arch }} ${{ env.CLI_BIN_NAME }}-${{ env.CLI_VERSION }}-${{ matrix.build }}
+        run: cargo gen-pkg deb --dir ${{ env.CLI_DEB_DIR }} --arch ${{ matrix.arch }} ${{ env.CLI_BIN_NAME }}-${CLI_VERSION}-${{ matrix.build }}
       - name: Test install .deb package
         if: matrix.build == 'linux-x86-64'
-        run: sudo dpkg -i ${{ env.CLI_DEB_DIR }}/${{ env.CLI_BIN_NAME }}-${{ env.CLI_VERSION }}-${{ matrix.build }}.deb
+        run: sudo dpkg -i ${{ env.CLI_DEB_DIR }}/${{ env.CLI_BIN_NAME }}-${CLI_VERSION}-${{ matrix.build }}.deb
       - name: Sanity test .deb package installation
         if: matrix.build == 'linux-x86-64'
         run: |
@@ -285,7 +306,7 @@ jobs:
           bencher mock
           man bencher
       - name: Generate .deb SHA256 checksum
-        run: shasum -a 256 ${{ env.CLI_DEB_DIR }}/${{ env.CLI_BIN_NAME }}-${{ env.CLI_VERSION }}-${{ matrix.build }}.deb > ${{ env.CLI_DEB_DIR }}/${{ env.CLI_BIN_NAME }}-${{ env.CLI_VERSION }}-${{ matrix.build }}.deb.sha256
+        run: shasum -a 256 ${{ env.CLI_DEB_DIR }}/${{ env.CLI_BIN_NAME }}-${CLI_VERSION}-${{ matrix.build }}.deb > ${{ env.CLI_DEB_DIR }}/${{ env.CLI_BIN_NAME }}-${CLI_VERSION}-${{ matrix.build }}.deb.sha256
       - name: Upload .deb Artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,8 @@ jobs:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-rust
         with:
           cache-key: cli
@@ -117,6 +119,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Download `bencher_valid` Artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -129,7 +133,9 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: npm run netlify
       - name: Install Netlify CLI
-        run: npm install --save-dev netlify-cli@${{ inputs.netlify-cli-version }}
+        env:
+          INPUTS_NETLIFY_CLI_VERSION: ${{ inputs.netlify-cli-version }}
+        run: npm install --save-dev "netlify-cli@$INPUTS_NETLIFY_CLI_VERSION"
       - name: Deploy Console UI to Netlify Dev
         env:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
@@ -158,6 +164,8 @@ jobs:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Log in to the Container registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
@@ -188,7 +196,7 @@ jobs:
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked] the prod deploy rebases main onto cloud and pushes, so it needs the persisted GITHUB_TOKEN
         with:
           fetch-depth: 0
       - name: Log in to the Container registry
@@ -222,6 +230,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Download `bencher_valid` Artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -234,7 +244,9 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: npm run netlify
       - name: Install Netlify CLI
-        run: npm install --save-dev netlify-cli@${{ inputs.netlify-cli-version }}
+        env:
+          INPUTS_NETLIFY_CLI_VERSION: ${{ inputs.netlify-cli-version }}
+        run: npm install --save-dev "netlify-cli@$INPUTS_NETLIFY_CLI_VERSION"
       - name: Deploy Console UI to Netlify
         env:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Log in to the Container registry
@@ -94,6 +96,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Log in to the Container registry
@@ -153,6 +157,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Log in to the Container registry

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,9 @@ on:
       typeshare-version:
         type: string
         required: true
+      zizmor-version:
+        type: string
+        required: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -19,6 +22,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Add fmt
         run: rustup component add rustfmt
       - name: Run fmt
@@ -29,6 +34,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-rust
         with:
           cache-key: all-features
@@ -43,6 +50,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
         with:
           mold-version: ${{ inputs.mold-version }}
@@ -51,7 +60,9 @@ jobs:
       - name: Check OpenAPI Spec for changes
         run: git diff --exit-code
       - name: Install Typeshare CLI
-        run: cargo install typeshare-cli --version ${{ inputs.typeshare-version }} --locked
+        env:
+          INPUTS_TYPESHARE_VERSION: ${{ inputs.typeshare-version }}
+        run: cargo install typeshare-cli --version "$INPUTS_TYPESHARE_VERSION" --locked
       - name: Generate Typescript Types
         run: cargo gen-ts
       - name: Check Typescript Types for changes
@@ -75,17 +86,56 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: EmbarkStudios/cargo-deny-action@6c8f9facfa5047ec02d8485b6bf52b587b7777d1 # v2.0.18
         with:
           log-level: warn
           command: check
           arguments: --locked
 
+  zizmor:
+    name: Zizmor
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run zizmor (offline)
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          version: ${{ inputs.zizmor-version }}
+          online-audits: false
+          advanced-security: false
+          annotations: true
+
+  zizmor_online:
+    name: Zizmor Online
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run zizmor (online)
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          version: ${{ inputs.zizmor-version }}
+          online-audits: true
+          advanced-security: false
+          annotations: true
+
   biome_format:
     name: Biome Format
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Biome format Action
         working-directory: ./services/action
         run: |
@@ -102,6 +152,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Biome check Action
         working-directory: ./services/action
         run: |

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install Nix
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
@@ -34,6 +36,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install Nix
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:

--- a/.github/workflows/rebase_cloud.yml
+++ b/.github/workflows/rebase_cloud.yml
@@ -12,7 +12,7 @@ jobs:
     name: Rebase cloud on devel
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked] this job rebases cloud onto devel and pushes, so it needs the persisted GITHUB_TOKEN
         with:
           fetch-depth: 0
       - name: Rebase cloud on devel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
     continue-on-error: ${{ !startsWith(github.ref, 'refs/tags/') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
         if: matrix.os == 'ubuntu-22.04'
         with:
@@ -65,11 +67,15 @@ jobs:
       BUILD_WINDOWS_ARM_64: windows-arm-64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set version
+        env:
+          HEAD_REF: ${{ github.head_ref || github.ref_name }}
         run: |
-          VERSION="${{ github.head_ref || github.ref_name }}"
-          echo "VERSION=${VERSION//\//-}" >> $GITHUB_ENV
+          VERSION="$HEAD_REF"
+          echo "VERSION=${VERSION//\//-}" >> "$GITHUB_ENV"
 
       # Download all artifacts from the CI workflow
       - name: Download CLI Linux x86_64 Artifact
@@ -143,7 +149,7 @@ jobs:
         run: |
           export GITHUB_IMAGE=${{ env.GITHUB_REGISTRY }}/${{ github.repository_owner }}/${{ env.API_DOCKER_IMAGE }}
           export DOCKER_HUB_IMAGE=${{ env.DOCKER_HUB_ORGANIZATION }}/${{ env.API_DOCKER_IMAGE }}
-          export TAG=${{ env.VERSION }}
+          export TAG=${VERSION}
           docker buildx imagetools create \
             --tag ${GITHUB_IMAGE}:latest \
             --tag ${GITHUB_IMAGE}:${TAG} \
@@ -155,7 +161,7 @@ jobs:
         run: |
           export GITHUB_IMAGE=${{ env.GITHUB_REGISTRY }}/${{ github.repository_owner }}/${{ env.CONSOLE_DOCKER_IMAGE }}
           export DOCKER_HUB_IMAGE=${{ env.DOCKER_HUB_ORGANIZATION }}/${{ env.CONSOLE_DOCKER_IMAGE }}
-          export TAG=${{ env.VERSION }}
+          export TAG=${VERSION}
           docker buildx imagetools create \
             --tag ${GITHUB_IMAGE}:latest \
             --tag ${GITHUB_IMAGE}:${TAG} \
@@ -167,7 +173,7 @@ jobs:
         run: |
           export GITHUB_IMAGE=${{ env.GITHUB_REGISTRY }}/${{ github.repository_owner }}/${{ env.CLI_DOCKER_IMAGE }}
           export DOCKER_HUB_IMAGE=${{ env.DOCKER_HUB_ORGANIZATION }}/${{ env.CLI_DOCKER_IMAGE }}
-          export TAG=${{ env.VERSION }}
+          export TAG=${VERSION}
           docker buildx imagetools create \
             --tag ${GITHUB_IMAGE}:latest \
             --tag ${GITHUB_IMAGE}:${TAG} \
@@ -184,7 +190,7 @@ jobs:
         run: cargo gen-notes
 
       - name: GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2 # zizmor: ignore[superfluous-actions] handles multi-file uploads, prerelease detection, and notes body; preferred over a hand-rolled `gh release` script
         with:
           tag_name: ${{ env.VERSION }}
           prerelease: ${{ contains(env.VERSION, '-rc') }}

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
@@ -62,10 +64,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set Runner version
+        env:
+          HEAD_REF: ${{ github.head_ref || github.ref_name }}
         run: |
-          VERSION="${{ github.head_ref || github.ref_name }}"
-          echo "RUNNER_VERSION=${VERSION//\//-}" >> $GITHUB_ENV
+          VERSION="$HEAD_REF"
+          echo "RUNNER_VERSION=${VERSION//\//-}" >> "$GITHUB_ENV"
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
@@ -77,15 +83,17 @@ jobs:
         with:
           version: ${{ inputs.zig-version }}
       - name: Install cargo-zigbuild
-        run: cargo install --version ${{ inputs.zig-build-version }} --locked --force cargo-zigbuild
+        env:
+          INPUTS_ZIG_BUILD_VERSION: ${{ inputs.zig-build-version }}
+        run: cargo install --version "$INPUTS_ZIG_BUILD_VERSION" --locked --force cargo-zigbuild
       - name: Build bencher-init (static musl)
         run: cargo zigbuild --release --target ${{ matrix.init-target }} -p bencher_init
       - name: Build bencher-runner (release)
         run: cargo zigbuild --release --target ${{ matrix.target }} -p bencher_runner_cli --features plus
       - name: Rename Runner binary
-        run: mv ./target/${{ matrix.target }}/release/${{ env.RUNNER_BIN_NAME }} ${{ env.RUNNER_BIN_NAME }}-${{ env.RUNNER_VERSION }}-${{ matrix.build }}
+        run: mv ./target/${{ matrix.target }}/release/${{ env.RUNNER_BIN_NAME }} ${{ env.RUNNER_BIN_NAME }}-${RUNNER_VERSION}-${{ matrix.build }}
       - name: Generate SHA256 checksum
-        run: sha256sum ${{ env.RUNNER_BIN_NAME }}-${{ env.RUNNER_VERSION }}-${{ matrix.build }} > ${{ env.RUNNER_BIN_NAME }}-${{ env.RUNNER_VERSION }}-${{ matrix.build }}.sha256
+        run: sha256sum ${{ env.RUNNER_BIN_NAME }}-${RUNNER_VERSION}-${{ matrix.build }} > ${{ env.RUNNER_BIN_NAME }}-${RUNNER_VERSION}-${{ matrix.build }}.sha256
       - name: Upload Runner Artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,8 @@ jobs:
         with:
           large-packages: false
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-rust
         with:
           cache-key: all-features
@@ -57,6 +59,8 @@ jobs:
         with:
           large-packages: false
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
         with:
           mold-version: ${{ inputs.mold-version }}
@@ -83,6 +87,8 @@ jobs:
         with:
           large-packages: false
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-rust
         if: ${{ !inputs.is-fork }}
         with:
@@ -123,10 +129,14 @@ jobs:
         with:
           large-packages: false
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Build Docker image
+        env:
+          INPUTS_MOLD_VERSION: ${{ inputs.mold-version }}
         run: |
           docker build \
-            --build-arg MOLD_VERSION=${{ inputs.mold-version }} \
+            --build-arg "MOLD_VERSION=$INPUTS_MOLD_VERSION" \
             -t bench:ci \
             -f docker/bench.Dockerfile \
             .
@@ -153,6 +163,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-rust
         if: matrix.os == 'ubuntu-22.04'
         with:
@@ -173,6 +185,9 @@ jobs:
 
   track_benchmarks:
     name: Track Benchmarks
+    permissions:
+      contents: read
+      checks: write
     if: ${{ github.ref == 'refs/heads/devel' }}
     needs: [bench_image, bencher_noise]
     uses: ./.github/workflows/track_benchmarks.yml
@@ -186,6 +201,8 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-rust
         if: ${{ !inputs.is-fork }}
         with:
@@ -213,6 +230,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
         with:
           mold-version: ${{ inputs.mold-version }}
@@ -226,6 +245,8 @@ jobs:
       WASM_PACK_VERSION: "0.12.1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install `wasm-pack`
         run: cargo install wasm-pack --version ${{ env.WASM_PACK_VERSION }} --locked --force
       - name: Build WASM
@@ -244,6 +265,8 @@ jobs:
         with:
           large-packages: false
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
         with:
           mold-version: ${{ inputs.mold-version }}

--- a/.github/workflows/track_benchmarks.yml
+++ b/.github/workflows/track_benchmarks.yml
@@ -37,13 +37,13 @@ jobs:
           docker tag bench:ci registry.bencher.dev/bencher:${{ github.sha }}
           echo '${{ secrets.BENCHER_API_TOKEN }}' | docker login registry.bencher.dev -u '${{ secrets.BENCHER_USER_EMAIL }}' --password-stdin
           docker push registry.bencher.dev/bencher:${{ github.sha }}
-      - uses: bencherdev/bencher@main
+      - uses: bencherdev/bencher@main # zizmor: ignore[unpinned-uses] first-party action; intentionally tracks @main to exercise the latest released CLI
       - name: Track Noise (ubuntu)
         run: |
           bencher run \
           --project bencher \
           --token '${{ secrets.BENCHER_API_TOKEN }}' \
-          --branch ${{ github.ref_name }} \
+          --branch ${GITHUB_REF_NAME} \
           --hash '${{ github.sha }}' \
           --testbed ubuntu-22.04 \
           --threshold-measure noise-score \
@@ -60,7 +60,7 @@ jobs:
           bencher run \
           --project bencher \
           --token '${{ secrets.BENCHER_API_TOKEN }}' \
-          --branch ${{ github.ref_name }} \
+          --branch ${GITHUB_REF_NAME} \
           --hash '${{ github.sha }}' \
           --testbed macos-14 \
           --threshold-measure noise-score \
@@ -77,7 +77,7 @@ jobs:
           bencher run \
           --project bencher \
           --token '${{ secrets.BENCHER_API_TOKEN }}' \
-          --branch ${{ github.ref_name }} \
+          --branch ${GITHUB_REF_NAME} \
           --hash '${{ github.sha }}' \
           --testbed windows-2022 \
           --threshold-measure noise-score \
@@ -95,7 +95,7 @@ jobs:
           --project bencher \
           --token '${{ secrets.BENCHER_API_TOKEN }}' \
           --image "bencher:${{ github.sha }}" \
-          --branch ${{ github.ref_name }} \
+          --branch ${GITHUB_REF_NAME} \
           --hash '${{ github.sha }}' \
           --testbed intel-v1 \
           --spec intel-v1 \

--- a/.github/workflows/track_pr_benchmarks.yml
+++ b/.github/workflows/track_pr_benchmarks.yml
@@ -1,7 +1,7 @@
 name: Track PR Benchmarks
 
 on:
-  workflow_run:
+  workflow_run: # zizmor: ignore[dangerous-triggers] fork-PR benchmarks must run after CI; this workflow never checks out untrusted PR code and treats all PR inputs as untrusted
     workflows: [CI]
     types: [completed]
 
@@ -30,11 +30,13 @@ jobs:
           run_id: ${{ github.event.workflow_run.id }}
       - name: Load and push image
         if: steps.download_bench.outcome == 'success'
+        env:
+          GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           docker load -i bench_image.tar
-          docker tag bench:ci registry.bencher.dev/bencher:${{ github.event.workflow_run.head_sha }}
+          docker tag bench:ci registry.bencher.dev/bencher:${GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA}
           echo '${{ secrets.BENCHER_API_TOKEN }}' | docker login registry.bencher.dev -u '${{ secrets.BENCHER_USER_EMAIL }}' --password-stdin
-          docker push registry.bencher.dev/bencher:${{ github.event.workflow_run.head_sha }}
+          docker push registry.bencher.dev/bencher:${GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA}
       - name: Read PR Event Data
         if: steps.download_bench.outcome == 'success'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
@@ -47,17 +49,18 @@ jobs:
             core.exportVariable('PR_BASE', prEvent.pull_request.base.ref);
             core.exportVariable('PR_BASE_SHA', prEvent.pull_request.base.sha);
             core.exportVariable('PR_NUMBER', prEvent.number);
-      - uses: bencherdev/bencher@main
+      - uses: bencherdev/bencher@main # zizmor: ignore[unpinned-uses] first-party action; intentionally tracks @main to exercise the latest released CLI
         if: steps.download_bench.outcome == 'success'
       - name: Track Benchmarks with Bencher
         if: steps.download_bench.outcome == 'success'
         env:
           BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+          GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           bencher run \
           --project bencher \
           --token "$BENCHER_API_TOKEN" \
-          --image "bencher:${{ github.event.workflow_run.head_sha }}" \
+          --image "bencher:${GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA}" \
           --branch "$PR_HEAD" \
           --hash "$PR_HEAD_SHA" \
           --start-point "$PR_BASE" \

--- a/.github/workflows/update_sandbox.yml
+++ b/.github/workflows/update_sandbox.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked] this job commits and force-pushes the update/sandbox branch, so it needs the persisted GITHUB_TOKEN
         with:
           ref: devel
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable


### PR DESCRIPTION
## Summary

- Add **zizmor** (a static-analysis security linter for GitHub Actions) via `zizmorcore/zizmor-action` in `lint.yml` as two jobs:
  - `Zizmor` — `online-audits: false`, **blocking**. Deterministic; fails CI on findings we control.
  - `Zizmor Online` — online audits on, `continue-on-error: true`, **warn-only** (like `cargo_deny`) so advisory findings (e.g. `known-vulnerable-actions`) surface without making the required gate non-deterministic.
  - Action SHA-pinned to `v0.5.6`; zizmor binary pinned to `v1.25.2` (passed from `ci.yml` like other tool versions).
- Harden all workflows so the offline gate passes (was 19 high / 15 medium / 8 low + advisory):
  - **template-injection** → env-var / shell-var indirection for `github.head_ref`, `inputs.*`, `matrix.*`, and the `head_ref`-derived `CLI_VERSION`.
  - **artipacked** → `persist-credentials: false` on read-only checkouts.
  - **excessive-permissions** → least-privilege `permissions:` (top-level `contents: read` in `ci.yml` plus per-job `packages`/`checks`/`contents` scopes derived by reading each reusable workflow).
  - **dependabot-cooldown** → 7-day cooldown on all ecosystems.
- 9 intentional patterns suppressed with justified inline comments: first-party `bencherdev/bencher@main|devel` pins, the `workflow_run` trigger, the GitHub Release action, and three push-jobs that need the persisted token (`rebase_cloud`, `update_sandbox`, prod deploy).

## Review notes

- **`ci.yml` job permissions** are now explicit/least-privilege (previously the repo default). Please sanity-check `deploy`/`release` (production) didn't rely on a broader default — the `deploy` label on this PR exercises the deploy path against the new scopes.
- **Dependabot cooldown** (`default-days: 7`) is new and delays dependency updates; adjust/remove if that cadence isn't wanted.
- `claude-review.yml` was rebased on top of #876 (which already hardened its event-data handling and bumped the model); this PR only adds `persist-credentials: false` there.

## Test plan

- [ ] `Lint / Zizmor` (blocking, offline) passes.
- [ ] `Lint / Zizmor Online` runs as non-blocking.
- [ ] `deploy` label: Docker build + dev/test deploy succeed under the new permission scopes.
- [ ] Verified locally with `zizmor 1.25.2`: `zizmor .` → exit 0 (offline and online).