### PR TITLE
Fix Windows build_cli regression and split cargo_deny gate

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -232,7 +232,7 @@ jobs:
         run: mv ./target/${{ matrix.target }}/release-small/${{ env.CLI_BIN_NAME }} ${{ env.CLI_BIN_NAME }}-${CLI_VERSION}-${{ matrix.build }}
       - name: Rename Windows CLI bin
         if: startsWith(matrix.build, 'windows')
-        run: mv ./target/${{ matrix.target }}/release-small/${{ env.CLI_BIN_NAME }}.exe ${{ env.CLI_BIN_NAME }}-${CLI_VERSION}-${{ matrix.build }}.exe
+        run: mv ./target/${{ matrix.target }}/release-small/${{ env.CLI_BIN_NAME }}.exe ${{ env.CLI_BIN_NAME }}-${env:CLI_VERSION}-${{ matrix.build }}.exe
       - name: Generate Unix SHA256 checksum
         if: (!startsWith(matrix.build, 'windows'))
         run: shasum -a 256 ${{ env.CLI_BIN_NAME }}-${CLI_VERSION}-${{ matrix.build }} > ${{ env.CLI_BIN_NAME }}-${CLI_VERSION}-${{ matrix.build }}.sha256

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -83,6 +83,20 @@ jobs:
   cargo_deny:
     name: Cargo Deny
     runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: EmbarkStudios/cargo-deny-action@6c8f9facfa5047ec02d8485b6bf52b587b7777d1 # v2.0.18
+        with:
+          log-level: warn
+          command: check
+          arguments: --locked
+          command-arguments: bans licenses sources
+
+  cargo_deny_advisories:
+    name: Cargo Deny Advisories
+    runs-on: ubuntu-22.04
     continue-on-error: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -93,6 +107,7 @@ jobs:
           log-level: warn
           command: check
           arguments: --locked
+          command-arguments: advisories
 
   zizmor:
     name: Zizmor


### PR DESCRIPTION
## Summary

- **Fix Windows `build_cli` regression from #877.** The "Rename Windows CLI bin" step runs under PowerShell (the Windows default shell), where the bash-style `${CLI_VERSION}` introduced in #877 expanded to empty — the binary was mis-named `bencher--windows-…exe`, so "Generate Windows SHA256 checksum" failed: `sha256sum: bencher-devel-windows-arm-64.exe: No such file or directory` (run 26724741432). Switched to pwsh `${env:CLI_VERSION}`, **keeping the step on PowerShell** so the Windows matrix exercises the real PowerShell path (not shimmed with `shell: bash`). Stays zizmor-clean (it's a shell ref, not a `${{ }}` template).
- **Split `cargo_deny` into deterministic + advisories**, mirroring the `zizmor` / `zizmor_online` split:
  - **Cargo Deny** (`bans licenses sources`) — now **blocking** (dropped `continue-on-error`); license/bans/sources violations fail the build.
  - **Cargo Deny Advisories** (`advisories`) — **`continue-on-error: true`** (the RustSec advisory DB is non-deterministic — new CVEs shouldn't flip a green PR red), staying warn-only as today.

## Verification

- Local (cargo-deny 0.19.0): `cargo deny --locked check bans licenses sources` → "bans ok, licenses ok, sources ok"; `check advisories` → "advisories ok"; `zizmor .` → exit 0.
- **Caveat:** `build_cli` is skipped on a workflow-only PR (the `cli` path filter excludes `.github/workflows/**`), so the Windows fix isn't exercised by *this* PR's CI — it runs on `devel` after merge. The pwsh `${env:CLI_VERSION}` fix is correct by construction.

## Test plan

- [ ] `Lint / Cargo Deny` runs as a **blocking** check; `Lint / Cargo Deny Advisories` runs **non-blocking**.
- [ ] After merge: `devel` Windows `build_cli` (arm64 + x86_64) goes green.