### PR TITLE
Add install gungraun-runner section to Gungraun guide

### DIFF
--- a/services/console/src/chunks/benchmarking-rust/gungraun/de/install-gungraun-runner.mdx
+++ b/services/console/src/chunks/benchmarking-rust/gungraun/de/install-gungraun-runner.mdx
@@ -1,0 +1,8 @@
+## Gungraun Runner installieren
+
+Gungraun erfordert, dass das [`gungraun-runner`](https://gungraun.github.io/gungraun/latest/html/installation/gungraun.html)-Binary installiert und in Ihrem `$PATH` verfügbar ist.
+Die Runner-Version muss mit der in Ihrer `Cargo.toml` verwendeten Bibliotheksversion übereinstimmen.
+
+Installieren Sie es mit: `cargo install --version 0.18.0 gungraun-runner`
+
+Oder mit [cargo-binstall](https://github.com/cargo-bins/cargo-binstall): `cargo binstall gungraun-runner@0.18.0`

--- a/services/console/src/chunks/benchmarking-rust/gungraun/en/install-gungraun-runner.mdx
+++ b/services/console/src/chunks/benchmarking-rust/gungraun/en/install-gungraun-runner.mdx
@@ -1,0 +1,8 @@
+## Install Gungraun Runner
+
+Gungraun requires the [`gungraun-runner`](https://gungraun.github.io/gungraun/latest/html/installation/gungraun.html) binary to be installed and available in your `$PATH`.
+The runner version must match the library version used in your `Cargo.toml`.
+
+Install it with: `cargo install --version 0.18.0 gungraun-runner`
+
+Or using [cargo-binstall](https://github.com/cargo-bins/cargo-binstall): `cargo binstall gungraun-runner@0.18.0`

--- a/services/console/src/chunks/benchmarking-rust/gungraun/es/install-gungraun-runner.mdx
+++ b/services/console/src/chunks/benchmarking-rust/gungraun/es/install-gungraun-runner.mdx
@@ -1,0 +1,8 @@
+## Instalar Gungraun Runner
+
+Gungraun requiere que el binario [`gungraun-runner`](https://gungraun.github.io/gungraun/latest/html/installation/gungraun.html) esté instalado y disponible en tu `$PATH`.
+La versión del runner debe coincidir con la versión de la biblioteca utilizada en tu `Cargo.toml`.
+
+Instálalo con: `cargo install --version 0.18.0 gungraun-runner`
+
+O usando [cargo-binstall](https://github.com/cargo-bins/cargo-binstall): `cargo binstall gungraun-runner@0.18.0`

--- a/services/console/src/chunks/benchmarking-rust/gungraun/fr/install-gungraun-runner.mdx
+++ b/services/console/src/chunks/benchmarking-rust/gungraun/fr/install-gungraun-runner.mdx
@@ -1,0 +1,8 @@
+## Installer Gungraun Runner
+
+Gungraun nécessite que le binaire [`gungraun-runner`](https://gungraun.github.io/gungraun/latest/html/installation/gungraun.html) soit installé et disponible dans votre `$PATH`.
+La version du runner doit correspondre à la version de la bibliothèque utilisée dans votre `Cargo.toml`.
+
+Installez-le avec : `cargo install --version 0.18.0 gungraun-runner`
+
+Ou en utilisant [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) : `cargo binstall gungraun-runner@0.18.0`

--- a/services/console/src/chunks/benchmarking-rust/gungraun/ja/install-gungraun-runner.mdx
+++ b/services/console/src/chunks/benchmarking-rust/gungraun/ja/install-gungraun-runner.mdx
@@ -1,0 +1,8 @@
+## Gungraun Runnerのインストール
+
+Gungraunは[`gungraun-runner`](https://gungraun.github.io/gungraun/latest/html/installation/gungraun.html)バイナリがインストールされ、`$PATH`で利用可能である必要があります。
+ランナーのバージョンは`Cargo.toml`で使用しているライブラリのバージョンと一致する必要があります。
+
+次のコマンドでインストール：`cargo install --version 0.18.0 gungraun-runner`
+
+または[cargo-binstall](https://github.com/cargo-bins/cargo-binstall)を使用：`cargo binstall gungraun-runner@0.18.0`

--- a/services/console/src/chunks/benchmarking-rust/gungraun/ko/install-gungraun-runner.mdx
+++ b/services/console/src/chunks/benchmarking-rust/gungraun/ko/install-gungraun-runner.mdx
@@ -1,0 +1,8 @@
+## Gungraun Runner 설치
+
+Gungraun은 [`gungraun-runner`](https://gungraun.github.io/gungraun/latest/html/installation/gungraun.html) 바이너리가 설치되어 있고 `$PATH`에서 사용 가능해야 합니다.
+러너 버전은 `Cargo.toml`에서 사용하는 라이브러리 버전과 일치해야 합니다.
+
+다음 명령으로 설치: `cargo install --version 0.18.0 gungraun-runner`
+
+또는 [cargo-binstall](https://github.com/cargo-bins/cargo-binstall)을 사용: `cargo binstall gungraun-runner@0.18.0`

--- a/services/console/src/chunks/benchmarking-rust/gungraun/pt/install-gungraun-runner.mdx
+++ b/services/console/src/chunks/benchmarking-rust/gungraun/pt/install-gungraun-runner.mdx
@@ -1,0 +1,8 @@
+## Instalar Gungraun Runner
+
+O Gungraun requer que o binário [`gungraun-runner`](https://gungraun.github.io/gungraun/latest/html/installation/gungraun.html) esteja instalado e disponível no seu `$PATH`.
+A versão do runner deve corresponder à versão da biblioteca utilizada no seu `Cargo.toml`.
+
+Instale com: `cargo install --version 0.18.0 gungraun-runner`
+
+Ou usando [cargo-binstall](https://github.com/cargo-bins/cargo-binstall): `cargo binstall gungraun-runner@0.18.0`

--- a/services/console/src/chunks/benchmarking-rust/gungraun/ru/install-gungraun-runner.mdx
+++ b/services/console/src/chunks/benchmarking-rust/gungraun/ru/install-gungraun-runner.mdx
@@ -1,0 +1,8 @@
+## Установка Gungraun Runner
+
+Gungraun требует, чтобы бинарный файл [`gungraun-runner`](https://gungraun.github.io/gungraun/latest/html/installation/gungraun.html) был установлен и доступен в вашем `$PATH`.
+Версия runner должна совпадать с версией библиотеки, используемой в вашем `Cargo.toml`.
+
+Установите его командой: `cargo install --version 0.18.0 gungraun-runner`
+
+Или с помощью [cargo-binstall](https://github.com/cargo-bins/cargo-binstall): `cargo binstall gungraun-runner@0.18.0`

--- a/services/console/src/chunks/benchmarking-rust/gungraun/zh/install-gungraun-runner.mdx
+++ b/services/console/src/chunks/benchmarking-rust/gungraun/zh/install-gungraun-runner.mdx
@@ -1,0 +1,8 @@
+## 安装 Gungraun Runner
+
+Gungraun 需要安装 [`gungraun-runner`](https://gungraun.github.io/gungraun/latest/html/installation/gungraun.html) 二进制文件并在 `$PATH` 中可用。
+Runner 版本必须与 `Cargo.toml` 中使用的库版本匹配。
+
+使用以下命令安装：`cargo install --version 0.18.0 gungraun-runner`
+
+或使用 [cargo-binstall](https://github.com/cargo-bins/cargo-binstall)：`cargo binstall gungraun-runner@0.18.0`

--- a/services/console/src/content/benchmarking-rust/de/gungraun.mdx
+++ b/services/console/src/content/benchmarking-rust/de/gungraun.mdx
@@ -3,7 +3,7 @@ title: "Gungraun"
 description: "Eine Schritt-für-Schritt-Anleitung, wie man Rust-Code mit Gungraun benchmarkt"
 heading: "Wie man Rust-Code mit Gungraun benchmarkt"
 published: "2026-05-17T00:00:00Z"
-modified: "2026-05-17T00:00:00Z"
+modified: "2026-06-03T00:00:00Z"
 sortOrder: 4
 ---
 
@@ -30,6 +30,7 @@ import FizzBuzzRules from "../../../chunks/benchmarking/de/fizz-buzz-rules.mdx";
 import FizzBuzzRust from "../../../chunks/benchmarking-rust/de/fizz-buzz-rust.mdx";
 import GameBenchesTree from "../../../chunks/benchmarking-rust/criterion/game-benches-tree.mdx";
 import GameCargoToml from "../../../chunks/benchmarking-rust/gungraun/game-cargo-toml.mdx";
+import InstallGungraunRunner from "../../../chunks/benchmarking-rust/gungraun/de/install-gungraun-runner.mdx";
 import MicroVsMacro from "../../../chunks/benchmarking/de/micro-vs-macro.mdx";
 import OnFire from "../../../chunks/benchmarking/de/on-fire.mdx";
 import PlayGameRustCode from "../../../chunks/benchmarking-rust/criterion/play-game-rust-code.mdx";
@@ -66,6 +67,8 @@ Die macOS-Unterstützung ist jedoch auf x86_64-Prozessoren beschränkt, da [arm6
 Auf Debian ausführen: `sudo apt-get install valgrind`
 
 Auf macOS (nur x86_64/Intel-Chip): `brew install valgrind`
+
+<InstallGungraunRunner />
 
 <FizzBuzzRefactor />
 

--- a/services/console/src/content/benchmarking-rust/en/gungraun.mdx
+++ b/services/console/src/content/benchmarking-rust/en/gungraun.mdx
@@ -3,7 +3,7 @@ title: "Gungraun"
 description: "A step-by-step guide on how to benchmark Rust code with Gungraun"
 heading: "How to benchmark Rust code with Gungraun"
 published: "2026-05-17T00:00:00Z"
-modified: "2026-05-17T00:00:00Z"
+modified: "2026-06-03T00:00:00Z"
 sortOrder: 4
 ---
 
@@ -30,6 +30,7 @@ import FizzBuzzRules from "../../../chunks/benchmarking/en/fizz-buzz-rules.mdx";
 import FizzBuzzRust from "../../../chunks/benchmarking-rust/en/fizz-buzz-rust.mdx";
 import GameBenchesTree from "../../../chunks/benchmarking-rust/criterion/game-benches-tree.mdx";
 import GameCargoToml from "../../../chunks/benchmarking-rust/gungraun/game-cargo-toml.mdx";
+import InstallGungraunRunner from "../../../chunks/benchmarking-rust/gungraun/en/install-gungraun-runner.mdx";
 import MicroVsMacro from "../../../chunks/benchmarking/en/micro-vs-macro.mdx";
 import OnFire from "../../../chunks/benchmarking/en/on-fire.mdx";
 import PlayGameRustCode from "../../../chunks/benchmarking-rust/criterion/play-game-rust-code.mdx";
@@ -66,6 +67,8 @@ However, the macOS support is limited to x86_64 processors as [arm64 (M1, M2, et
 On Debian run: `sudo apt-get install valgrind`
 
 On macOS (x86_64/Intel chip only): `brew install valgrind`
+
+<InstallGungraunRunner />
 
 <FizzBuzzRefactor />
 

--- a/services/console/src/content/benchmarking-rust/es/gungraun.mdx
+++ b/services/console/src/content/benchmarking-rust/es/gungraun.mdx
@@ -3,7 +3,7 @@ title: "Gungraun"
 description: "Una guía paso a paso sobre cómo hacer benchmarks de código Rust con Gungraun"
 heading: "Cómo hacer benchmarks de código Rust con Gungraun"
 published: "2026-05-17T00:00:00Z"
-modified: "2026-05-17T00:00:00Z"
+modified: "2026-06-03T00:00:00Z"
 sortOrder: 4
 ---
 
@@ -30,6 +30,7 @@ import FizzBuzzRules from "../../../chunks/benchmarking/es/fizz-buzz-rules.mdx";
 import FizzBuzzRust from "../../../chunks/benchmarking-rust/es/fizz-buzz-rust.mdx";
 import GameBenchesTree from "../../../chunks/benchmarking-rust/criterion/game-benches-tree.mdx";
 import GameCargoToml from "../../../chunks/benchmarking-rust/gungraun/game-cargo-toml.mdx";
+import InstallGungraunRunner from "../../../chunks/benchmarking-rust/gungraun/es/install-gungraun-runner.mdx";
 import MicroVsMacro from "../../../chunks/benchmarking/es/micro-vs-macro.mdx";
 import OnFire from "../../../chunks/benchmarking/es/on-fire.mdx";
 import PlayGameRustCode from "../../../chunks/benchmarking-rust/criterion/play-game-rust-code.mdx";
@@ -66,6 +67,8 @@ Sin embargo, el soporte de macOS está limitado a procesadores x86_64 ya que [lo
 En Debian ejecuta: `sudo apt-get install valgrind`
 
 En macOS (solo chip x86_64/Intel): `brew install valgrind`
+
+<InstallGungraunRunner />
 
 <FizzBuzzRefactor />
 

--- a/services/console/src/content/benchmarking-rust/fr/gungraun.mdx
+++ b/services/console/src/content/benchmarking-rust/fr/gungraun.mdx
@@ -3,7 +3,7 @@ title: "Gungraun"
 description: "Un guide étape par étape sur comment faire un benchmark du code Rust avec Gungraun"
 heading: "Comment faire un benchmark du code Rust avec Gungraun"
 published: "2026-05-17T00:00:00Z"
-modified: "2026-05-17T00:00:00Z"
+modified: "2026-06-03T00:00:00Z"
 sortOrder: 4
 ---
 
@@ -30,6 +30,7 @@ import FizzBuzzRules from "../../../chunks/benchmarking/fr/fizz-buzz-rules.mdx";
 import FizzBuzzRust from "../../../chunks/benchmarking-rust/fr/fizz-buzz-rust.mdx";
 import GameBenchesTree from "../../../chunks/benchmarking-rust/criterion/game-benches-tree.mdx";
 import GameCargoToml from "../../../chunks/benchmarking-rust/gungraun/game-cargo-toml.mdx";
+import InstallGungraunRunner from "../../../chunks/benchmarking-rust/gungraun/fr/install-gungraun-runner.mdx";
 import MicroVsMacro from "../../../chunks/benchmarking/fr/micro-vs-macro.mdx";
 import OnFire from "../../../chunks/benchmarking/fr/on-fire.mdx";
 import PlayGameRustCode from "../../../chunks/benchmarking-rust/criterion/play-game-rust-code.mdx";
@@ -66,6 +67,8 @@ Cependant, le support macOS est limité aux processeurs x86_64 car [les processe
 Sur Debian exécutez : `sudo apt-get install valgrind`
 
 Sur macOS (puce x86_64/Intel uniquement) : `brew install valgrind`
+
+<InstallGungraunRunner />
 
 <FizzBuzzRefactor />
 

--- a/services/console/src/content/benchmarking-rust/ja/gungraun.mdx
+++ b/services/console/src/content/benchmarking-rust/ja/gungraun.mdx
@@ -3,7 +3,7 @@ title: "Gungraun"
 description: "GungraunでRustコードをベンチマークする方法のステップバイステップガイド"
 heading: "GungraunでRustコードをベンチマークする方法"
 published: "2026-05-17T00:00:00Z"
-modified: "2026-05-17T00:00:00Z"
+modified: "2026-06-03T00:00:00Z"
 sortOrder: 4
 ---
 
@@ -30,6 +30,7 @@ import FizzBuzzRules from "../../../chunks/benchmarking/ja/fizz-buzz-rules.mdx";
 import FizzBuzzRust from "../../../chunks/benchmarking-rust/ja/fizz-buzz-rust.mdx";
 import GameBenchesTree from "../../../chunks/benchmarking-rust/criterion/game-benches-tree.mdx";
 import GameCargoToml from "../../../chunks/benchmarking-rust/gungraun/game-cargo-toml.mdx";
+import InstallGungraunRunner from "../../../chunks/benchmarking-rust/gungraun/ja/install-gungraun-runner.mdx";
 import MicroVsMacro from "../../../chunks/benchmarking/ja/micro-vs-macro.mdx";
 import OnFire from "../../../chunks/benchmarking/ja/on-fire.mdx";
 import PlayGameRustCode from "../../../chunks/benchmarking-rust/criterion/play-game-rust-code.mdx";
@@ -66,6 +67,8 @@ ValgrindはLinux、Solaris、FreeBSD、macOSをサポートしています。
 Debianでは実行：`sudo apt-get install valgrind`
 
 macOS（x86_64/Intelチップのみ）では：`brew install valgrind`
+
+<InstallGungraunRunner />
 
 <FizzBuzzRefactor />
 

--- a/services/console/src/content/benchmarking-rust/ko/gungraun.mdx
+++ b/services/console/src/content/benchmarking-rust/ko/gungraun.mdx
@@ -3,7 +3,7 @@ title: "Gungraun"
 description: "Gungraun으로 Rust 코드를 벤치마크하는 방법에 대한 단계별 가이드"
 heading: "Gungraun으로 Rust 코드를 벤치마크하는 방법"
 published: "2026-05-17T00:00:00Z"
-modified: "2026-05-17T00:00:00Z"
+modified: "2026-06-03T00:00:00Z"
 sortOrder: 4
 ---
 
@@ -30,6 +30,7 @@ import FizzBuzzRules from "../../../chunks/benchmarking/ko/fizz-buzz-rules.mdx";
 import FizzBuzzRust from "../../../chunks/benchmarking-rust/ko/fizz-buzz-rust.mdx";
 import GameBenchesTree from "../../../chunks/benchmarking-rust/criterion/game-benches-tree.mdx";
 import GameCargoToml from "../../../chunks/benchmarking-rust/gungraun/game-cargo-toml.mdx";
+import InstallGungraunRunner from "../../../chunks/benchmarking-rust/gungraun/ko/install-gungraun-runner.mdx";
 import MicroVsMacro from "../../../chunks/benchmarking/ko/micro-vs-macro.mdx";
 import OnFire from "../../../chunks/benchmarking/ko/on-fire.mdx";
 import PlayGameRustCode from "../../../chunks/benchmarking-rust/criterion/play-game-rust-code.mdx";
@@ -66,6 +67,8 @@ Valgrind는 Linux, Solaris, FreeBSD 및 macOS를 지원합니다.
 Debian에서 실행: `sudo apt-get install valgrind`
 
 macOS에서 (x86_64/Intel 칩만): `brew install valgrind`
+
+<InstallGungraunRunner />
 
 <FizzBuzzRefactor />
 

--- a/services/console/src/content/benchmarking-rust/pt/gungraun.mdx
+++ b/services/console/src/content/benchmarking-rust/pt/gungraun.mdx
@@ -3,7 +3,7 @@ title: "Gungraun"
 description: "Um guia passo a passo sobre como fazer benchmark de código Rust com Gungraun"
 heading: "Como fazer benchmark de código Rust com Gungraun"
 published: "2026-05-17T00:00:00Z"
-modified: "2026-05-17T00:00:00Z"
+modified: "2026-06-03T00:00:00Z"
 sortOrder: 4
 ---
 
@@ -30,6 +30,7 @@ import FizzBuzzRules from "../../../chunks/benchmarking/pt/fizz-buzz-rules.mdx";
 import FizzBuzzRust from "../../../chunks/benchmarking-rust/pt/fizz-buzz-rust.mdx";
 import GameBenchesTree from "../../../chunks/benchmarking-rust/criterion/game-benches-tree.mdx";
 import GameCargoToml from "../../../chunks/benchmarking-rust/gungraun/game-cargo-toml.mdx";
+import InstallGungraunRunner from "../../../chunks/benchmarking-rust/gungraun/pt/install-gungraun-runner.mdx";
 import MicroVsMacro from "../../../chunks/benchmarking/pt/micro-vs-macro.mdx";
 import OnFire from "../../../chunks/benchmarking/pt/on-fire.mdx";
 import PlayGameRustCode from "../../../chunks/benchmarking-rust/criterion/play-game-rust-code.mdx";
@@ -66,6 +67,8 @@ No entanto, o suporte ao macOS é limitado a processadores x86_64, pois [process
 No Debian execute: `sudo apt-get install valgrind`
 
 No macOS (apenas chip x86_64/Intel): `brew install valgrind`
+
+<InstallGungraunRunner />
 
 <FizzBuzzRefactor />
 

--- a/services/console/src/content/benchmarking-rust/ru/gungraun.mdx
+++ b/services/console/src/content/benchmarking-rust/ru/gungraun.mdx
@@ -3,7 +3,7 @@ title: "Gungraun"
 description: "Пошаговое руководство по бенчмаркингу кода Rust с помощью Gungraun"
 heading: "Как выполнять бенчмаркинг кода Rust с помощью Gungraun"
 published: "2026-05-17T00:00:00Z"
-modified: "2026-05-17T00:00:00Z"
+modified: "2026-06-03T00:00:00Z"
 sortOrder: 4
 ---
 
@@ -30,6 +30,7 @@ import FizzBuzzRules from "../../../chunks/benchmarking/ru/fizz-buzz-rules.mdx";
 import FizzBuzzRust from "../../../chunks/benchmarking-rust/ru/fizz-buzz-rust.mdx";
 import GameBenchesTree from "../../../chunks/benchmarking-rust/criterion/game-benches-tree.mdx";
 import GameCargoToml from "../../../chunks/benchmarking-rust/gungraun/game-cargo-toml.mdx";
+import InstallGungraunRunner from "../../../chunks/benchmarking-rust/gungraun/ru/install-gungraun-runner.mdx";
 import MicroVsMacro from "../../../chunks/benchmarking/ru/micro-vs-macro.mdx";
 import OnFire from "../../../chunks/benchmarking/ru/on-fire.mdx";
 import PlayGameRustCode from "../../../chunks/benchmarking-rust/criterion/play-game-rust-code.mdx";
@@ -66,6 +67,8 @@ Valgrind поддерживает Linux, Solaris, FreeBSD и macOS.
 На Debian выполните: `sudo apt-get install valgrind`
 
 На macOS (только чип x86_64/Intel): `brew install valgrind`
+
+<InstallGungraunRunner />
 
 <FizzBuzzRefactor />
 

--- a/services/console/src/content/benchmarking-rust/zh/gungraun.mdx
+++ b/services/console/src/content/benchmarking-rust/zh/gungraun.mdx
@@ -3,7 +3,7 @@ title: "Gungraun"
 description: "如何使用 Gungraun 对 Rust 代码进行基准测试的分步指南"
 heading: "如何使用 Gungraun 对 Rust 代码进行基准测试"
 published: "2026-05-17T00:00:00Z"
-modified: "2026-05-17T00:00:00Z"
+modified: "2026-06-03T00:00:00Z"
 sortOrder: 4
 ---
 
@@ -30,6 +30,7 @@ import FizzBuzzRules from "../../../chunks/benchmarking/zh/fizz-buzz-rules.mdx";
 import FizzBuzzRust from "../../../chunks/benchmarking-rust/zh/fizz-buzz-rust.mdx";
 import GameBenchesTree from "../../../chunks/benchmarking-rust/criterion/game-benches-tree.mdx";
 import GameCargoToml from "../../../chunks/benchmarking-rust/gungraun/game-cargo-toml.mdx";
+import InstallGungraunRunner from "../../../chunks/benchmarking-rust/gungraun/zh/install-gungraun-runner.mdx";
 import MicroVsMacro from "../../../chunks/benchmarking/zh/micro-vs-macro.mdx";
 import OnFire from "../../../chunks/benchmarking/zh/on-fire.mdx";
 import PlayGameRustCode from "../../../chunks/benchmarking-rust/criterion/play-game-rust-code.mdx";
@@ -66,6 +67,8 @@ Valgrind 支持 Linux、Solaris、FreeBSD 和 macOS。
 在 Debian 上运行：`sudo apt-get install valgrind`
 
 在 macOS 上（仅 x86_64/Intel 芯片）：`brew install valgrind`
+
+<InstallGungraunRunner />
 
 <FizzBuzzRefactor />
 


### PR DESCRIPTION
## Summary
- Adds a missing "Install Gungraun Runner" section to the Gungraun benchmarking guide across all 9 languages
- The `gungraun-runner` binary is a required prerequisite that was not mentioned in the guide
- Created as reusable i18n chunk files under `chunks/benchmarking-rust/gungraun/{lang}/`

Reported by a user on [r/rustfr](https://www.reddit.com/r/rustfr/comments/1til75i/comment/oo4g2af/) who discovered the missing step while following the tutorial.

First added here https://github.com/bencherdev/bencher/pull/783 and translated here https://github.com/bencherdev/bencher/pull/852

## Test plan
- [x] Verified EN page renders correctly at `/learn/benchmarking/rust/gungraun/`
- [x] Verified FR page renders correctly at `/fr/learn/benchmarking/rust/gungraun/`
- [x] Spot-check remaining languages