### PR TITLE
Install aws-lc-rs crypto provider in update_sandbox task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8814,6 +8814,7 @@ dependencies = [
  "camino",
  "clap",
  "hex",
+ "rustls",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/tasks/update_sandbox/Cargo.toml
+++ b/tasks/update_sandbox/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 anyhow.workspace = true
 camino.workspace = true
 clap.workspace = true
+rustls.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 hex.workspace = true

--- a/tasks/update_sandbox/src/main.rs
+++ b/tasks/update_sandbox/src/main.rs
@@ -6,6 +6,12 @@ mod task;
 use task::Task;
 
 fn main() -> anyhow::Result<()> {
+    use rustls::crypto::aws_lc_rs;
+
+    aws_lc_rs::default_provider()
+        .install_default()
+        .map_err(|_err| anyhow::anyhow!("Failed to install default TLS crypto provider"))?;
+
     let task = Task::new()?;
     task.exec()
 }


### PR DESCRIPTION
## Problem

The scheduled [Update Sandbox](https://github.com/bencherdev/bencher/actions/runs/27016395122/job/79732425410) job fails at startup:

```
thread 'main' panicked at ureq-3.3.0/src/tls/rustls.rs:154:9:
No CryptoProvider for Rustls. Either enable feature `rustls`, or set process
default using CryptoProvider::set_default(), or configure
TlsConfig::rustls_crypto_provider()
```

## Root cause

The `update_sandbox` task makes HTTPS requests via `ureq`, which the workspace configures with the `rustls-no-provider` feature. That feature deliberately ships no default crypto provider, so each binary must install a process-default rustls `CryptoProvider` before its first TLS request.

#866 switched the workspace TLS backend from `ring` to `aws-lc-rs` but missed this binary, so its first HTTPS call (fetching the latest Firecracker/kernel releases) panics.

## Fix

Install the `aws-lc-rs` default provider at the top of `main`, matching the pattern already used by `api`, `cli`, `runner`, `test_netlify`, and `xtask`.

## Verification

- `cargo build -p update_sandbox`
- `cargo clippy --no-deps -p update_sandbox --all-targets --all-features -- -Dwarnings`
- `cargo fmt -p update_sandbox --check`
- `./target/debug/update_sandbox --dry-run` now completes the TLS requests instead of panicking:
  ```
  [dry run] Update kernel 6.1.168 -> 6.1.172
  ```

## Audit

Checked every `tasks/*` binary (and `xtask`) for the same missing-provider issue. `update_sandbox` was the only one affected:

- `test_netlify` and `xtask` make TLS calls and already install the provider (xtask's install is gated behind the same `plus` feature as its `reqwest` dependency).
- `runner_ops` / `test_api` shell out to subprocesses (`gh`, `ssh`, the `bencher` CLI) — no in-process TLS.
- `gen_pkg` / `gen_types` only introspect the CLI/API to emit manpages/OpenAPI — no TLS calls.
- `bin_version`, `gen_installer`, `gen_notes`, `test_runner` have no TLS client.
