### PR TITLE
Allow `--project` to not be specified when `--image` is used

### DIFF
--- a/lib/api_run/src/run.rs
+++ b/lib/api_run/src/run.rs
@@ -1,5 +1,7 @@
 use bencher_endpoint::{CorsResponse, Endpoint, Post, ResponseCreated};
-use bencher_json::{JsonNewRun, JsonReport, ProjectSlug, ResourceName, RunContext};
+use bencher_json::{
+    JsonNewRun, JsonReport, ProjectResourceId, ProjectSlug, ResourceName, RunContext,
+};
 use bencher_rbac::project::Permission;
 use bencher_schema::{
     auth_conn,
@@ -110,10 +112,18 @@ async fn post_inner(
         },
     }
 
+    let target_project = TargetProject::find(&json_run);
     let project_name_fn = || project_name(&json_run);
     let project_slug_fn = || project_slug(&json_run);
-    let query_project = if let Some(project) = json_run.project.as_ref() {
-        QueryProject::get_or_create(log, context, public_user, project, project_name_fn).await?
+    let query_project = if let Some(project) = &target_project {
+        QueryProject::get_or_create(
+            log,
+            context,
+            public_user,
+            project.resource_id(),
+            project_name_fn,
+        )
+        .await?
     } else {
         QueryProject::get_or_create_from_context(
             log,
@@ -173,10 +183,22 @@ async fn post_inner_project_key(
 ) -> Result<JsonReport, HttpError> {
     let query_project = QueryProject::get(auth_conn!(context), project_key_actor.project_id)?;
 
-    // Verify the run targets this project (if explicitly specified)
-    if let Some(project_rid) = json_run.project.as_ref() {
-        let target = QueryProject::from_resource_id(auth_conn!(context), project_rid)?;
-        project_key_actor.verify_project(target.id)?;
+    // Verify the run targets this project (if explicitly specified or derived from image)
+    match TargetProject::find(&json_run) {
+        Some(TargetProject::Explicit(project_rid)) => {
+            let target = QueryProject::from_resource_id(auth_conn!(context), &project_rid)?;
+            project_key_actor.verify_project(target.id)?;
+        },
+        #[cfg(feature = "plus")]
+        Some(TargetProject::Derived(project_rid)) => {
+            // A derived repository may not name a project at all, so only
+            // verify when it resolves. A bogus image instead fails digest
+            // resolution during report creation.
+            if let Ok(target) = QueryProject::from_resource_id(auth_conn!(context), &project_rid) {
+                project_key_actor.verify_project(target.id)?;
+            }
+        },
+        None => {},
     }
 
     slog::info!(log, "New run via project key"; "project" => ?query_project.uuid);
@@ -255,6 +277,48 @@ async fn create_run_report(
     };
 
     QueryReport::create(log, context, query_project, new_run_report, api_actor).await
+}
+
+/// The project that a run targets.
+enum TargetProject {
+    /// The `project` field was specified.
+    Explicit(ProjectResourceId),
+    /// The project was derived from the job image repository.
+    #[cfg(feature = "plus")]
+    Derived(ProjectResourceId),
+}
+
+impl TargetProject {
+    /// Find the target project for a run, if any.
+    ///
+    /// Bencher registry images are named `[{registry}/]{project}:{tag}`,
+    /// so a job image project repository that parses as a project
+    /// resource ID derives the target project.
+    /// Multi-segment repositories (e.g. `{user}/{image}`) are not
+    /// supported by the Bencher registry, so no project is derived for them.
+    fn find(json_run: &JsonNewRun) -> Option<Self> {
+        if let Some(project) = json_run.project.clone() {
+            return Some(Self::Explicit(project));
+        }
+        #[cfg(feature = "plus")]
+        if let Some(job) = &json_run.job
+            && let Some(project) = job
+                .image
+                .project_repository()
+                .and_then(|repository| repository.parse().ok())
+        {
+            return Some(Self::Derived(project));
+        }
+        None
+    }
+
+    fn resource_id(&self) -> &ProjectResourceId {
+        match self {
+            Self::Explicit(project) => project,
+            #[cfg(feature = "plus")]
+            Self::Derived(project) => project,
+        }
+    }
 }
 
 fn project_name(json_run: &JsonNewRun) -> Result<ResourceName, HttpError> {

--- a/lib/api_run/tests/run.rs
+++ b/lib/api_run/tests/run.rs
@@ -316,6 +316,247 @@ async fn run_post_with_job_creates_job() {
     );
 }
 
+// POST /v0/run with job but no project field derives project from image repository
+#[cfg(feature = "plus")]
+#[tokio::test]
+async fn run_post_with_job_project_from_image() {
+    let server = TestServer::new().await;
+    let user = server.signup("Job User", "runjobimg@example.com").await;
+    let org = server.create_org(&user, "Job Image Org").await;
+    let project = server
+        .create_project(&user, &org, "Job Image Project")
+        .await;
+
+    let _spec = create_fallback_spec(&server, &user).await;
+
+    let project_slug: &str = project.slug.as_ref();
+    push_test_image(&server, &project, &user, "v1").await;
+
+    let body = serde_json::json!({
+        "branch": "main",
+        "testbed": "localhost",
+        "start_time": "2024-01-01T00:00:00Z",
+        "end_time": "2024-01-01T00:01:00Z",
+        "results": [bmf_results().to_string()],
+        "job": {
+            "image": format!("localhost/{project_slug}:v1")
+        }
+    });
+
+    let resp = server
+        .client
+        .post(server.api_url("/v0/run"))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(&body)
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let report: JsonReport = resp.json().await.expect("Failed to parse response");
+    assert_eq!(
+        AsRef::<str>::as_ref(&report.project.slug),
+        project_slug,
+        "Project should be derived from image repository"
+    );
+}
+
+// POST /v0/run with an unqualified job image derives the project from the image repository
+#[cfg(feature = "plus")]
+#[tokio::test]
+async fn run_post_with_job_project_from_unqualified_image() {
+    let server = TestServer::new().await;
+    let user = server.signup("Job User", "runjobimgunq@example.com").await;
+    let org = server.create_org(&user, "Job Unqualified Org").await;
+    let project = server
+        .create_project(&user, &org, "Job Unqualified Project")
+        .await;
+
+    let _spec = create_fallback_spec(&server, &user).await;
+
+    let project_slug: &str = project.slug.as_ref();
+    push_test_image(&server, &project, &user, "v1").await;
+
+    let body = serde_json::json!({
+        "branch": "main",
+        "testbed": "localhost",
+        "start_time": "2024-01-01T00:00:00Z",
+        "end_time": "2024-01-01T00:01:00Z",
+        "results": [bmf_results().to_string()],
+        "job": {
+            "image": format!("{project_slug}:v1")
+        }
+    });
+
+    let resp = server
+        .client
+        .post(server.api_url("/v0/run"))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(&body)
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let report: JsonReport = resp.json().await.expect("Failed to parse response");
+    assert_eq!(
+        AsRef::<str>::as_ref(&report.project.slug),
+        project_slug,
+        "Project should be derived from the unqualified image repository"
+    );
+}
+
+// POST /v0/run with both a context and a job image derives the project from the image
+#[cfg(feature = "plus")]
+#[tokio::test]
+async fn run_post_with_job_project_from_image_overrides_context() {
+    let server = TestServer::new().await;
+    let user = server.signup("Job User", "runjobimgctx@example.com").await;
+    let org = server.create_org(&user, "Job Context Org").await;
+    let project = server
+        .create_project(&user, &org, "Job Context Project")
+        .await;
+
+    let _spec = create_fallback_spec(&server, &user).await;
+
+    let project_slug: &str = project.slug.as_ref();
+    push_test_image(&server, &project, &user, "v1").await;
+
+    // Without the image, this context would get-or-create a context-derived project
+    let body = serde_json::json!({
+        "branch": "main",
+        "testbed": "localhost",
+        "start_time": "2024-01-01T00:00:00Z",
+        "end_time": "2024-01-01T00:01:00Z",
+        "results": [bmf_results().to_string()],
+        "context": {
+            "bencher.dev/v0/repo/name": "context-repo",
+            "bencher.dev/v0/repo/hash": "0123456789abcdef0123456789abcdef01234567",
+            "bencher.dev/v0/testbed/fingerprint": "0123456789ABCDEF"
+        },
+        "job": {
+            "image": format!("localhost/{project_slug}:v1")
+        }
+    });
+
+    let resp = server
+        .client
+        .post(server.api_url("/v0/run"))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(&body)
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let report: JsonReport = resp.json().await.expect("Failed to parse response");
+    assert_eq!(
+        AsRef::<str>::as_ref(&report.project.slug),
+        project_slug,
+        "Image-derived project should take precedence over the run context"
+    );
+}
+
+// POST /v0/run with a project key rejects a job image that references a different project
+#[cfg(feature = "plus")]
+#[tokio::test]
+async fn run_post_project_key_job_image_other_project() {
+    let server = TestServer::new().await;
+    let user = server
+        .signup("Job User", "runjobkeyother@example.com")
+        .await;
+    let org = server.create_org(&user, "Key Image Org").await;
+    let key_project = server.create_project(&user, &org, "Key Project").await;
+    let image_project = server.create_project(&user, &org, "Image Project").await;
+
+    let _spec = create_fallback_spec(&server, &user).await;
+
+    let image_project_slug: &str = image_project.slug.as_ref();
+    push_test_image(&server, &image_project, &user, "v1").await;
+
+    let project_key = server
+        .create_project_key(&user, &key_project, "Run Key")
+        .await;
+
+    let body = serde_json::json!({
+        "branch": "main",
+        "testbed": "localhost",
+        "start_time": "2024-01-01T00:00:00Z",
+        "end_time": "2024-01-01T00:01:00Z",
+        "results": [bmf_results().to_string()],
+        "job": {
+            "image": format!("localhost/{image_project_slug}:v1")
+        }
+    });
+
+    let resp = server
+        .client
+        .post(server.api_url("/v0/run"))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(project_key.key.as_ref()),
+        )
+        .json(&body)
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "A project key must not run a job image for a different project"
+    );
+}
+
+// POST /v0/run with a project key skips verification when the job image repository is not a project
+#[cfg(feature = "plus")]
+#[tokio::test]
+async fn run_post_project_key_job_image_unknown_project() {
+    let server = TestServer::new().await;
+    let user = server
+        .signup("Job User", "runjobkeyunknown@example.com")
+        .await;
+    let org = server.create_org(&user, "Key Unknown Org").await;
+    let project = server
+        .create_project(&user, &org, "Key Unknown Project")
+        .await;
+
+    let _spec = create_fallback_spec(&server, &user).await;
+
+    let project_key = server.create_project_key(&user, &project, "Run Key").await;
+
+    // The image repository parses as a valid project slug, but no such project exists
+    let body = serde_json::json!({
+        "branch": "main",
+        "testbed": "localhost",
+        "start_time": "2024-01-01T00:00:00Z",
+        "end_time": "2024-01-01T00:01:00Z",
+        "results": [bmf_results().to_string()],
+        "job": {
+            "image": "localhost/no-such-project:v1"
+        }
+    });
+
+    let resp = server
+        .client
+        .post(server.api_url("/v0/run"))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(project_key.key.as_ref()),
+        )
+        .json(&body)
+        .send()
+        .await
+        .expect("Request failed");
+    // The unresolvable derived project must not 404; image digest resolution fails instead
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
 // POST /v0/run with job + explicit spec creates a job using that spec
 #[cfg(feature = "plus")]
 #[tokio::test]

--- a/lib/bencher_schema/src/model/runner/job.rs
+++ b/lib/bencher_schema/src/model/runner/job.rs
@@ -350,7 +350,7 @@ impl PendingInsertJob {
         })?;
         new_run_job
             .image
-            .validate_registry(registry_host)
+            .validate_registry(registry_host, registry_url.port_or_known_default())
             .map_err(|e| bad_request_error(e.to_string()))?;
         let registry_url: bencher_json::Url = registry_url.clone().into();
         let digest = resolve_digest(

--- a/lib/bencher_valid/src/plus/image_reference.rs
+++ b/lib/bencher_valid/src/plus/image_reference.rs
@@ -126,6 +126,27 @@ impl ImageReference {
         &self.repository
     }
 
+    /// The repository as a candidate project resource ID.
+    ///
+    /// Bencher registry images are named `[{registry}/]{project}:{tag}`,
+    /// so a repository with a single path segment is a project candidate.
+    /// The implied `library/` namespace for default-registry images is
+    /// ignored, matching Docker semantics where `{name}` and
+    /// `library/{name}` are equivalent.
+    /// Multi-segment repositories (e.g. `{user}/{image}`) are not supported
+    /// by the Bencher registry, so `None` is returned for them.
+    #[must_use]
+    pub fn project_repository(&self) -> Option<&str> {
+        let repository = if self.registry == DEFAULT_OCI_REGISTRY {
+            self.repository
+                .strip_prefix("library/")
+                .unwrap_or(&self.repository)
+        } else {
+            &self.repository
+        };
+        (!repository.contains('/')).then_some(repository)
+    }
+
     /// Tag or digest reference.
     #[must_use]
     pub fn reference(&self) -> &str {
@@ -140,15 +161,32 @@ impl ImageReference {
 
     /// Validate that this image's registry is either the default (`docker.io`)
     /// or the expected Bencher registry.
-    pub fn validate_registry(&self, expected_registry: &str) -> Result<(), ImageRegistryError> {
+    ///
+    /// The expected registry matches either as a bare host (`expected_host`)
+    /// or as a full authority (`expected_host:expected_port`), so both
+    /// `registry.bencher.dev/...` and `registry.bencher.dev:443/...` are
+    /// accepted for a registry served on that host and port. Pass the registry
+    /// URL's `port_or_known_default()` as `expected_port` so the scheme's
+    /// default port (e.g. 443 for HTTPS) is matched as well as an explicit
+    /// port (e.g. a self-hosted `:8443`).
+    pub fn validate_registry(
+        &self,
+        expected_host: &str,
+        expected_port: Option<u16>,
+    ) -> Result<(), ImageRegistryError> {
         let image_registry = self.registry();
-        if image_registry != DEFAULT_OCI_REGISTRY && image_registry != expected_registry {
-            return Err(ImageRegistryError::UnsupportedRegistry {
-                image_registry: image_registry.to_owned(),
-                expected_registry: expected_registry.to_owned(),
-            });
+        if image_registry == DEFAULT_OCI_REGISTRY || image_registry == expected_host {
+            return Ok(());
         }
-        Ok(())
+        if let Some(port) = expected_port
+            && image_registry == format!("{expected_host}:{port}")
+        {
+            return Ok(());
+        }
+        Err(ImageRegistryError::UnsupportedRegistry {
+            image_registry: image_registry.to_owned(),
+            expected_registry: expected_host.to_owned(),
+        })
     }
 }
 
@@ -264,6 +302,42 @@ mod tests {
     }
 
     #[test]
+    fn project_repository_unqualified() {
+        let ref_ = ImageReference::parse("my-project:v1").unwrap();
+        assert_eq!(ref_.project_repository(), Some("my-project"));
+    }
+
+    #[test]
+    fn project_repository_qualified() {
+        let ref_ = ImageReference::parse("localhost/my-project:v1").unwrap();
+        assert_eq!(ref_.project_repository(), Some("my-project"));
+    }
+
+    #[test]
+    fn project_repository_qualified_with_port() {
+        let ref_ = ImageReference::parse("localhost:5000/my-project:v1").unwrap();
+        assert_eq!(ref_.project_repository(), Some("my-project"));
+    }
+
+    #[test]
+    fn project_repository_explicit_library() {
+        let ref_ = ImageReference::parse("library/my-project:v1").unwrap();
+        assert_eq!(ref_.project_repository(), Some("my-project"));
+    }
+
+    #[test]
+    fn project_repository_user_image() {
+        let ref_ = ImageReference::parse("myuser/myimage:v1").unwrap();
+        assert_eq!(ref_.project_repository(), None);
+    }
+
+    #[test]
+    fn project_repository_custom_registry_multi_segment() {
+        let ref_ = ImageReference::parse("ghcr.io/owner/repo:latest").unwrap();
+        assert_eq!(ref_.project_repository(), None);
+    }
+
+    #[test]
     fn round_trip_serde() {
         let original = ImageReference::parse("ghcr.io/owner/repo:v1").unwrap();
         let json = serde_json::to_string(&original).unwrap();
@@ -337,21 +411,48 @@ mod tests {
     fn validate_registry_default_ok() {
         // Images from docker.io are always accepted
         let ref_ = ImageReference::parse("alpine:3.18").unwrap();
-        ref_.validate_registry("registry.bencher.dev").unwrap();
+        ref_.validate_registry("registry.bencher.dev", Some(443))
+            .unwrap();
     }
 
     #[test]
     fn validate_registry_expected_ok() {
-        // Images from the expected registry are accepted
+        // Images from the expected registry (bare host) are accepted
         let ref_ = ImageReference::parse("registry.bencher.dev/owner/repo:v1").unwrap();
-        ref_.validate_registry("registry.bencher.dev").unwrap();
+        ref_.validate_registry("registry.bencher.dev", Some(443))
+            .unwrap();
+    }
+
+    #[test]
+    fn validate_registry_default_port_ok() {
+        // The scheme's default port (443 for HTTPS) is accepted explicitly
+        let ref_ = ImageReference::parse("registry.bencher.dev:443/owner/repo:v1").unwrap();
+        ref_.validate_registry("registry.bencher.dev", Some(443))
+            .unwrap();
+    }
+
+    #[test]
+    fn validate_registry_custom_port_ok() {
+        // A self-hosted registry on a non-default port accepts the host:port form
+        let ref_ = ImageReference::parse("localhost:61016/my-project:v1").unwrap();
+        ref_.validate_registry("localhost", Some(61016)).unwrap();
+    }
+
+    #[test]
+    fn validate_registry_bare_host_for_custom_port_ok() {
+        // The bare host is accepted even when the registry serves on a non-default port
+        let ref_ = ImageReference::parse("bencher.example.com/my-project:v1").unwrap();
+        ref_.validate_registry("bencher.example.com", Some(8443))
+            .unwrap();
     }
 
     #[test]
     fn validate_registry_unsupported() {
         // Images from an external registry are rejected
         let ref_ = ImageReference::parse("ghcr.io/owner/repo:v1").unwrap();
-        let err = ref_.validate_registry("registry.bencher.dev").unwrap_err();
+        let err = ref_
+            .validate_registry("registry.bencher.dev", Some(443))
+            .unwrap_err();
         let msg = err.to_string();
         assert!(
             msg.contains("ghcr.io"),
@@ -364,9 +465,18 @@ mod tests {
     }
 
     #[test]
+    fn validate_registry_wrong_port_unsupported() {
+        // The right host on the wrong port is rejected
+        let ref_ = ImageReference::parse("registry.bencher.dev:8080/owner/repo:v1").unwrap();
+        ref_.validate_registry("registry.bencher.dev", Some(443))
+            .unwrap_err();
+    }
+
+    #[test]
     fn validate_registry_user_image_ok() {
         // user/image format defaults to docker.io, which is allowed
         let ref_ = ImageReference::parse("myuser/myimage:v1").unwrap();
-        ref_.validate_registry("registry.bencher.dev").unwrap();
+        ref_.validate_registry("registry.bencher.dev", Some(443))
+            .unwrap();
     }
 }

--- a/services/cli/src/bencher/sub/run/error.rs
+++ b/services/cli/src/bencher/sub/run/error.rs
@@ -13,7 +13,7 @@ pub enum RunError {
     CiOnTheFly,
 
     #[error(
-        "A project-scoped API key (`bencher_run_*`) requires `--project`/`BENCHER_PROJECT`. The key is scoped to a single existing project and cannot auto-create one. Use a user-scoped API key (`bencher_user_*`) or a user JWT token to create projects on the fly."
+        "A project-scoped API key (`bencher_run_*`) requires `--project`/`BENCHER_PROJECT` or an `--image` named after the project (`[{{registry}}/]{{project}}:{{tag}}`). The key is scoped to a single existing project and cannot auto-create one. Use a user-scoped API key (`bencher_user_*`) or a user JWT token to create projects on the fly."
     )]
     ProjectKeyRequiresProject,
 

--- a/services/cli/src/bencher/sub/run/mod.rs
+++ b/services/cli/src/bencher/sub/run/mod.rs
@@ -10,8 +10,7 @@ use bencher_comment::ReportComment;
 #[cfg(feature = "plus")]
 use bencher_json::SpecResourceId;
 use bencher_json::{
-    BencherKey, DateTime, JsonReport, ProjectResourceId, RunContext, TestbedNameId,
-    project::report::Iteration,
+    DateTime, JsonReport, ProjectResourceId, RunContext, TestbedNameId, project::report::Iteration,
 };
 
 use crate::{
@@ -33,7 +32,7 @@ use branch::Branch;
 use ci::Ci;
 pub use error::RunError;
 use format::Format;
-use project::map_project;
+use project::resolve_project;
 use runner::Runner;
 use sub_adapter::SubAdapter;
 
@@ -171,16 +170,20 @@ impl TryFrom<CliRun> for Run {
         #[cfg(not(feature = "plus"))]
         let runner = Some(cmd.try_into()?);
 
-        // Project-scoped keys (`bencher_run_*`) are bound to a single existing
-        // project at issue time and cannot perform slug auto-creation, so a
-        // `--project` is mandatory whenever `--key` is one of them. User-scoped
-        // keys (`bencher_user_*`) and JWT tokens have no such restriction.
-        if backend.key.as_ref().is_some_and(BencherKey::is_project) && project.project.is_none() {
-            return Err(RunError::ProjectKeyRequiresProject.into());
-        }
+        // The server derives the target project from the job image repository
+        // (`[{registry}/]{project}:{tag}`) when `--project` is not specified.
+        // Mirror that derivation here to relax the `--project` requirements.
+        #[cfg(feature = "plus")]
+        let has_image_project = job.as_ref().is_some_and(|job| {
+            job.image
+                .project_repository()
+                .is_some_and(|repository| repository.parse::<ProjectResourceId>().is_ok())
+        });
+        #[cfg(not(feature = "plus"))]
+        let has_image_project = false;
 
         Ok(Self {
-            project: map_project(project)?,
+            project: resolve_project(project, backend.key.as_ref(), has_image_project)?,
             branch: branch.try_into().map_err(RunError::Branch)?,
             testbed,
             #[cfg(feature = "plus")]
@@ -607,4 +610,92 @@ fn run_sender(
         let json_new_run = json_new_run.clone();
         Box::pin(async move { client.run_post().body(json_new_run.clone()).send().await })
     })
+}
+
+#[cfg(test)]
+mod tests {
+    mod project_key {
+        use clap::Parser as _;
+
+        use super::super::Run;
+        use crate::CliError;
+        use crate::bencher::sub::RunError;
+        use crate::parser::run::CliRun;
+
+        const PROJECT_KEY: &str = "bencher_run_aB3xY9mN2pQ7rS4tU8vW1zK5jL0fGh";
+
+        fn parse_run(args: &[&str]) -> CliRun {
+            CliRun::try_parse_from(std::iter::once("run").chain(args.iter().copied()))
+                .expect("Failed to parse args")
+        }
+
+        #[test]
+        fn without_project_errors() {
+            let result = Run::try_from(parse_run(&["--key", PROJECT_KEY, "bencher", "mock"]));
+            assert!(
+                matches!(
+                    result,
+                    Err(CliError::Run(RunError::ProjectKeyRequiresProject))
+                ),
+                "{result:?}"
+            );
+        }
+
+        #[test]
+        fn with_project() {
+            Run::try_from(parse_run(&[
+                "--key",
+                PROJECT_KEY,
+                "--project",
+                "my-project",
+                "bencher",
+                "mock",
+            ]))
+            .expect("project key with `--project` should be accepted");
+        }
+
+        #[cfg(feature = "plus")]
+        #[test]
+        fn with_qualified_image_project() {
+            Run::try_from(parse_run(&[
+                "--key",
+                PROJECT_KEY,
+                "--image",
+                "localhost/my-project:v1",
+            ]))
+            .expect("project key with an image-derived project should be accepted");
+        }
+
+        #[cfg(feature = "plus")]
+        #[test]
+        fn with_unqualified_image_project() {
+            Run::try_from(parse_run(&[
+                "--key",
+                PROJECT_KEY,
+                "--image",
+                "my-project:v1",
+            ]))
+            .expect("project key with an image-derived project should be accepted");
+        }
+
+        #[cfg(feature = "plus")]
+        #[test]
+        fn with_image_without_project_repository_errors() {
+            // Multi-segment repositories (`{user}/{image}`) are not supported
+            // by the Bencher registry, so no project can be derived
+            let result = Run::try_from(parse_run(&[
+                "--key",
+                PROJECT_KEY,
+                "--image",
+                "ghcr.io/owner/repo:v1",
+            ]));
+            assert!(
+                matches!(
+                    result,
+                    Err(CliError::Run(RunError::ProjectKeyRequiresProject))
+                ),
+                "{result:?}"
+            );
+        }
+    }
 }

--- a/services/cli/src/bencher/sub/run/project.rs
+++ b/services/cli/src/bencher/sub/run/project.rs
@@ -1,13 +1,88 @@
-use bencher_json::ProjectResourceId;
+use bencher_json::{BencherKey, ProjectResourceId};
 
 use crate::{RunError, parser::run::CliRunProject};
 
-pub fn map_project(run_project: CliRunProject) -> Result<Option<ProjectResourceId>, RunError> {
+pub fn resolve_project(
+    run_project: CliRunProject,
+    key: Option<&BencherKey>,
+    has_image_project: bool,
+) -> Result<Option<ProjectResourceId>, RunError> {
+    // Project-scoped keys (`bencher_run_*`) are bound to a single existing
+    // project at issue time and cannot perform slug auto-creation, so a
+    // `--project` is mandatory whenever `--key` is one of them, unless the
+    // project can be derived from the job image (`--image`). User-scoped
+    // keys (`bencher_user_*`) and JWT tokens have no such restriction.
+    if key.is_some_and(BencherKey::is_project)
+        && run_project.project.is_none()
+        && !has_image_project
+    {
+        return Err(RunError::ProjectKeyRequiresProject);
+    }
+
+    let is_ci = std::env::var("CI").unwrap_or_default() == "true";
+    map_project(run_project, has_image_project, is_ci)
+}
+
+fn map_project(
+    run_project: CliRunProject,
+    has_image_project: bool,
+    is_ci: bool,
+) -> Result<Option<ProjectResourceId>, RunError> {
     if let Some(project_id) = run_project.project {
         Ok(Some(project_id))
-    } else if std::env::var("CI").unwrap_or_default() == "true" && !run_project.ci_on_the_fly {
+    } else if has_image_project {
+        // The server derives the project from the job image repository,
+        // so there is no risk of on-the-fly project creation in CI
+        Ok(None)
+    } else if is_ci && !run_project.ci_on_the_fly {
         Err(RunError::CiOnTheFly)
     } else {
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CliRunProject, RunError, map_project};
+
+    fn run_project(project: Option<&str>, ci_on_the_fly: bool) -> CliRunProject {
+        CliRunProject {
+            project: project.map(|project| project.parse().expect("Invalid project")),
+            ci_on_the_fly,
+        }
+    }
+
+    #[test]
+    fn explicit_project() {
+        let project = map_project(run_project(Some("my-project"), false), false, true)
+            .expect("Explicit project should always be accepted");
+        assert!(project.is_some());
+    }
+
+    #[test]
+    fn no_project_not_ci() {
+        let project = map_project(run_project(None, false), false, false)
+            .expect("On-the-fly project should be accepted outside of CI");
+        assert!(project.is_none());
+    }
+
+    #[test]
+    fn no_project_ci_errors() {
+        let result = map_project(run_project(None, false), false, true);
+        assert!(matches!(result, Err(RunError::CiOnTheFly)), "{result:?}");
+    }
+
+    #[test]
+    fn no_project_ci_on_the_fly() {
+        let project = map_project(run_project(None, true), false, true)
+            .expect("`--ci-on-the-fly` should allow an on-the-fly project in CI");
+        assert!(project.is_none());
+    }
+
+    #[test]
+    fn image_project_ci() {
+        let project = map_project(run_project(None, false), true, true)
+            .expect("An image-derived project should be accepted in CI");
+        assert!(project.is_none());
     }
 }

--- a/services/cli/src/parser/run.rs
+++ b/services/cli/src/parser/run.rs
@@ -14,7 +14,8 @@ use super::project::report::{
     CliReportAdapter, CliReportAverage, CliReportFold, CliReportThresholds,
 };
 
-// `--key` requires `--project` only for project-scoped keys (`bencher_run_*`).
+// `--key` requires `--project` only for project-scoped keys (`bencher_run_*`)
+// without an `--image` named after the project to derive the project from.
 // User-scoped keys (`bencher_user_*`) authenticate as the owning user and can
 // auto-create a project on the fly just like a JWT. Because clap groups can't
 // inspect the parsed value, this constraint is enforced at runtime in the

--- a/tasks/test_api/src/task/plus/runner.rs
+++ b/tasks/test_api/src/task/plus/runner.rs
@@ -69,6 +69,7 @@ impl RunnerTest {
                 "no-sandbox-spec"
             };
             run_runner_test(&self.url, &self.username, &self.token, spec)?;
+            run_image_project_runner_test(&self.url, &self.token, spec)?;
             run_user_key_runner_test(&self.url, &self.username, &self.token, spec)?;
             run_project_key_runner_test(&self.url, &self.admin_token, spec)
         }
@@ -243,8 +244,15 @@ impl RunnerTest {
             Ok(())
         };
 
+        // Run the image-derived project runner test
+        let image_project_result = if result.is_ok() {
+            run_image_project_runner_test(&self.url, &self.token, spec)
+        } else {
+            Ok(())
+        };
+
         // Run the no-sandbox runner test
-        let no_sandbox_result = if result.is_ok() {
+        let no_sandbox_result = if image_project_result.is_ok() {
             run_no_sandbox_runner_test(&self.url, &self.token)
         } else {
             Ok(())
@@ -290,6 +298,7 @@ impl RunnerTest {
 
         unclaimed_result?;
         result?;
+        image_project_result?;
         no_sandbox_result?;
         detach_result?;
         user_key_result?;
@@ -406,6 +415,68 @@ pub fn run_runner_test(url: &Url, username: &str, token: &Jwt, spec: &str) -> an
     assert!(json.job.is_some(), "Expected job UUID in report: {json:?}");
 
     println!("Runner smoke test passed!");
+    Ok(())
+}
+
+/// Run the image-derived project runner smoke test variant.
+///
+/// Similar to `run_runner_test` but omits `--project`:
+/// the project is derived from the unqualified image repository.
+/// The project key variant covers the registry-qualified form.
+#[expect(clippy::panic_in_result_fn, reason = "test harness")]
+fn run_image_project_runner_test(url: &Url, token: &Jwt, spec: &str) -> anyhow::Result<()> {
+    let host = url.as_ref();
+
+    println!("Running image-derived project runner smoke test against: {host}");
+
+    // The image should already be pushed from the first test
+    println!("Submitting job via bencher run --image without --project...");
+    let image_ref = format!("{PROJECT_SLUG}:{IMAGE_TAG}");
+    let mut cmd = Command::cargo_bin(BENCHER_CMD)?;
+    let args = [
+        "run",
+        HOST_ARG,
+        host,
+        TOKEN_ARG,
+        token.as_ref(),
+        "--branch",
+        "master",
+        "--testbed",
+        "base",
+        "--image",
+        &image_ref,
+        "--spec",
+        spec,
+        "--format",
+        "json",
+        "--quiet",
+        "--job-timeout",
+        "120",
+        "--job-poll-interval",
+        "1",
+        "--exec",
+        "mock",
+    ];
+    cmd.args(args).current_dir(CLI_DIR);
+    let output = cmd.output()?;
+    anyhow::ensure!(
+        output.status.success(),
+        "bencher run without --project failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    println!("Verifying results...");
+    let json: bencher_json::JsonReport = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(
+        json.project.slug.to_string(),
+        PROJECT_SLUG,
+        "Project should be derived from the image repository"
+    );
+    #[cfg(feature = "plus")]
+    assert!(json.job.is_some(), "Expected job UUID in report: {json:?}");
+
+    println!("Image-derived project runner smoke test passed!");
     Ok(())
 }
 
@@ -686,8 +757,13 @@ fn run_user_key_runner_test(url: &Url, email: &str, token: &Jwt, spec: &str) -> 
 /// Run the runner smoke test with project key authentication.
 ///
 /// Creates a project key, logs into Docker with the project slug as username
-/// and the key as password, pushes the image, and submits a job via `bencher run --key`.
-#[expect(clippy::panic_in_result_fn, reason = "test harness")]
+/// and the key as password, pushes the image, and submits a job via `bencher run --key`,
+/// both with an explicit `--project` and with an image-derived project.
+#[expect(
+    clippy::panic_in_result_fn,
+    clippy::too_many_lines,
+    reason = "test harness"
+)]
 fn run_project_key_runner_test(url: &Url, admin_token: &Jwt, spec: &str) -> anyhow::Result<()> {
     let host = url.as_ref();
 
@@ -780,6 +856,62 @@ fn run_project_key_runner_test(url: &Url, admin_token: &Jwt, spec: &str) -> anyh
     println!("Step 5: Verifying results...");
     let json: bencher_json::JsonReport = serde_json::from_slice(&output.stdout)?;
     assert_eq!(json.project.slug.to_string(), PROJECT_SLUG);
+    #[cfg(feature = "plus")]
+    assert!(
+        json.job.is_some(),
+        "Expected job UUID in project key report: {json:?}"
+    );
+
+    // Step 6: Submit a job without `--project`:
+    // the project is derived from the registry-qualified image repository
+    // and verified against the project key. The image uses the same registry
+    // reference it was pushed to (with its port locally, e.g.
+    // `localhost:61016/...`; the bare host on the deployed registries, e.g.
+    // `dev.registry.bencher.dev/...`).
+    println!("Step 6: Submitting job via bencher run --key without --project...");
+    let image_ref = format!("{registry}/{PROJECT_SLUG}:{IMAGE_TAG}");
+    let mut cmd = Command::cargo_bin(BENCHER_CMD)?;
+    cmd.args([
+        "run",
+        HOST_ARG,
+        host,
+        KEY_ARG,
+        project_key.as_ref(),
+        "--branch",
+        "master",
+        "--testbed",
+        "base",
+        "--image",
+        &image_ref,
+        "--spec",
+        spec,
+        "--format",
+        "json",
+        "--quiet",
+        "--job-timeout",
+        "120",
+        "--job-poll-interval",
+        "1",
+        "--exec",
+        "mock",
+    ])
+    .current_dir(CLI_DIR);
+    let output = cmd.output()?;
+    anyhow::ensure!(
+        output.status.success(),
+        "bencher run --key without --project failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Step 7: Verify the results
+    println!("Step 7: Verifying results...");
+    let json: bencher_json::JsonReport = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(
+        json.project.slug.to_string(),
+        PROJECT_SLUG,
+        "Project should be derived from the image repository"
+    );
     #[cfg(feature = "plus")]
     assert!(
         json.job.is_some(),


### PR DESCRIPTION
This changeset moves to allowing `--project` to not be specified when `--image` is used because the image always contains the project resource ID.