### PR TITLE
Fix cargo-deny advisories: upgrade diesel, ignore proc-macro-error2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2725,9 +2725,9 @@ checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "diesel"
-version = "2.3.9"
+version = "2.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9940fb8467a0a06312218ed384185cb8536aa10d8ec017d0ce7fad2c1bd882d5"
+checksum = "29fe29a87fb84c631ffb3ba21798c4b1f3a964701ba78f0dce4bf8668562ec88"
 dependencies = [
  "chrono",
  "diesel_derives",
@@ -7847,7 +7847,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/deny.toml
+++ b/deny.toml
@@ -25,18 +25,8 @@ ignore = [
     "RUSTSEC-2024-0436",
     # https://rustsec.org/advisories/RUSTSEC-2025-0134.html
     "RUSTSEC-2025-0134",
-    # https://rustsec.org/advisories/RUSTSEC-2026-0049.html
-    "RUSTSEC-2026-0049",
-    # https://rustsec.org/advisories/RUSTSEC-2026-0098.html
-    "RUSTSEC-2026-0098",
-    # https://rustsec.org/advisories/RUSTSEC-2026-0099.html
-    "RUSTSEC-2026-0099",
-    # https://rustsec.org/advisories/RUSTSEC-2026-0104.html
-    "RUSTSEC-2026-0104",
-    # https://rustsec.org/advisories/RUSTSEC-2026-0118.html
-    "RUSTSEC-2026-0118",
-    # https://rustsec.org/advisories/RUSTSEC-2026-0119.html
-    "RUSTSEC-2026-0119",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0173.html
+    "RUSTSEC-2026-0173",
 ]
 
 [bans]


### PR DESCRIPTION
## Summary

The **Cargo Deny Advisories** CI job is failing on `devel` due to two newly published RustSec advisories detected as errors.

- **RUSTSEC-2026-0172** (unsound) — `diesel 2.3.9` use-after-free in `SqliteConnection::deserialize_readonly_database`. Fixed by upgrading to `diesel 2.3.10` (`Cargo.lock` only; the workspace `"2.3"` requirement already permits it).
- **RUSTSEC-2026-0173** (unmaintained) — `proc-macro-error2`, a build-time proc-macro pulled in transitively via `tabled_derive 0.11.0`. The latest `tabled` (`0.21.0`) still requires `tabled_derive ^0.11`, which still depends on it, so there is no upgrade path that removes it. Added to the `deny.toml` ignore list.

Also removes six stale ignore entries that no longer match any crate (`RUSTSEC-2026-0049/0098/0099/0104/0118/0119`), which were emitting `advisory-not-detected` warnings.

## Verification

- `cargo deny --locked check` → `advisories ok, bans ok, licenses ok, sources ok`
- `cargo build --locked` → clean
- `cargo nextest run` and `cargo test --doc` → pass
