### PR TITLE
Fix OCI token endpoint for Docker 29 containerd image store

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,8 +80,12 @@ jobs:
           if-no-files-found: error
 
   api_smoke_test:
-    name: API Smoke Test
+    name: API Smoke Test (${{ matrix.image-store }})
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        image-store: [overlay2, containerd]
     steps:
       - uses: BRAINSia/free-disk-space@7048ffbf50819342ac964ef3998a51c2564a8a75 # v2.1.3
         with:
@@ -111,10 +115,16 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-      - name: Configure Docker for insecure local registry
+      - name: Configure Docker for insecure local registry (overlay2)
         # Port must match bencher_json::BENCHER_API_PORT
+        if: matrix.image-store == 'overlay2'
         run: |
           echo '{"insecure-registries": ["localhost:61016"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+      - name: Configure Docker for insecure local registry (containerd)
+        if: matrix.image-store == 'containerd'
+        run: |
+          echo '{"insecure-registries": ["localhost:61016"], "features": {"containerd-snapshotter": true}}' | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
       - name: Run Smoke Test
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "slog",
  "tokio",
 ]
@@ -1122,6 +1123,7 @@ dependencies = [
  "http 1.4.1",
  "libsqlite3-sys",
  "reqwest",
+ "rustls",
  "serde_json",
  "sha2 0.11.0",
  "slog",

--- a/lib/api_auth/Cargo.toml
+++ b/lib/api_auth/Cargo.toml
@@ -15,6 +15,7 @@ plus = [
     "dep:chrono",
     "dep:http",
     "dep:serde_json",
+    "dep:serde_urlencoded",
     "bencher_endpoint/plus",
     "bencher_json/plus",
     "bencher_otel?/plus",
@@ -38,6 +39,7 @@ http = { workspace = true, optional = true }
 schemars.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, optional = true }
+serde_urlencoded = { workspace = true, optional = true }
 slog.workspace = true
 
 [dev-dependencies]

--- a/lib/api_auth/src/lib.rs
+++ b/lib/api_auth/src/lib.rs
@@ -74,6 +74,7 @@ impl bencher_endpoint::Registrar for Api {
                 api_description.register(oci::auth_oci_token_options)?;
             }
             api_description.register(oci::auth_oci_token_get)?;
+            api_description.register(oci::auth_oci_token_post)?;
         }
 
         Ok(())

--- a/lib/api_auth/src/oci/mod.rs
+++ b/lib/api_auth/src/oci/mod.rs
@@ -3,6 +3,7 @@
 //! OCI Token Endpoint
 //!
 //! - GET /v0/auth/oci/token - Exchange credentials for an OCI bearer token
+//! - POST /v0/auth/oci/token - `OAuth2` token exchange (Docker 29+ / containerd)
 //!
 //! This endpoint implements the Docker Registry Auth specification.
 //! Clients authenticate using Basic auth with their Bencher API token
@@ -14,7 +15,7 @@
 //! - "push" action requires Create permission on the project (for claimed orgs)
 
 use base64::{Engine as _, engine::general_purpose::STANDARD};
-use bencher_endpoint::{CorsResponse, Endpoint, Get};
+use bencher_endpoint::{CorsResponse, Endpoint, Get, Post};
 use bencher_json::oci::{OCI_ERROR_DENIED, OCI_ERROR_UNAUTHORIZED, oci_error_body};
 use bencher_json::{Email, Jwt, PROJECT_KEY_PREFIX, ProjectKey, ProjectKeyHash, ProjectResourceId};
 use bencher_rbac::project::Permission;
@@ -29,7 +30,9 @@ use bencher_schema::{
 };
 use bencher_token::OciAction;
 use chrono::Utc;
-use dropshot::{Body, ClientErrorStatusCode, HttpError, Query, RequestContext, endpoint};
+use dropshot::{
+    Body, ClientErrorStatusCode, HttpError, Query, RequestContext, UntypedBody, endpoint,
+};
 use http::Response;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -38,17 +41,18 @@ use serde::{Deserialize, Serialize};
 pub const OCI_TOKEN_TTL: u32 = 300;
 
 /// Query parameters for token endpoint
+///
+/// The `scope` parameter is parsed from the raw query string rather than
+/// through Dropshot's `Query<T>`, because Docker 29+ (containerd image store)
+/// sends multiple `scope` query params which `serde_urlencoded` rejects as
+/// duplicate fields on a scalar type.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct TokenQuery {
     /// Service identifier (e.g., "registry.bencher.dev")
-    /// Not currently used but accepted for OCI spec compliance
     pub service: Option<String>,
-    /// Scope in format "repository:name:action,action"
-    /// e.g., "repository:org/project:pull,push"
-    pub scope: Option<String>,
 }
 
-/// Token response following Docker Registry Auth spec
+/// Token response following Docker Registry Auth spec (GET)
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct TokenResponse {
     /// The short-lived OCI JWT
@@ -57,6 +61,34 @@ pub struct TokenResponse {
     pub expires_in: u32,
     /// When the token was issued (RFC3339)
     pub issued_at: String,
+}
+
+/// `OAuth2` token form body for POST requests (containerd / Docker 29+)
+#[derive(Debug, Deserialize)]
+struct OAuthTokenForm {
+    grant_type: String,
+    #[expect(dead_code, reason = "accepted for spec compliance")]
+    service: Option<String>,
+    scope: Option<String>,
+    #[expect(dead_code, reason = "accepted for spec compliance")]
+    client_id: Option<String>,
+    username: Option<String>,
+    password: Option<String>,
+    #[expect(dead_code, reason = "accepted for spec compliance")]
+    refresh_token: Option<String>,
+    #[expect(dead_code, reason = "accepted for spec compliance")]
+    access_type: Option<String>,
+}
+
+/// `OAuth2` token response for POST requests
+///
+/// Per the `OAuth2` token spec, the response field is `access_token` (not `token`).
+#[derive(Debug, Serialize)]
+struct OAuthTokenResponse {
+    access_token: String,
+    expires_in: u32,
+    scope: Option<String>,
+    issued_at: String,
 }
 
 /// CORS preflight for token endpoint
@@ -68,10 +100,10 @@ pub struct TokenResponse {
 pub async fn auth_oci_token_options(
     _rqctx: RequestContext<ApiContext>,
 ) -> Result<CorsResponse, HttpError> {
-    Ok(Endpoint::cors(&[Get.into()]))
+    Ok(Endpoint::cors(&[Get.into(), Post.into()]))
 }
 
-/// OCI token endpoint
+/// OCI token endpoint (GET)
 ///
 /// Authenticates via Basic auth and returns a short-lived JWT for OCI operations.
 /// Supports two credential types:
@@ -79,6 +111,8 @@ pub async fn auth_oci_token_options(
 /// - `project-slug-or-uuid:bencher_run_xxxxx`: project key authentication
 ///
 /// If no Basic auth credentials are provided, issues a public (anonymous) OCI token.
+///
+/// Accepts multiple `scope` query parameters (Docker 29+ / containerd sends these).
 #[endpoint {
     method = GET,
     path = "/v0/auth/oci/token",
@@ -86,62 +120,23 @@ pub async fn auth_oci_token_options(
 }]
 pub async fn auth_oci_token_get(
     rqctx: RequestContext<ApiContext>,
-    query: Query<TokenQuery>,
+    _query: Query<TokenQuery>,
 ) -> Result<Response<Body>, HttpError> {
     let context = rqctx.context();
-    let query = query.into_inner();
 
-    // Parse scope to extract repository and actions
-    let (repository, actions) = if let Some(scope) = &query.scope {
-        parse_scope(scope)?
-    } else {
+    // Docker 29+ (containerd) sends multiple `scope` query params that Dropshot
+    // can't deserialize into a scalar. Parse all scopes from the raw query string.
+    let scopes = extract_scopes_from_query(rqctx.request.uri());
+    let (repository, actions) = if scopes.is_empty() {
         (None, vec![])
+    } else {
+        parse_scopes(&scopes)?
     };
 
-    let jwt = match extract_basic_credentials(&rqctx)? {
-        Some((username, password)) if password.starts_with(PROJECT_KEY_PREFIX) => {
-            if let (Ok(project), Ok(project_key)) = (
-                username.parse::<ProjectResourceId>(),
-                password.parse::<ProjectKey>(),
-            ) {
-                project_key_oci_token(
-                    &rqctx,
-                    context,
-                    &query,
-                    &project,
-                    &project_key,
-                    repository,
-                    actions,
-                )
-                .await?
-            } else {
-                return Err(unauthorized_with_www_authenticate(
-                    &rqctx,
-                    query.scope.as_deref(),
-                ));
-            }
-        },
-        Some((username, password)) => {
-            if let (Ok(email), Ok(api_token)) = (username.parse::<Email>(), password.parse::<Jwt>())
-            {
-                auth_oci_token(
-                    &rqctx, context, &query, &email, &api_token, repository, actions,
-                )
-                .await?
-            } else {
-                return Err(unauthorized_with_www_authenticate(
-                    &rqctx,
-                    query.scope.as_deref(),
-                ));
-            }
-        },
-        None => context
-            .token_key
-            .new_oci_public(OCI_TOKEN_TTL, repository, actions)
-            .map_err(|e| {
-                HttpError::for_internal_error(format!("Failed to create public OCI token: {e}"))
-            })?,
-    };
+    let scope_str = scopes.first().map(String::as_str);
+    let credentials = extract_basic_credentials(&rqctx)?;
+    let jwt =
+        dispatch_oci_token(&rqctx, context, scope_str, repository, actions, credentials).await?;
 
     let response = TokenResponse {
         token: jwt.to_string(),
@@ -160,18 +155,180 @@ pub async fn auth_oci_token_get(
         .map_err(|e| HttpError::for_internal_error(format!("Failed to build response: {e}")))
 }
 
+/// Build an `OAuth2` token-endpoint error body per RFC 6749 §5.2.
+///
+/// The token endpoint speaks `OAuth2`, so its errors use `{"error", "error_description"}`
+/// rather than the OCI registry's `oci_error_body` envelope.
+fn oauth_error_body(error: &str, description: &str) -> String {
+    serde_json::json!({
+        "error": error,
+        "error_description": description,
+    })
+    .to_string()
+}
+
+/// OCI token endpoint (POST) — `OAuth2` token exchange
+///
+/// Accepts `application/x-www-form-urlencoded` body with `grant_type=password`.
+/// Docker 29+ (containerd image store) uses this flow before falling back to GET.
+#[endpoint {
+    method = POST,
+    path = "/v0/auth/oci/token",
+    tags = ["auth", "oci"],
+}]
+pub async fn auth_oci_token_post(
+    rqctx: RequestContext<ApiContext>,
+    body: UntypedBody,
+) -> Result<Response<Body>, HttpError> {
+    let context = rqctx.context();
+
+    let form: OAuthTokenForm = serde_urlencoded::from_bytes(body.as_bytes()).map_err(|e| {
+        HttpError::for_client_error(
+            None,
+            ClientErrorStatusCode::BAD_REQUEST,
+            oauth_error_body("invalid_request", &format!("Invalid form body: {e}")),
+        )
+    })?;
+
+    if form.grant_type == "refresh_token" {
+        return Err(HttpError::for_client_error(
+            None,
+            ClientErrorStatusCode::BAD_REQUEST,
+            oauth_error_body(
+                "unsupported_grant_type",
+                "Bencher does not issue refresh tokens",
+            ),
+        ));
+    }
+
+    if form.grant_type != "password" {
+        return Err(HttpError::for_client_error(
+            None,
+            ClientErrorStatusCode::BAD_REQUEST,
+            oauth_error_body(
+                "unsupported_grant_type",
+                &format!("expected \"password\", got \"{}\"", form.grant_type),
+            ),
+        ));
+    }
+
+    let credentials = match (form.username, form.password) {
+        (Some(username), Some(password)) if !username.is_empty() => Some((username, password)),
+        _ => extract_basic_credentials(&rqctx)?,
+    };
+
+    let Some(credentials) = credentials else {
+        return Err(HttpError::for_client_error(
+            None,
+            ClientErrorStatusCode::BAD_REQUEST,
+            oauth_error_body(
+                "invalid_request",
+                "grant_type=password requires username and password",
+            ),
+        ));
+    };
+
+    // Containerd joins multiple scopes with spaces in the POST body:
+    // form.Set("scope", strings.Join(scopes, " "))
+    let (repository, actions) = if let Some(scope) = &form.scope {
+        let scopes: Vec<String> = scope
+            .split(' ')
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .collect();
+        parse_scopes(&scopes)?
+    } else {
+        (None, vec![])
+    };
+
+    let scope_str = form.scope.as_ref().and_then(|s| s.split(' ').next());
+    let jwt = dispatch_oci_token(
+        &rqctx,
+        context,
+        scope_str,
+        repository,
+        actions,
+        Some(credentials),
+    )
+    .await?;
+
+    let response = OAuthTokenResponse {
+        access_token: jwt.to_string(),
+        expires_in: OCI_TOKEN_TTL,
+        scope: form.scope,
+        issued_at: Utc::now().to_rfc3339(),
+    };
+
+    let body = serde_json::to_vec(&response)
+        .map_err(|e| HttpError::for_internal_error(format!("Failed to serialize response: {e}")))?;
+
+    Response::builder()
+        .status(http::StatusCode::OK)
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .header(http::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+        .body(Body::from(body))
+        .map_err(|e| HttpError::for_internal_error(format!("Failed to build response: {e}")))
+}
+
+/// Dispatch to the appropriate token issuer based on credential type.
+async fn dispatch_oci_token(
+    rqctx: &RequestContext<ApiContext>,
+    context: &ApiContext,
+    scope: Option<&str>,
+    repository: Option<String>,
+    actions: Vec<OciAction>,
+    credentials: Option<(String, String)>,
+) -> Result<Jwt, HttpError> {
+    match credentials {
+        Some((username, password)) if password.starts_with(PROJECT_KEY_PREFIX) => {
+            if let (Ok(project), Ok(project_key)) = (
+                username.parse::<ProjectResourceId>(),
+                password.parse::<ProjectKey>(),
+            ) {
+                project_key_oci_token(
+                    rqctx,
+                    context,
+                    scope,
+                    &project,
+                    &project_key,
+                    repository,
+                    actions,
+                )
+                .await
+            } else {
+                Err(unauthorized_with_www_authenticate(rqctx, scope))
+            }
+        },
+        Some((username, password)) => {
+            if let (Ok(email), Ok(api_token)) = (username.parse::<Email>(), password.parse::<Jwt>())
+            {
+                auth_oci_token(
+                    rqctx, context, scope, &email, &api_token, repository, actions,
+                )
+                .await
+            } else {
+                Err(unauthorized_with_www_authenticate(rqctx, scope))
+            }
+        },
+        None => context
+            .token_key
+            .new_oci_public(OCI_TOKEN_TTL, repository, actions)
+            .map_err(|e| {
+                HttpError::for_internal_error(format!("Failed to create public OCI token: {e}"))
+            }),
+    }
+}
+
 /// Issue an authenticated OCI token after validating credentials and RBAC.
 async fn auth_oci_token(
     rqctx: &RequestContext<ApiContext>,
     context: &ApiContext,
-    query: &TokenQuery,
+    scope: Option<&str>,
     email: &Email,
     api_token: &Jwt,
     repository: Option<String>,
     actions: Vec<OciAction>,
 ) -> Result<Jwt, HttpError> {
-    let scope = query.scope.as_deref();
-
     // Validate the API token
     let claims = context
         .token_key
@@ -313,14 +470,12 @@ pub fn log_unauthorized_with_www_authenticate(
 async fn project_key_oci_token(
     rqctx: &RequestContext<ApiContext>,
     context: &ApiContext,
-    query: &TokenQuery,
+    scope: Option<&str>,
     project_rid: &ProjectResourceId,
     project_key: &ProjectKey,
     repository: Option<String>,
     actions: Vec<OciAction>,
 ) -> Result<Jwt, HttpError> {
-    let scope = query.scope.as_deref();
-
     // Pull-only requests are not allowed for project key auth.
     // Only bare metal runners should be pulling, and they use runner tokens.
     if actions.contains(&OciAction::Pull) && !actions.contains(&OciAction::Push) {
@@ -421,7 +576,43 @@ fn extract_basic_credentials(
     Ok(Some((username.to_owned(), password.to_owned())))
 }
 
-/// Parse OCI scope string into repository and actions
+/// Parse multiple OCI scope strings into a single repository + its actions.
+///
+/// Docker 29+ (containerd) sends multiple `scope` query params, e.g.:
+/// `scope=repository:proj:pull&scope=repository:proj:pull,push`
+///
+/// The issued token is single-repository, so we select one target repository
+/// and union the actions requested for it:
+/// - The target is the first scope that names a repository — the registry's
+///   challenge scope, i.e. the resource the client is actually accessing.
+/// - Actions are unioned **only** from scopes whose repository matches the
+///   target. Cached scopes that containerd may append for *other* repositories
+///   (or any repository-less scope) are dropped, so they can never widen the
+///   token's actions or retarget it.
+fn parse_scopes(scopes: &[String]) -> Result<(Option<String>, Vec<OciAction>), HttpError> {
+    // Parse every scope first so a malformed scope still errors, as before.
+    let parsed: Vec<(Option<String>, Vec<OciAction>)> = scopes
+        .iter()
+        .map(|s| parse_scope(s))
+        .collect::<Result<_, _>>()?;
+
+    let target = parsed.iter().find_map(|(repo, _)| repo.clone());
+
+    let mut actions = Vec::new();
+    for (repo, scope_actions) in parsed {
+        if repo.as_deref() == target.as_deref() {
+            for action in scope_actions {
+                if !actions.contains(&action) {
+                    actions.push(action);
+                }
+            }
+        }
+    }
+
+    Ok((target, actions))
+}
+
+/// Parse a single OCI scope string into repository and actions.
 ///
 /// Format: "repository:name:actions" where actions is comma-separated
 /// Example: "repository:org/project:pull,push"
@@ -462,6 +653,24 @@ fn parse_scope(scope: &str) -> Result<(Option<String>, Vec<OciAction>), HttpErro
     Ok((Some((*repository_name).to_owned()), actions))
 }
 
+/// Extract all `scope` query parameter values from a URI.
+///
+/// Docker 29+ (containerd) sends multiple `scope` query params, e.g.:
+/// `?scope=repository:proj:pull&scope=repository:proj:pull,push`
+///
+/// Dropshot's `Query<T>` requires scalar types, so we parse the raw query string.
+fn extract_scopes_from_query(uri: &http::Uri) -> Vec<String> {
+    let Some(query) = uri.query() else {
+        return Vec::new();
+    };
+    serde_urlencoded::from_str::<Vec<(String, String)>>(query)
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|(key, _)| key == "scope")
+        .map(|(_, value)| value)
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -497,11 +706,71 @@ mod tests {
 
     #[test]
     fn parse_scope_sanitizes_quotes() {
-        // Quotes in repository name are stripped by scope sanitization
-        // before reaching parse_scope, but parse_scope itself should
-        // handle the already-sanitized input correctly
         let (repo, actions) = parse_scope("repository:org/project:pull").unwrap();
         assert_eq!(repo, Some("org/project".to_owned()));
         assert_eq!(actions, vec![OciAction::Pull]);
+    }
+
+    #[test]
+    fn parse_scopes_merges_actions() {
+        let scopes = vec![
+            "repository:the-computer:pull".to_owned(),
+            "repository:the-computer:pull,push".to_owned(),
+        ];
+        let (repo, actions) = parse_scopes(&scopes).unwrap();
+        assert_eq!(repo, Some("the-computer".to_owned()));
+        assert_eq!(actions, vec![OciAction::Pull, OciAction::Push]);
+    }
+
+    #[test]
+    fn parse_scopes_single() {
+        let scopes = vec!["repository:myrepo:push".to_owned()];
+        let (repo, actions) = parse_scopes(&scopes).unwrap();
+        assert_eq!(repo, Some("myrepo".to_owned()));
+        assert_eq!(actions, vec![OciAction::Push]);
+    }
+
+    #[test]
+    fn parse_scopes_empty() {
+        let scopes: Vec<String> = vec![];
+        let (repo, actions) = parse_scopes(&scopes).unwrap();
+        assert_eq!(repo, None);
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn parse_scopes_ignores_other_repos() {
+        let scopes = vec![
+            "repository:repo-a:pull".to_owned(),
+            "repository:repo-b:push".to_owned(),
+        ];
+        let (repo, actions) = parse_scopes(&scopes).unwrap();
+        assert_eq!(repo, Some("repo-a".to_owned()));
+        assert_eq!(actions, vec![OciAction::Pull]);
+    }
+
+    // A foreign repository's actions must never leak into the target token,
+    // even when they overlap/exceed the target's own actions.
+    #[test]
+    fn parse_scopes_excludes_other_repo_actions() {
+        let scopes = vec![
+            "repository:repo-a:pull".to_owned(),
+            "repository:repo-b:pull,push".to_owned(),
+        ];
+        let (repo, actions) = parse_scopes(&scopes).unwrap();
+        assert_eq!(repo, Some("repo-a".to_owned()));
+        assert_eq!(actions, vec![OciAction::Pull]);
+    }
+
+    // Multiple scopes for the same (target) repository still union, in order.
+    #[test]
+    fn parse_scopes_unions_same_repo_in_order() {
+        let scopes = vec![
+            "repository:r:push".to_owned(),
+            "repository:r:pull".to_owned(),
+        ];
+        let (repo, actions) = parse_scopes(&scopes).unwrap();
+        assert_eq!(repo, Some("r".to_owned()));
+        assert_eq!(actions, vec![OciAction::Push, OciAction::Pull]);
     }
 }

--- a/lib/bencher_api_tests/Cargo.toml
+++ b/lib/bencher_api_tests/Cargo.toml
@@ -39,6 +39,7 @@ hex = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
 libsqlite3-sys.workspace = true
 reqwest = { workspace = true, features = ["json", "rustls-no-provider"] }
+rustls.workspace = true
 serde_json = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
 slog.workspace = true

--- a/lib/bencher_api_tests/src/context.rs
+++ b/lib/bencher_api_tests/src/context.rs
@@ -1,5 +1,7 @@
 use std::{path::PathBuf, sync::Arc};
 
+use rustls::crypto::aws_lc_rs;
+
 use bencher_config::DEFAULT_MAX_BODY_SIZE;
 use bencher_endpoint::Registrar as _;
 use bencher_rbac::init_rbac;
@@ -255,6 +257,8 @@ impl TestServer {
             .start();
 
         let url = format!("http://{}", server.local_addr());
+
+        let _provider = aws_lc_rs::default_provider().install_default();
 
         let client = reqwest::Client::builder()
             .build()

--- a/lib/bencher_api_tests/src/lib.rs
+++ b/lib/bencher_api_tests/src/lib.rs
@@ -43,4 +43,6 @@ pub mod oci;
 mod seed;
 
 pub use context::TestServer;
+#[cfg(feature = "plus")]
+pub use seed::TestProjectKey;
 pub use seed::{TestOrg, TestProject, TestUser};

--- a/lib/bencher_api_tests/src/seed.rs
+++ b/lib/bencher_api_tests/src/seed.rs
@@ -3,6 +3,8 @@ use bencher_json::{
     JsonSignup, OrganizationSlug, OrganizationUuid, ProjectSlug, ProjectUuid, ResourceName,
     UserName, UserSlug, UserUuid, system::auth::JsonAuthUser,
 };
+#[cfg(feature = "plus")]
+use bencher_json::{JsonProjectKeyCreated, ProjectKey};
 
 use crate::TestServer;
 
@@ -27,6 +29,11 @@ pub struct TestProject {
     pub uuid: ProjectUuid,
     pub name: ResourceName,
     pub slug: ProjectSlug,
+}
+
+#[cfg(feature = "plus")]
+pub struct TestProjectKey {
+    pub key: ProjectKey,
 }
 
 impl TestServer {
@@ -187,6 +194,42 @@ impl TestServer {
             uuid: project.uuid,
             name: project.name,
             slug: project.slug,
+        }
+    }
+
+    #[cfg(feature = "plus")]
+    #[expect(clippy::expect_used, reason = "test helper for project key creation")]
+    pub async fn create_project_key(
+        &self,
+        user: &TestUser,
+        project: &TestProject,
+        name: &str,
+    ) -> TestProjectKey {
+        let project_slug: &str = project.slug.as_ref();
+
+        let resp = self
+            .client
+            .post(self.api_url(&format!("/v0/projects/{project_slug}/keys")))
+            .header(
+                bencher_json::AUTHORIZATION,
+                bencher_json::bearer_header(&user.token),
+            )
+            .json(&serde_json::json!({"name": name}))
+            .send()
+            .await
+            .expect("Failed to create project key");
+
+        assert!(
+            resp.status().is_success(),
+            "Create project key failed: {}",
+            resp.text().await.unwrap_or_default()
+        );
+
+        let key_created: JsonProjectKeyCreated =
+            resp.json().await.expect("Failed to parse project key");
+
+        TestProjectKey {
+            key: key_created.key,
         }
     }
 

--- a/plus/api_oci/src/auth.rs
+++ b/plus/api_oci/src/auth.rs
@@ -328,13 +328,17 @@ pub async fn validate_push_access(
     // Apply rate limiting based on authentication status
     apply_push_rate_limit(log, context, &public_user)?;
 
-    // Try to find existing project, or create if using a slug
-    let conn = public_conn!(context);
-    let push_access = match QueryProject::from_resource_id(conn, repository) {
-        Ok(project) => {
+    // Try to find existing project, or create if using a slug.
+    // Bind the lookup result so the pool connection is dropped before the async match arms.
+    // Temporaries in a match scrutinee live until the end of the match expression,
+    // which includes the `.await` — holding the connection across that would deadlock
+    // under containerd's ~19 concurrent layer pushes.
+    let existing_project = QueryProject::from_resource_id(public_conn!(context), repository).ok();
+    let push_access = match existing_project {
+        Some(project) => {
             handle_existing_project(log, rqctx, context, project, &public_user, claims).await
         },
-        Err(_) => handle_nonexistent_project(log, context, repository, &public_user, claims).await,
+        None => handle_nonexistent_project(log, context, repository, &public_user, claims).await,
     }?;
     context
         .rate_limiting

--- a/plus/api_oci/src/manifests.rs
+++ b/plus/api_oci/src/manifests.rs
@@ -272,7 +272,11 @@ pub async fn oci_manifest_put(
         }
     }
 
-    // Verify referenced blobs exist (for image manifests and Docker manifests)
+    slog::debug!(
+        &rqctx.log,
+        "Verifying manifest references";
+        "manifest_type" => parsed_manifest.media_type()
+    );
     verify_referenced_blobs(storage, &project_uuid, &parsed_manifest).await?;
 
     // Extract subject digest from manifest if present (for OCI-Subject header)
@@ -342,30 +346,47 @@ async fn verify_referenced_blobs(
     repository: &ProjectUuid,
     manifest: &Manifest,
 ) -> Result<(), HttpError> {
-    let digests: Vec<&str> = match manifest {
+    enum RefKind<'a> {
+        Blob(&'a str),
+        Manifest(&'a str),
+    }
+
+    let refs: Vec<RefKind<'_>> = match manifest {
         Manifest::OciImageManifest(m) => {
-            let mut d = vec![m.config.digest.as_str()];
-            d.extend(m.layers.iter().map(|l| l.digest.as_str()));
-            d
+            let mut r = vec![RefKind::Blob(m.config.digest.as_str())];
+            r.extend(m.layers.iter().map(|l| RefKind::Blob(l.digest.as_str())));
+            r
         },
         Manifest::DockerManifestV2(m) => {
-            let mut d = vec![m.config.digest.as_str()];
-            d.extend(m.layers.iter().map(|l| l.digest.as_str()));
-            d
+            let mut r = vec![RefKind::Blob(m.config.digest.as_str())];
+            r.extend(m.layers.iter().map(|l| RefKind::Blob(l.digest.as_str())));
+            r
         },
-        // Image indices/manifest lists reference manifests, not blobs
-        Manifest::OciImageIndex(_) | Manifest::DockerManifestList(_) => return Ok(()),
+        Manifest::OciImageIndex(index) => index
+            .manifests
+            .iter()
+            .map(|m| RefKind::Manifest(m.digest.as_str()))
+            .collect(),
+        Manifest::DockerManifestList(list) => list
+            .manifests
+            .iter()
+            .map(|m| RefKind::Manifest(m.digest.as_str()))
+            .collect(),
     };
 
-    // Parse all digests first, then check existence in parallel
-    let parsed_digests: Vec<(Digest, String)> = digests
+    let parsed_refs: Vec<(Digest, String, bool)> = refs
         .iter()
-        .map(|d| {
-            d.parse::<Digest>()
-                .map(|parsed| (parsed, (*d).to_owned()))
+        .map(|r| {
+            let (digest_str, is_manifest) = match r {
+                RefKind::Blob(d) => (*d, false),
+                RefKind::Manifest(d) => (*d, true),
+            };
+            digest_str
+                .parse::<Digest>()
+                .map(|parsed| (parsed, digest_str.to_owned(), is_manifest))
                 .map_err(|_e| {
                     crate::error::into_http_error(OciError::DigestInvalid {
-                        digest: (*d).to_owned(),
+                        digest: digest_str.to_owned(),
                     })
                 })
         })
@@ -375,19 +396,29 @@ async fn verify_referenced_blobs(
         .map_or(1, std::num::NonZeroUsize::get)
         .clamp(1, MAX_CONCURRENCY);
 
-    stream::iter(parsed_digests.into_iter().map(Ok))
-        .try_for_each_concurrent(concurrency, |(digest, digest_str)| async move {
-            let exists = storage
-                .blob_exists(repository, &digest)
-                .await
-                .map_err(storage_error)?;
-            if !exists {
-                return Err(crate::error::into_http_error(
-                    OciError::ManifestBlobUnknown { digest: digest_str },
-                ));
-            }
-            Ok(())
-        })
+    stream::iter(parsed_refs.into_iter().map(Ok))
+        .try_for_each_concurrent(
+            concurrency,
+            |(digest, digest_str, is_manifest)| async move {
+                let exists = if is_manifest {
+                    storage
+                        .manifest_exists(repository, &digest)
+                        .await
+                        .map_err(storage_error)?
+                } else {
+                    storage
+                        .blob_exists(repository, &digest)
+                        .await
+                        .map_err(storage_error)?
+                };
+                if !exists {
+                    return Err(crate::error::into_http_error(
+                        OciError::ManifestBlobUnknown { digest: digest_str },
+                    ));
+                }
+                Ok(())
+            },
+        )
         .await?;
 
     Ok(())

--- a/plus/api_oci/tests/manifests.rs
+++ b/plus/api_oci/tests/manifests.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "plus")]
 #![expect(
     unused_crate_dependencies,
+    clippy::missing_assert_message,
     clippy::tests_outside_test_module,
     clippy::uninlined_format_args,
     clippy::expect_used,
@@ -1382,30 +1383,24 @@ async fn manifest_get_docker_v2_by_tag() {
 // =============================================================================
 
 /// Create a Docker manifest list JSON for testing
-fn create_docker_manifest_list() -> String {
+fn create_docker_manifest_list(child_digests: &[&str]) -> String {
+    let manifests: Vec<_> = child_digests
+        .iter()
+        .enumerate()
+        .map(|(i, digest)| {
+            let arch = if i == 0 { "amd64" } else { "arm64" };
+            serde_json::json!({
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "digest": digest,
+                "size": 528,
+                "platform": { "architecture": arch, "os": "linux" }
+            })
+        })
+        .collect();
     serde_json::json!({
         "schemaVersion": 2,
         "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
-        "manifests": [
-            {
-                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-                "digest": "sha256:e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5",
-                "size": 528,
-                "platform": {
-                    "architecture": "amd64",
-                    "os": "linux"
-                }
-            },
-            {
-                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-                "digest": "sha256:f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6",
-                "size": 528,
-                "platform": {
-                    "architecture": "arm64",
-                    "os": "linux"
-                }
-            }
-        ]
+        "manifests": manifests
     })
     .to_string()
 }
@@ -1426,7 +1421,9 @@ async fn manifest_put_docker_manifest_list() {
     let pull_token = server.oci_pull_token(&user, &project);
     let project_slug: &str = project.slug.as_ref();
 
-    let manifest = create_docker_manifest_list();
+    let d1 = push_child_manifest(&server, project_slug, &push_token, "child-amd64").await;
+    let d2 = push_child_manifest(&server, project_slug, &push_token, "child-arm64").await;
+    let manifest = create_docker_manifest_list(&[&d1, &d2]);
 
     // PUT with Docker manifest list Content-Type
     let put_resp = server
@@ -1483,7 +1480,9 @@ async fn manifest_get_docker_manifest_list() {
     let pull_token = server.oci_pull_token(&user, &project);
     let project_slug: &str = project.slug.as_ref();
 
-    let manifest = create_docker_manifest_list();
+    let d1 = push_child_manifest(&server, project_slug, &push_token, "child-amd64-get").await;
+    let d2 = push_child_manifest(&server, project_slug, &push_token, "child-arm64-get").await;
+    let manifest = create_docker_manifest_list(&[&d1, &d2]);
 
     server
         .client
@@ -1544,42 +1543,68 @@ async fn manifest_get_docker_manifest_list() {
 // =============================================================================
 
 /// Create an OCI image index JSON for testing
-fn create_oci_image_index() -> String {
+fn create_oci_image_index(child_digests: &[&str]) -> String {
+    let manifests: Vec<_> = child_digests
+        .iter()
+        .enumerate()
+        .map(|(i, digest)| {
+            if i == 1 {
+                serde_json::json!({
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "digest": digest,
+                    "size": 1024,
+                    "platform": { "architecture": "arm64", "os": "linux", "variant": "v8" }
+                })
+            } else {
+                let arch = if i == 0 { "amd64" } else { "s390x" };
+                serde_json::json!({
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "digest": digest,
+                    "size": 1024,
+                    "platform": { "architecture": arch, "os": "linux" }
+                })
+            }
+        })
+        .collect();
     serde_json::json!({
         "schemaVersion": 2,
         "mediaType": "application/vnd.oci.image.index.v1+json",
-        "manifests": [
-            {
-                "mediaType": "application/vnd.oci.image.manifest.v1+json",
-                "digest": "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
-                "size": 1024,
-                "platform": {
-                    "architecture": "amd64",
-                    "os": "linux"
-                }
-            },
-            {
-                "mediaType": "application/vnd.oci.image.manifest.v1+json",
-                "digest": "sha256:b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
-                "size": 1024,
-                "platform": {
-                    "architecture": "arm64",
-                    "os": "linux",
-                    "variant": "v8"
-                }
-            },
-            {
-                "mediaType": "application/vnd.oci.image.manifest.v1+json",
-                "digest": "sha256:c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
-                "size": 1024,
-                "platform": {
-                    "architecture": "s390x",
-                    "os": "linux"
-                }
-            }
-        ]
+        "manifests": manifests
     })
     .to_string()
+}
+
+/// Push a minimal OCI manifest (with blobs) and return its content digest.
+async fn push_child_manifest(
+    server: &TestServer,
+    project_slug: &str,
+    push_token: &str,
+    tag: &str,
+) -> String {
+    let config_digest = server
+        .upload_blob(project_slug, push_token, b"child-config")
+        .await;
+    let layer_digest = server
+        .upload_blob(project_slug, push_token, b"child-layer")
+        .await;
+    let manifest = create_oci_manifest(&config_digest, &layer_digest);
+    let manifest_digest = compute_digest(manifest.as_bytes());
+
+    let resp = server
+        .client
+        .put(server.api_url(&format!("/v2/{project_slug}/manifests/{tag}")))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(push_token),
+        )
+        .header("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+        .body(manifest)
+        .send()
+        .await
+        .expect("PUT child manifest failed");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    manifest_digest
 }
 
 // PUT multi-platform OCI image index, verify 201
@@ -1595,7 +1620,10 @@ async fn manifest_put_oci_image_index() {
     let push_token = server.oci_push_token(&user, &project);
     let project_slug: &str = project.slug.as_ref();
 
-    let manifest = create_oci_image_index();
+    let d1 = push_child_manifest(&server, project_slug, &push_token, "child-amd64").await;
+    let d2 = push_child_manifest(&server, project_slug, &push_token, "child-arm64").await;
+    let d3 = push_child_manifest(&server, project_slug, &push_token, "child-s390x").await;
+    let manifest = create_oci_image_index(&[&d1, &d2, &d3]);
 
     let put_resp = server
         .client
@@ -1631,7 +1659,10 @@ async fn manifest_get_oci_image_index() {
     let pull_token = server.oci_pull_token(&user, &project);
     let project_slug: &str = project.slug.as_ref();
 
-    let manifest = create_oci_image_index();
+    let d1 = push_child_manifest(&server, project_slug, &push_token, "child-amd64-get").await;
+    let d2 = push_child_manifest(&server, project_slug, &push_token, "child-arm64-get").await;
+    let d3 = push_child_manifest(&server, project_slug, &push_token, "child-s390x-get").await;
+    let manifest = create_oci_image_index(&[&d1, &d2, &d3]);
 
     // Upload
     server
@@ -2285,4 +2316,75 @@ async fn manifest_put_within_server_default() {
         resp.status()
     );
     assert!(resp.headers().contains_key("docker-content-digest"));
+}
+
+// PUT OCI image index referencing non-existent child manifests → rejected
+#[tokio::test]
+async fn manifest_put_oci_image_index_missing_child() {
+    let server = TestServer::new().await;
+    let user = server
+        .signup("IdxMissing User", "idxmissing@example.com")
+        .await;
+    let org = server.create_org(&user, "IdxMissing Org").await;
+    let project = server
+        .create_project(&user, &org, "IdxMissing Project")
+        .await;
+
+    let push_token = server.oci_push_token(&user, &project);
+    let project_slug: &str = project.slug.as_ref();
+
+    let fake_digest = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+    let manifest = create_oci_image_index(&[fake_digest]);
+
+    let resp = server
+        .client
+        .put(server.api_url(&format!("/v2/{project_slug}/manifests/missing-child")))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&push_token),
+        )
+        .header("Content-Type", "application/vnd.oci.image.index.v1+json")
+        .body(manifest)
+        .send()
+        .await
+        .expect("PUT failed");
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+// PUT Docker manifest list referencing non-existent child manifests → rejected
+#[tokio::test]
+async fn manifest_put_docker_manifest_list_missing_child() {
+    let server = TestServer::new().await;
+    let user = server
+        .signup("ListMissing User", "listmissing@example.com")
+        .await;
+    let org = server.create_org(&user, "ListMissing Org").await;
+    let project = server
+        .create_project(&user, &org, "ListMissing Project")
+        .await;
+
+    let push_token = server.oci_push_token(&user, &project);
+    let project_slug: &str = project.slug.as_ref();
+
+    let fake_digest = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+    let manifest = create_docker_manifest_list(&[fake_digest]);
+
+    let resp = server
+        .client
+        .put(server.api_url(&format!("/v2/{project_slug}/manifests/missing-child")))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&push_token),
+        )
+        .header(
+            "Content-Type",
+            "application/vnd.docker.distribution.manifest.list.v2+json",
+        )
+        .body(manifest)
+        .send()
+        .await
+        .expect("PUT failed");
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }

--- a/plus/api_oci/tests/token.rs
+++ b/plus/api_oci/tests/token.rs
@@ -4,9 +4,10 @@
     clippy::tests_outside_test_module,
     reason = "integration test file"
 )]
-//! Integration tests for the OCI token endpoint (GET /v0/auth/oci/token).
+//! Integration tests for the OCI token endpoint (GET and POST /v0/auth/oci/token).
 
 use bencher_api_tests::TestServer;
+use bencher_json::PROJECT_KEY_PREFIX;
 use http::StatusCode;
 use serde_json::Value;
 
@@ -144,4 +145,304 @@ async fn oci_token_bad_credentials() {
 
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     assert!(resp.headers().contains_key("www-authenticate"));
+}
+
+// GET with multiple scope params (Docker 29 containerd pattern) → 200 with merged actions
+#[tokio::test]
+async fn oci_token_multiple_scopes() {
+    let server = TestServer::new().await;
+    let user = server
+        .signup("MultiScope User", "multiscope@example.com")
+        .await;
+    let org = server.create_org(&user, "MultiScope Org").await;
+    let project = server
+        .create_project(&user, &org, "MultiScope Project")
+        .await;
+
+    let api_key = server
+        .token_key()
+        .new_api_key(user.email.clone(), u32::MAX)
+        .expect("Failed to create API key");
+
+    let project_slug: &str = project.slug.as_ref();
+    let url = format!(
+        "/v0/auth/oci/token?scope=repository:{project_slug}:pull&scope=repository:{project_slug}:pull,push&service=localhost"
+    );
+
+    let resp = server
+        .client
+        .get(server.api_url(&url))
+        .basic_auth(user.email.as_ref(), Some(api_key.as_ref()))
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body: Value = resp.json().await.expect("Invalid JSON");
+    assert!(body["token"].is_string());
+}
+
+// GET with multiple scope params using project key auth
+#[tokio::test]
+async fn oci_token_multiple_scopes_project_key() {
+    let server = TestServer::new().await;
+    let user = server
+        .signup("MultiScopeKey User", "multiscopekey@example.com")
+        .await;
+    let org = server.create_org(&user, "MultiScopeKey Org").await;
+    let project = server
+        .create_project(&user, &org, "MultiScopeKey Project")
+        .await;
+    let project_key = server
+        .create_project_key(&user, &project, "multi-scope-key")
+        .await;
+
+    let project_slug: &str = project.slug.as_ref();
+    let url = format!(
+        "/v0/auth/oci/token?scope=repository:{project_slug}:pull&scope=repository:{project_slug}:pull,push&service=localhost"
+    );
+
+    let resp = server
+        .client
+        .get(server.api_url(&url))
+        .basic_auth(project_slug, Some(project_key.key.as_ref()))
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body: Value = resp.json().await.expect("Invalid JSON");
+    assert!(body["token"].is_string());
+}
+
+// POST with grant_type=password and user credentials → 200 with access_token
+#[tokio::test]
+async fn oci_token_post_authenticated() {
+    let server = TestServer::new().await;
+    let user = server.signup("PostAuth User", "postauth@example.com").await;
+    let org = server.create_org(&user, "PostAuth Org").await;
+    let project = server.create_project(&user, &org, "PostAuth Project").await;
+
+    let api_key = server
+        .token_key()
+        .new_api_key(user.email.clone(), u32::MAX)
+        .expect("Failed to create API key");
+
+    let project_slug: &str = project.slug.as_ref();
+    let scope = format!("repository:{project_slug}:push");
+
+    let resp = server
+        .client
+        .post(server.api_url("/v0/auth/oci/token"))
+        .form(&[
+            ("grant_type", "password"),
+            ("username", user.email.as_ref()),
+            ("password", api_key.as_ref()),
+            ("scope", &scope),
+            ("service", "localhost"),
+        ])
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body: Value = resp.json().await.expect("Invalid JSON");
+    assert!(
+        body["access_token"].is_string(),
+        "POST response should contain access_token"
+    );
+    assert!(
+        body["token"].is_null(),
+        "POST response should NOT contain token"
+    );
+    assert!(body["expires_in"].is_number());
+    assert!(body["issued_at"].is_string());
+
+    let token = body["access_token"].as_str().unwrap();
+    let v2_resp = server
+        .client
+        .get(server.api_url("/v2/"))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(v2_resp.status(), StatusCode::OK);
+}
+
+// POST with grant_type=password and project key → 200 with access_token
+#[tokio::test]
+async fn oci_token_post_project_key() {
+    let server = TestServer::new().await;
+    let user = server.signup("PostKey User", "postkey@example.com").await;
+    let org = server.create_org(&user, "PostKey Org").await;
+    let project = server.create_project(&user, &org, "PostKey Project").await;
+    let project_key = server.create_project_key(&user, &project, "post-key").await;
+
+    let project_slug: &str = project.slug.as_ref();
+    let scope = format!("repository:{project_slug}:push");
+
+    assert!(
+        project_key.key.as_ref().starts_with(PROJECT_KEY_PREFIX),
+        "Project key should start with bencher_run_ prefix"
+    );
+
+    let resp = server
+        .client
+        .post(server.api_url("/v0/auth/oci/token"))
+        .form(&[
+            ("grant_type", "password"),
+            ("username", project_slug),
+            ("password", project_key.key.as_ref()),
+            ("scope", &scope),
+            ("service", "localhost"),
+        ])
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body: Value = resp.json().await.expect("Invalid JSON");
+    assert!(body["access_token"].is_string());
+
+    let token = body["access_token"].as_str().unwrap();
+    let v2_resp = server
+        .client
+        .get(server.api_url("/v2/"))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(v2_resp.status(), StatusCode::OK);
+}
+
+// POST with wrong credentials → 401
+#[tokio::test]
+async fn oci_token_post_bad_credentials() {
+    let server = TestServer::new().await;
+    let user = server.signup("PostBad User", "postbad@example.com").await;
+
+    let bad_api_key = server
+        .token_key()
+        .new_api_key("wrong@example.com".parse().unwrap(), u32::MAX)
+        .expect("Failed to create API key");
+
+    let resp = server
+        .client
+        .post(server.api_url("/v0/auth/oci/token"))
+        .form(&[
+            ("grant_type", "password"),
+            ("username", user.email.as_ref()),
+            ("password", bad_api_key.as_ref()),
+            ("scope", "repository:test:push"),
+        ])
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    assert!(resp.headers().contains_key("www-authenticate"));
+}
+
+// POST with grant_type=refresh_token → 400
+#[tokio::test]
+async fn oci_token_post_refresh_token_rejected() {
+    let server = TestServer::new().await;
+
+    let resp = server
+        .client
+        .post(server.api_url("/v0/auth/oci/token"))
+        .form(&[
+            ("grant_type", "refresh_token"),
+            ("refresh_token", "some-token"),
+        ])
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+// POST with missing grant_type → 400
+#[tokio::test]
+async fn oci_token_post_missing_grant_type() {
+    let server = TestServer::new().await;
+
+    let resp = server
+        .client
+        .post(server.api_url("/v0/auth/oci/token"))
+        .form(&[("scope", "repository:test:push")])
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+// POST with space-separated scopes (containerd joins scopes with spaces in POST body)
+#[tokio::test]
+async fn oci_token_post_space_separated_scopes() {
+    let server = TestServer::new().await;
+    let user = server
+        .signup("PostScopes User", "postscopes@example.com")
+        .await;
+    let org = server.create_org(&user, "PostScopes Org").await;
+    let project = server
+        .create_project(&user, &org, "PostScopes Project")
+        .await;
+    let project_key = server
+        .create_project_key(&user, &project, "post-scopes-key")
+        .await;
+
+    let project_slug: &str = project.slug.as_ref();
+    let scope = format!("repository:{project_slug}:pull repository:{project_slug}:pull,push");
+
+    let resp = server
+        .client
+        .post(server.api_url("/v0/auth/oci/token"))
+        .form(&[
+            ("grant_type", "password"),
+            ("username", project_slug),
+            ("password", project_key.key.as_ref()),
+            ("scope", &scope),
+            ("service", "localhost"),
+        ])
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body: Value = resp.json().await.expect("Invalid JSON");
+    assert!(body["access_token"].is_string());
+}
+
+// POST with grant_type=password but no credentials → 400
+#[tokio::test]
+async fn oci_token_post_no_credentials() {
+    let server = TestServer::new().await;
+
+    let resp = server
+        .client
+        .post(server.api_url("/v0/auth/oci/token"))
+        .form(&[
+            ("grant_type", "password"),
+            ("scope", "repository:test:push"),
+        ])
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }

--- a/plus/bencher_oci/src/registry.rs
+++ b/plus/bencher_oci/src/registry.rs
@@ -146,7 +146,7 @@ impl RegistryClient {
         let image_manifest = match &parsed {
             bencher_json::oci::Manifest::OciImageIndex(index) => {
                 let desc = select_platform_manifest(&index.manifests)?;
-                let (_, nested_bytes) = self.pull_blob(image_ref, &desc.digest)?;
+                let (_, nested_bytes) = self.pull_manifest_by_digest(image_ref, &desc.digest)?;
 
                 // Save nested manifest blob
                 let nested_path = blob_path_for_digest(&blobs_base, &desc.digest)?;
@@ -160,7 +160,7 @@ impl RegistryClient {
             },
             bencher_json::oci::Manifest::DockerManifestList(list) => {
                 let desc = select_platform_manifest(&list.manifests)?;
-                let (_, nested_bytes) = self.pull_blob(image_ref, &desc.digest)?;
+                let (_, nested_bytes) = self.pull_manifest_by_digest(image_ref, &desc.digest)?;
 
                 // Save nested manifest blob
                 let nested_path = blob_path_for_digest(&blobs_base, &desc.digest)?;
@@ -273,6 +273,38 @@ impl RegistryClient {
         if image_ref.is_digest() && computed_digest != image_ref.reference() {
             return Err(OciError::DigestMismatch {
                 expected: image_ref.reference().to_owned(),
+                actual: computed_digest,
+            });
+        }
+
+        Ok((computed_digest, bytes))
+    }
+
+    fn pull_manifest_by_digest(
+        &mut self,
+        image_ref: &ImageReference,
+        digest: &str,
+    ) -> Result<(String, Vec<u8>), OciError> {
+        let url = self.registry_url(
+            image_ref.registry(),
+            &format!("/v2/{}/manifests/{digest}", image_ref.repository()),
+        );
+
+        let accept = MANIFEST_MEDIA_TYPES.join(", ");
+        let mut response = self.authenticated_request(&url, &accept)?;
+
+        let bytes = response
+            .body_mut()
+            .read_to_vec()
+            .map_err(|e| OciError::Registry(format!("Failed to read manifest: {e}")))?;
+
+        let parsed: bencher_valid::ImageDigest = digest
+            .parse()
+            .map_err(|_err| OciError::InvalidReference(digest.to_owned()))?;
+        let computed_digest = DigestHasher::digest(parsed.algorithm(), &bytes)?;
+        if computed_digest != digest {
+            return Err(OciError::DigestMismatch {
+                expected: digest.to_owned(),
                 actual: computed_digest,
             });
         }

--- a/plus/bencher_oci_storage/src/local.rs
+++ b/plus/bencher_oci_storage/src/local.rs
@@ -751,6 +751,16 @@ impl OciLocalStorage {
         Ok(Bytes::from(data))
     }
 
+    /// Checks if a manifest exists
+    pub async fn manifest_exists(
+        &self,
+        repository: &ProjectUuid,
+        digest: &Digest,
+    ) -> Result<bool, OciStorageError> {
+        let path = self.manifest_path(repository, digest);
+        Ok(fs::try_exists(&path).await.unwrap_or(false))
+    }
+
     /// Resolves a tag to a digest
     pub async fn resolve_tag(
         &self,
@@ -1086,6 +1096,29 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(retrieved.as_ref(), content.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn manifest_exists_reports_presence() {
+        let tmp = tempfile::tempdir().unwrap();
+        let storage = test_storage(&tmp);
+        let repo = test_repository();
+        let content = test_manifest_json(
+            "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        );
+        let manifest = bencher_json::oci::Manifest::from_bytes(content.as_bytes()).unwrap();
+
+        let digest = storage
+            .put_manifest(&repo, Bytes::from(content), None, &manifest)
+            .await
+            .unwrap();
+
+        // A stored manifest is reported as existing
+        assert!(storage.manifest_exists(&repo, &digest).await.unwrap());
+
+        // A never-written digest is reported as absent
+        let missing = Digest::from_sha256_bytes(b"no such manifest");
+        assert!(!storage.manifest_exists(&repo, &missing).await.unwrap());
     }
 
     #[tokio::test]

--- a/plus/bencher_oci_storage/src/storage.rs
+++ b/plus/bencher_oci_storage/src/storage.rs
@@ -525,6 +525,18 @@ impl OciStorage {
         }
     }
 
+    /// Checks if a manifest exists
+    pub async fn manifest_exists(
+        &self,
+        repository: &ProjectUuid,
+        digest: &Digest,
+    ) -> Result<bool, OciStorageError> {
+        match self {
+            Self::S3(s3) => s3.manifest_exists(repository, digest).await,
+            Self::Local(local) => local.manifest_exists(repository, digest).await,
+        }
+    }
+
     /// Resolves a tag to a digest
     pub async fn resolve_tag(
         &self,
@@ -1626,6 +1638,32 @@ impl OciS3Storage {
             .into_bytes();
 
         Ok(data)
+    }
+
+    /// Checks if a manifest exists
+    pub async fn manifest_exists(
+        &self,
+        repository: &ProjectUuid,
+        digest: &Digest,
+    ) -> Result<bool, OciStorageError> {
+        let key = self.manifest_key_by_digest(repository, digest);
+        match self
+            .client
+            .head_object()
+            .bucket(&self.config.bucket_arn)
+            .key(&key)
+            .send()
+            .await
+        {
+            Ok(_) => Ok(true),
+            Err(e) => {
+                if is_s3_not_found(&e) {
+                    Ok(false)
+                } else {
+                    Err(OciStorageError::S3(e.to_string()))
+                }
+            },
+        }
     }
 
     /// Resolves a tag to a digest

--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -694,29 +694,50 @@
           "auth",
           "oci"
         ],
-        "summary": "OCI token endpoint",
-        "description": "Authenticates via Basic auth and returns a short-lived JWT for OCI operations. Supports two credential types: - `email:api-key-jwt`: user authentication - `project-slug-or-uuid:bencher_run_xxxxx`: project key authentication\n\nIf no Basic auth credentials are provided, issues a public (anonymous) OCI token.",
+        "summary": "OCI token endpoint (GET)",
+        "description": "Authenticates via Basic auth and returns a short-lived JWT for OCI operations. Supports two credential types: - `email:api-key-jwt`: user authentication - `project-slug-or-uuid:bencher_run_xxxxx`: project key authentication\n\nIf no Basic auth credentials are provided, issues a public (anonymous) OCI token.\n\nAccepts multiple `scope` query parameters (Docker 29+ / containerd sends these).",
         "operationId": "auth_oci_token_get",
         "parameters": [
           {
             "in": "query",
-            "name": "scope",
-            "description": "Scope in format \"repository:name:action,action\" e.g., \"repository:org/project:pull,push\"",
-            "schema": {
-              "nullable": true,
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
             "name": "service",
-            "description": "Service identifier (e.g., \"registry.bencher.dev\") Not currently used but accepted for OCI spec compliance",
+            "description": "Service identifier (e.g., \"registry.bencher.dev\")",
             "schema": {
               "nullable": true,
               "type": "string"
             }
           }
         ],
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "auth",
+          "oci"
+        ],
+        "summary": "OCI token endpoint (POST) — `OAuth2` token exchange",
+        "description": "Accepts `application/x-www-form-urlencoded` body with `grant_type=password`. Docker 29+ (containerd image store) uses this flow before falling back to GET.",
+        "operationId": "auth_oci_token_post",
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "default": {
             "description": "",

--- a/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
+++ b/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
@@ -1,5 +1,6 @@
 ## Pending
 - `bencher run` now rejects `--key`/`BENCHER_API_KEY` unless `--project`/`BENCHER_PROJECT` is also set, since project-scoped API keys cannot create new Projects
+- Fix the OCI registry token endpoint for the Docker 29+ containerd image store, which sends multiple `scope` query parameters and an `OAuth2` POST token exchange (Thank you [@travishathaway](https://github.com/travishathaway))
 
 ## `v0.6.6`
 - Show context-aware auth hints in API 404 errors: routes that accept project API keys now mention both API tokens and project keys, while token-only routes mention only API tokens


### PR DESCRIPTION
## Summary

- Fix duplicate `scope` query param rejection (400) when Docker 29's containerd sends multiple scope params during token fetch
- Add OAuth2 POST handler (`grant_type=password`) so containerd's first auth attempt succeeds without relying on GET fallback
- Add containerd image store matrix to CI smoke tests (`test.yml`) and deploy smoke tests (`deploy.yml`) to test both overlay2 and containerd paths
- Add `TestProjectKey` / `create_project_key` test helper to `bencher_api_tests`

## Test plan

- [x] `cargo nextest run -p api_auth --features plus` — 30/30 pass (includes `parse_scopes` unit tests)
- [x] `cargo nextest run -p api_oci --features plus` — 158/158 pass (includes 8 new integration tests: 2 multi-scope GET, 6 POST)
- [x] `cargo check --no-default-features` — clean
- [x] `cargo clippy --no-deps --all-targets --all-features -- -Dwarnings` — clean
- [x] Local curl verification against running API: GET multi-scope → 200, POST grant_type=password → 200
- [x] Reproduced Docker 29.5.2 + containerd push failure against `dev.registry.bencher.dev` before fix