### PR TITLE
Migrate dogfooding to --key and deprecate remaining user token endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
       is-fork: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
       build-cli: ${{ needs.changes.outputs.cli == 'true' || github.ref == 'refs/heads/devel' || startsWith(github.ref, 'refs/tags/') }}
     secrets:
-      BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+      BENCHER_API_KEY: ${{ secrets.BENCHER_API_KEY }}
 
   runner:
     name: Runner
@@ -143,8 +143,7 @@ jobs:
       is-fork: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
     secrets:
       TEST_BILLING_KEY: ${{ secrets.TEST_BILLING_KEY }}
-      BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
-      BENCHER_USER_EMAIL: ${{ secrets.BENCHER_USER_EMAIL }}
+      BENCHER_API_KEY: ${{ secrets.BENCHER_API_KEY }}
 
   build:
     name: Build

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -28,10 +28,11 @@ on:
         type: boolean
         required: true
     secrets:
-      BENCHER_API_TOKEN:
+      BENCHER_API_KEY:
         required: true
 
 env:
+  BENCHER_PROJECT: bencher
   CARGO_TERM_COLOR: always
   CLI_BIN_NAME: bencher
 
@@ -47,7 +48,7 @@ jobs:
     steps:
       - uses: bencherdev/bencher@main # zizmor: ignore[unpinned-uses] first-party action; intentionally tracks @main to exercise the latest released CLI
       - name: Run Bencher CLI
-        run: bencher run --project bencher --token ${{ secrets.BENCHER_API_TOKEN }} --dry-run "bencher mock"
+        run: bencher run --project ${{ env.BENCHER_PROJECT }} --key ${{ secrets.BENCHER_API_KEY }} --dry-run "bencher mock"
 
   action_devel:
     name: Action `devel`
@@ -62,7 +63,7 @@ jobs:
     steps:
       - uses: bencherdev/bencher@devel # zizmor: ignore[unpinned-uses] first-party action; intentionally tracks @devel to exercise the unreleased CLI
       - name: Run Bencher CLI
-        run: bencher run --project bencher --token ${{ secrets.BENCHER_API_TOKEN }} --dry-run "bencher mock"
+        run: bencher run --project ${{ env.BENCHER_PROJECT }} --key ${{ secrets.BENCHER_API_KEY }} --dry-run "bencher mock"
 
   script_cloud:
     name: Script Cloud
@@ -80,7 +81,7 @@ jobs:
         if: matrix.os == 'windows-2022'
         run: powershell -c "irm https://bencher.dev/download/install-cli.ps1 | iex"
       - name: Run Bencher CLI
-        run: bencher run --project bencher --token ${{ secrets.BENCHER_API_TOKEN }} --dry-run "bencher mock"
+        run: bencher run --project ${{ env.BENCHER_PROJECT }} --key ${{ secrets.BENCHER_API_KEY }} --dry-run "bencher mock"
 
   script_gen:
     name: Script Gen
@@ -103,7 +104,7 @@ jobs:
         if: matrix.os == 'windows-2022'
         run: powershell -c "gc -Raw services/cli/templates/output/install-cli.ps1 | iex"
       - name: Run Bencher CLI
-        run: bencher run --project bencher --token ${{ secrets.BENCHER_API_TOKEN }} --dry-run "bencher mock"
+        run: bencher run --project ${{ env.BENCHER_PROJECT }} --key ${{ secrets.BENCHER_API_KEY }} --dry-run "bencher mock"
 
   script_gen_version:
     name: Script Gen Version
@@ -130,7 +131,7 @@ jobs:
           BENCHER_VERSION: ${{ inputs.bencher-version }}
         run: powershell -c "gc -Raw services/cli/templates/output/install-cli.ps1 | iex"
       - name: Run Bencher CLI
-        run: bencher run --project bencher --token ${{ secrets.BENCHER_API_TOKEN }} --dry-run "bencher mock"
+        run: bencher run --project ${{ env.BENCHER_PROJECT }} --key ${{ secrets.BENCHER_API_KEY }} --dry-run "bencher mock"
 
   cargo_main:
     name: Cargo `main`
@@ -146,7 +147,7 @@ jobs:
       - name: Cargo CLI Install main
         run: cargo install --git https://github.com/bencherdev/bencher --branch main --locked bencher_cli
       - name: Run Bencher CLI
-        run: bencher run --project bencher --token ${{ secrets.BENCHER_API_TOKEN }} --dry-run "bencher mock"
+        run: bencher run --project ${{ env.BENCHER_PROJECT }} --key ${{ secrets.BENCHER_API_KEY }} --dry-run "bencher mock"
 
   cargo_devel:
     name: Cargo `devel`
@@ -162,7 +163,7 @@ jobs:
       - name: Cargo CLI Install devel
         run: cargo install --git https://github.com/bencherdev/bencher --branch devel --locked bencher_cli
       - name: Run Bencher CLI
-        run: bencher run --project bencher --token ${{ secrets.BENCHER_API_TOKEN }} --dry-run "bencher mock"
+        run: bencher run --project ${{ env.BENCHER_PROJECT }} --key ${{ secrets.BENCHER_API_KEY }} --dry-run "bencher mock"
 
   build_cli:
     name: Build CLI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,7 @@ on:
     secrets:
       TEST_BILLING_KEY:
         required: true
-      BENCHER_API_TOKEN:
-        required: true
-      BENCHER_USER_EMAIL:
+      BENCHER_API_KEY:
         required: true
 
 env:
@@ -202,8 +200,7 @@ jobs:
     needs: [bench_image, bencher_noise]
     uses: ./.github/workflows/track_benchmarks.yml
     secrets:
-      BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
-      BENCHER_USER_EMAIL: ${{ secrets.BENCHER_USER_EMAIL }}
+      BENCHER_API_KEY: ${{ secrets.BENCHER_API_KEY }}
 
   cargo_udeps:
     name: Cargo Unused Deps

--- a/.github/workflows/track_benchmarks.yml
+++ b/.github/workflows/track_benchmarks.yml
@@ -3,10 +3,13 @@ name: Track Benchmarks
 on:
   workflow_call:
     secrets:
-      BENCHER_API_TOKEN:
+      BENCHER_API_KEY:
         required: true
-      BENCHER_USER_EMAIL:
-        required: true
+
+env:
+  # The Bencher project slug. For a project-scoped API key (`bencher_run_*`) this
+  # is also the `docker login` username for the OCI registry. Replace with your own.
+  BENCHER_PROJECT: bencher
 
 jobs:
   track_benchmarks:
@@ -35,14 +38,14 @@ jobs:
         run: |
           docker load -i bench_image.tar
           docker tag bench:ci registry.bencher.dev/bencher:${{ github.sha }}
-          echo '${{ secrets.BENCHER_API_TOKEN }}' | docker login registry.bencher.dev -u '${{ secrets.BENCHER_USER_EMAIL }}' --password-stdin
+          echo '${{ secrets.BENCHER_API_KEY }}' | docker login registry.bencher.dev -u "$BENCHER_PROJECT" --password-stdin
           docker push registry.bencher.dev/bencher:${{ github.sha }}
       - uses: bencherdev/bencher@main # zizmor: ignore[unpinned-uses] first-party action; intentionally tracks @main to exercise the latest released CLI
       - name: Track Noise (ubuntu)
         run: |
           bencher run \
-          --project bencher \
-          --token '${{ secrets.BENCHER_API_TOKEN }}' \
+          --project "$BENCHER_PROJECT" \
+          --key '${{ secrets.BENCHER_API_KEY }}' \
           --branch ${GITHUB_REF_NAME} \
           --hash '${{ github.sha }}' \
           --testbed ubuntu-22.04 \
@@ -58,8 +61,8 @@ jobs:
       - name: Track Noise (macos)
         run: |
           bencher run \
-          --project bencher \
-          --token '${{ secrets.BENCHER_API_TOKEN }}' \
+          --project "$BENCHER_PROJECT" \
+          --key '${{ secrets.BENCHER_API_KEY }}' \
           --branch ${GITHUB_REF_NAME} \
           --hash '${{ github.sha }}' \
           --testbed macos-14 \
@@ -75,8 +78,8 @@ jobs:
       - name: Track Noise (windows)
         run: |
           bencher run \
-          --project bencher \
-          --token '${{ secrets.BENCHER_API_TOKEN }}' \
+          --project "$BENCHER_PROJECT" \
+          --key '${{ secrets.BENCHER_API_KEY }}' \
           --branch ${GITHUB_REF_NAME} \
           --hash '${{ github.sha }}' \
           --testbed windows-2022 \
@@ -92,8 +95,8 @@ jobs:
       - name: Track benchmarks with Bencher
         run: |
           bencher run \
-          --project bencher \
-          --token '${{ secrets.BENCHER_API_TOKEN }}' \
+          --project "$BENCHER_PROJECT" \
+          --key '${{ secrets.BENCHER_API_KEY }}' \
           --image "bencher:${{ github.sha }}" \
           --branch ${GITHUB_REF_NAME} \
           --hash '${{ github.sha }}' \

--- a/.github/workflows/track_pr_benchmarks.yml
+++ b/.github/workflows/track_pr_benchmarks.yml
@@ -5,6 +5,11 @@ on:
     workflows: [CI]
     types: [completed]
 
+env:
+  # The Bencher project slug. For a project-scoped API key (`bencher_run_*`) this
+  # is also the `docker login` username for the OCI registry. Replace with your own.
+  BENCHER_PROJECT: bencher
+
 jobs:
   track_pr_benchmarks:
     name: Track PR Benchmarks with Bencher
@@ -36,7 +41,7 @@ jobs:
         run: |
           docker load -i bench_image.tar
           docker tag bench:ci registry.bencher.dev/bencher:${GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA}
-          echo '${{ secrets.BENCHER_API_TOKEN }}' | docker login registry.bencher.dev -u '${{ secrets.BENCHER_USER_EMAIL }}' --password-stdin
+          echo '${{ secrets.BENCHER_API_KEY }}' | docker login registry.bencher.dev -u "$BENCHER_PROJECT" --password-stdin
           docker push registry.bencher.dev/bencher:${GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA}
       - name: Read PR Event Data
         if: steps.download_bench.outcome == 'success'
@@ -55,12 +60,12 @@ jobs:
       - name: Track Benchmarks with Bencher
         if: steps.download_bench.outcome == 'success'
         env:
-          BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+          BENCHER_API_KEY: ${{ secrets.BENCHER_API_KEY }}
           GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           bencher run \
-          --project bencher \
-          --token "$BENCHER_API_TOKEN" \
+          --project "$BENCHER_PROJECT" \
+          --key "$BENCHER_API_KEY" \
           --image "bencher:${GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA}" \
           --branch "$PR_HEAD" \
           --hash "$PR_HEAD_SHA" \

--- a/lib/api_users/src/tokens.rs
+++ b/lib/api_users/src/tokens.rs
@@ -70,6 +70,10 @@ pub async fn user_tokens_options(
 
 /// List tokens for a user
 ///
+/// DEPRECATED: User API tokens have been deprecated in favor of user API keys.
+/// This endpoint remains available to manage existing API tokens.
+/// Create a [user API key](https://bencher.dev/docs/explanation/bencher-run/#--key-key) instead.
+///
 /// List all API tokens for a user.
 /// Only the authenticated user themselves and server admins have access to this endpoint.
 /// By default, the tokens are sorted in alphabetical order by name.
@@ -77,7 +81,8 @@ pub async fn user_tokens_options(
 #[endpoint {
     method = GET,
     path =  "/v0/users/{user}/tokens",
-    tags = ["users", "tokens"]
+    tags = ["users", "tokens"],
+    deprecated = true,
 }]
 pub async fn user_tokens_get(
     rqctx: RequestContext<ApiContext>,
@@ -176,7 +181,7 @@ fn get_ls_query<'q>(
 ///
 /// DEPRECATED: User API tokens have been deprecated in favor of user API keys,
 /// so this endpoint always fails with a `403 Forbidden` error.
-/// Create a user API key instead: <https://bencher.dev/docs/explanation/bencher-run/#--key-key>
+/// Create a [user API key](https://bencher.dev/docs/explanation/bencher-run/#--key-key) instead.
 /// Existing API tokens continue to work and can still be viewed, updated, and revoked.
 #[endpoint {
     method = POST,
@@ -222,12 +227,17 @@ pub async fn user_token_options(
 
 /// View a token
 ///
+/// DEPRECATED: User API tokens have been deprecated in favor of user API keys.
+/// This endpoint remains available to manage existing API tokens.
+/// Create a [user API key](https://bencher.dev/docs/explanation/bencher-run/#--key-key) instead.
+///
 /// View an API token for a user.
 /// Only the authenticated user themselves and server admins have access to this endpoint.
 #[endpoint {
     method = GET,
     path =  "/v0/users/{user}/tokens/{token}",
-    tags = ["users", "tokens"]
+    tags = ["users", "tokens"],
+    deprecated = true,
 }]
 pub async fn user_token_get(
     rqctx: RequestContext<ApiContext>,
@@ -259,12 +269,17 @@ async fn get_one_inner(
 
 /// Update a token
 ///
+/// DEPRECATED: User API tokens have been deprecated in favor of user API keys.
+/// This endpoint remains available to manage existing API tokens.
+/// Create a [user API key](https://bencher.dev/docs/explanation/bencher-run/#--key-key) instead.
+///
 /// Update an API token for a user.
 /// Only the authenticated user themselves and server admins have access to this endpoint.
 #[endpoint {
     method = PATCH,
     path =  "/v0/users/{user}/tokens/{token}",
-    tags = ["users", "tokens"]
+    tags = ["users", "tokens"],
+    deprecated = true,
 }]
 pub async fn user_token_patch(
     rqctx: RequestContext<ApiContext>,
@@ -311,6 +326,10 @@ async fn patch_inner(
 
 /// Revoke a token
 ///
+/// DEPRECATED: User API tokens have been deprecated in favor of user API keys.
+/// This endpoint remains available to manage existing API tokens.
+/// Create a [user API key](https://bencher.dev/docs/explanation/bencher-run/#--key-key) instead.
+///
 /// Revoke an API token for a user.
 /// Revocation is terminal: a revoked token can no longer authenticate any request,
 /// and the revocation cannot be undone (for security — a leaked JWT must not become valid again).
@@ -318,7 +337,8 @@ async fn patch_inner(
 #[endpoint {
     method = DELETE,
     path =  "/v0/users/{user}/tokens/{token}",
-    tags = ["users", "tokens"]
+    tags = ["users", "tokens"],
+    deprecated = true,
 }]
 pub async fn user_token_delete(
     rqctx: RequestContext<ApiContext>,

--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -10525,7 +10525,7 @@
           "tokens"
         ],
         "summary": "List tokens for a user",
-        "description": "List all API tokens for a user. Only the authenticated user themselves and server admins have access to this endpoint. By default, the tokens are sorted in alphabetical order by name. The HTTP response header `X-Total-Count` contains the total number of tokens.",
+        "description": "DEPRECATED: User API tokens have been deprecated in favor of user API keys. This endpoint remains available to manage existing API tokens. Create a [user API key](https://bencher.dev/docs/explanation/bencher-run/#--key-key) instead.\n\nList all API tokens for a user. Only the authenticated user themselves and server admins have access to this endpoint. By default, the tokens are sorted in alphabetical order by name. The HTTP response header `X-Total-Count` contains the total number of tokens.",
         "operationId": "user_tokens_get",
         "parameters": [
           {
@@ -10655,7 +10655,8 @@
           "5XX": {
             "$ref": "#/components/responses/Error"
           }
-        }
+        },
+        "deprecated": true
       },
       "post": {
         "tags": [
@@ -10663,7 +10664,7 @@
           "tokens"
         ],
         "summary": "Create a token",
-        "description": "DEPRECATED: User API tokens have been deprecated in favor of user API keys, so this endpoint always fails with a `403 Forbidden` error. Create a user API key instead: <https://bencher.dev/docs/explanation/bencher-run/#--key-key> Existing API tokens continue to work and can still be viewed, updated, and revoked.",
+        "description": "DEPRECATED: User API tokens have been deprecated in favor of user API keys, so this endpoint always fails with a `403 Forbidden` error. Create a [user API key](https://bencher.dev/docs/explanation/bencher-run/#--key-key) instead. Existing API tokens continue to work and can still be viewed, updated, and revoked.",
         "operationId": "user_token_post",
         "parameters": [
           {
@@ -10751,7 +10752,7 @@
           "tokens"
         ],
         "summary": "View a token",
-        "description": "View an API token for a user. Only the authenticated user themselves and server admins have access to this endpoint.",
+        "description": "DEPRECATED: User API tokens have been deprecated in favor of user API keys. This endpoint remains available to manage existing API tokens. Create a [user API key](https://bencher.dev/docs/explanation/bencher-run/#--key-key) instead.\n\nView an API token for a user. Only the authenticated user themselves and server admins have access to this endpoint.",
         "operationId": "user_token_get",
         "parameters": [
           {
@@ -10828,7 +10829,8 @@
           "5XX": {
             "$ref": "#/components/responses/Error"
           }
-        }
+        },
+        "deprecated": true
       },
       "delete": {
         "tags": [
@@ -10836,7 +10838,7 @@
           "tokens"
         ],
         "summary": "Revoke a token",
-        "description": "Revoke an API token for a user. Revocation is terminal: a revoked token can no longer authenticate any request, and the revocation cannot be undone (for security — a leaked JWT must not become valid again). Only the authenticated user themselves and server admins have access to this endpoint.",
+        "description": "DEPRECATED: User API tokens have been deprecated in favor of user API keys. This endpoint remains available to manage existing API tokens. Create a [user API key](https://bencher.dev/docs/explanation/bencher-run/#--key-key) instead.\n\nRevoke an API token for a user. Revocation is terminal: a revoked token can no longer authenticate any request, and the revocation cannot be undone (for security — a leaked JWT must not become valid again). Only the authenticated user themselves and server admins have access to this endpoint.",
         "operationId": "user_token_delete",
         "parameters": [
           {
@@ -10906,7 +10908,8 @@
           "5XX": {
             "$ref": "#/components/responses/Error"
           }
-        }
+        },
+        "deprecated": true
       },
       "patch": {
         "tags": [
@@ -10914,7 +10917,7 @@
           "tokens"
         ],
         "summary": "Update a token",
-        "description": "Update an API token for a user. Only the authenticated user themselves and server admins have access to this endpoint.",
+        "description": "DEPRECATED: User API tokens have been deprecated in favor of user API keys. This endpoint remains available to manage existing API tokens. Create a [user API key](https://bencher.dev/docs/explanation/bencher-run/#--key-key) instead.\n\nUpdate an API token for a user. Only the authenticated user themselves and server admins have access to this endpoint.",
         "operationId": "user_token_patch",
         "parameters": [
           {
@@ -11001,7 +11004,8 @@
           "5XX": {
             "$ref": "#/components/responses/Error"
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/v2": {

--- a/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
+++ b/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
@@ -1,3 +1,6 @@
+## Pending `v0.6.8`
+- Mark the remaining user API token REST endpoints (list, view, update, and revoke) as deprecated in the OpenAPI spec and API docs; they continue to work for existing tokens
+
 ## `v0.6.7`
 - Fix the OCI registry token endpoint for the Docker 29+ containerd image store, which sends multiple `scope` query parameters and an `OAuth2` POST token exchange (Thank you [@travishathaway](https://github.com/travishathaway))
 - Add user-scoped API keys (`bencher_user_...`) that authenticate as the owning user across every endpoint a JWT can reach, including `docker login`; the one exception is key management: a user API key cannot create more keys and can only see, update, or revoke itself, so a leaked key cannot mint credentials that outlive its own revocation, tamper with the user's other keys, or enumerate them

--- a/services/console/src/components/docs/api/Operation.astro
+++ b/services/console/src/components/docs/api/Operation.astro
@@ -24,6 +24,42 @@ const { path, method, headers, cli, index } = Astro.props;
 const operation = openapi?.paths?.[path]?.[method];
 const id = slugify(`${method}-${path}`, { lower: true, strict: true });
 const methodClass = new Method(method);
+
+// Render an OpenAPI description: split into paragraphs on blank lines, and within
+// each paragraph render markdown links `[text](url)` as real anchors. Everything
+// else renders as plain text, so link-free descriptions are unchanged.
+type InlineSegment =
+	| { kind: "text"; value: string }
+	| { kind: "link"; text: string; href: string };
+
+const parseInline = (paragraph: string): InlineSegment[] => {
+	const segments: InlineSegment[] = [];
+	const linkPattern = /\[([^\]]+)\]\(([^)]+)\)/g;
+	let lastIndex = 0;
+	let match: RegExpExecArray | null = linkPattern.exec(paragraph);
+	while (match !== null) {
+		if (match.index > lastIndex) {
+			segments.push({
+				kind: "text",
+				value: paragraph.slice(lastIndex, match.index),
+			});
+		}
+		segments.push({ kind: "link", text: match[1] ?? "", href: match[2] ?? "" });
+		lastIndex = linkPattern.lastIndex;
+		match = linkPattern.exec(paragraph);
+	}
+	if (lastIndex < paragraph.length) {
+		segments.push({ kind: "text", value: paragraph.slice(lastIndex) });
+	}
+	return segments;
+};
+
+const description: string = operation?.description ?? "";
+const descriptionParagraphs = description
+	.split(/\n\n+/)
+	.map((paragraph) => paragraph.trim())
+	.filter((paragraph) => paragraph.length > 0)
+	.map(parseInline);
 ---
 
 <h2 id={id} class="title is-4" style={index > 0 ? "margin-top: 6rem;" : ""}>
@@ -38,7 +74,15 @@ const methodClass = new Method(method);
 </blockquote>
 <div class="columns">
   <div class="column">
-    <p>{operation?.description}</p>
+    {descriptionParagraphs.map((paragraph) => (
+      <p>{paragraph.map((segment) =>
+        segment.kind === "link" ? (
+          <a href={segment.href}>{segment.text}</a>
+        ) : (
+          segment.value
+        ),
+      )}</p>
+    ))}
     <Headers headers={headers} />
     <PathParameters parameters={operation?.parameters} />
     <QueryParameters path={path} parameters={operation?.parameters} />

--- a/services/console/src/content/docs-explanation/de/bencher-run.mdx
+++ b/services/console/src/content/docs-explanation/de/bencher-run.mdx
@@ -3,7 +3,7 @@ title: "bencher run"
 description: "Überblick über das bencher run CLI-Unterkommando und alle seine Flags, Argumente und Funktionen"
 heading: "`bencher run` CLI-Unterbefehl"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-06-15T00:00:00Z"
+modified: "2026-06-16T00:00:00Z"
 sortOrder: 3
 ---
 
@@ -12,8 +12,8 @@ import Cmd from "../../../chunks/docs-explanation/bencher-run/cmd.mdx";
 import BenchmarkCommand from "../../../chunks/docs-explanation/bencher-run/de/benchmark-command.mdx";
 import Project from "../../../chunks/docs-explanation/bencher-run/de/project.mdx";
 import CiOnTheFly from "../../../chunks/docs-explanation/bencher-run/de/ci-on-the-fly.mdx";
-import Token from "../../../chunks/docs-explanation/bencher-run/de/token.mdx";
 import Key from "../../../chunks/docs-explanation/bencher-run/de/key.mdx";
+import Token from "../../../chunks/docs-explanation/bencher-run/de/token.mdx";
 import Image from "../../../chunks/docs-explanation/bencher-run/de/image.mdx";
 import BranchSelection from "../../../chunks/docs-explanation/bencher-run/de/branch-selection.mdx";
 import Testbed from "../../../chunks/docs-explanation/bencher-run/de/testbed.mdx";
@@ -60,11 +60,11 @@ import Help from "../../../chunks/docs-explanation/bencher-run/de/help.mdx";
 
 <br />
 
-<Token />
+<Key />
 
 <br />
 
-<Key />
+<Token />
 
 <br />
 

--- a/services/console/src/content/docs-explanation/en/bencher-run.mdx
+++ b/services/console/src/content/docs-explanation/en/bencher-run.mdx
@@ -3,7 +3,7 @@ title: "bencher run"
 description: "Overview of the bencher run CLI subcommand and all of its flags, arguments, and features"
 heading: "`bencher run` CLI Subcommand"
 published: "2023-08-12T16:07:00Z"
-modified: "2026-06-14T00:00:00Z"
+modified: "2026-06-16T00:00:00Z"
 sortOrder: 3
 ---
 
@@ -12,8 +12,8 @@ import Cmd from "../../../chunks/docs-explanation/bencher-run/cmd.mdx";
 import BenchmarkCommand from "../../../chunks/docs-explanation/bencher-run/en/benchmark-command.mdx";
 import Project from "../../../chunks/docs-explanation/bencher-run/en/project.mdx";
 import CiOnTheFly from "../../../chunks/docs-explanation/bencher-run/en/ci-on-the-fly.mdx";
-import Token from "../../../chunks/docs-explanation/bencher-run/en/token.mdx";
 import Key from "../../../chunks/docs-explanation/bencher-run/en/key.mdx";
+import Token from "../../../chunks/docs-explanation/bencher-run/en/token.mdx";
 import Image from "../../../chunks/docs-explanation/bencher-run/en/image.mdx";
 import BranchSelection from "../../../chunks/docs-explanation/bencher-run/en/branch-selection.mdx";
 import Testbed from "../../../chunks/docs-explanation/bencher-run/en/testbed.mdx";
@@ -60,11 +60,11 @@ import Help from "../../../chunks/docs-explanation/bencher-run/en/help.mdx";
 
 <br />
 
-<Token />
+<Key />
 
 <br />
 
-<Key />
+<Token />
 
 <br />
 

--- a/services/console/src/content/docs-explanation/es/bencher-run.mdx
+++ b/services/console/src/content/docs-explanation/es/bencher-run.mdx
@@ -3,7 +3,7 @@ title: "Ejecutar bencher"
 description: "Visión general del subcomando bencher run CLI y todas sus banderas, argumentos y características"
 heading: "Subcomando `bencher run` CLI"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-06-14T00:00:00Z"
+modified: "2026-06-16T00:00:00Z"
 sortOrder: 3
 ---
 
@@ -12,8 +12,8 @@ import Cmd from "../../../chunks/docs-explanation/bencher-run/cmd.mdx";
 import BenchmarkCommand from "../../../chunks/docs-explanation/bencher-run/es/benchmark-command.mdx";
 import Project from "../../../chunks/docs-explanation/bencher-run/es/project.mdx";
 import CiOnTheFly from "../../../chunks/docs-explanation/bencher-run/es/ci-on-the-fly.mdx";
-import Token from "../../../chunks/docs-explanation/bencher-run/es/token.mdx";
 import Key from "../../../chunks/docs-explanation/bencher-run/es/key.mdx";
+import Token from "../../../chunks/docs-explanation/bencher-run/es/token.mdx";
 import Image from "../../../chunks/docs-explanation/bencher-run/es/image.mdx";
 import BranchSelection from "../../../chunks/docs-explanation/bencher-run/es/branch-selection.mdx";
 import Testbed from "../../../chunks/docs-explanation/bencher-run/es/testbed.mdx";
@@ -60,11 +60,11 @@ import Help from "../../../chunks/docs-explanation/bencher-run/es/help.mdx";
 
 <br />
 
-<Token />
+<Key />
 
 <br />
 
-<Key />
+<Token />
 
 <br />
 

--- a/services/console/src/content/docs-explanation/fr/bencher-run.mdx
+++ b/services/console/src/content/docs-explanation/fr/bencher-run.mdx
@@ -3,7 +3,7 @@ title: "bencher run"
 description: "Aperçu de la sous-commande CLI bencher run et de tous ses flags, arguments, et fonctionnalités"
 heading: "Sous-commande CLI `bencher run`"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-06-14T00:00:00Z"
+modified: "2026-06-16T00:00:00Z"
 sortOrder: 3
 ---
 
@@ -12,8 +12,8 @@ import Cmd from "../../../chunks/docs-explanation/bencher-run/cmd.mdx";
 import BenchmarkCommand from "../../../chunks/docs-explanation/bencher-run/fr/benchmark-command.mdx";
 import Project from "../../../chunks/docs-explanation/bencher-run/fr/project.mdx";
 import CiOnTheFly from "../../../chunks/docs-explanation/bencher-run/fr/ci-on-the-fly.mdx";
-import Token from "../../../chunks/docs-explanation/bencher-run/fr/token.mdx";
 import Key from "../../../chunks/docs-explanation/bencher-run/fr/key.mdx";
+import Token from "../../../chunks/docs-explanation/bencher-run/fr/token.mdx";
 import Image from "../../../chunks/docs-explanation/bencher-run/fr/image.mdx";
 import BranchSelection from "../../../chunks/docs-explanation/bencher-run/fr/branch-selection.mdx";
 import Testbed from "../../../chunks/docs-explanation/bencher-run/fr/testbed.mdx";
@@ -60,11 +60,11 @@ import Help from "../../../chunks/docs-explanation/bencher-run/fr/help.mdx";
 
 <br />
 
-<Token />
+<Key />
 
 <br />
 
-<Key />
+<Token />
 
 <br />
 

--- a/services/console/src/content/docs-explanation/ja/bencher-run.mdx
+++ b/services/console/src/content/docs-explanation/ja/bencher-run.mdx
@@ -3,7 +3,7 @@ title: "bencher run"
 description: "bencher run CLI サブコマンドとそのすべてのフラグ、引数、機能についての概観"
 heading: "`bencher run` CLI サブコマンド"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-06-14T00:00:00Z"
+modified: "2026-06-16T00:00:00Z"
 sortOrder: 3
 ---
 
@@ -12,8 +12,8 @@ import Cmd from "../../../chunks/docs-explanation/bencher-run/cmd.mdx";
 import BenchmarkCommand from "../../../chunks/docs-explanation/bencher-run/ja/benchmark-command.mdx";
 import Project from "../../../chunks/docs-explanation/bencher-run/ja/project.mdx";
 import CiOnTheFly from "../../../chunks/docs-explanation/bencher-run/ja/ci-on-the-fly.mdx";
-import Token from "../../../chunks/docs-explanation/bencher-run/ja/token.mdx";
 import Key from "../../../chunks/docs-explanation/bencher-run/ja/key.mdx";
+import Token from "../../../chunks/docs-explanation/bencher-run/ja/token.mdx";
 import Image from "../../../chunks/docs-explanation/bencher-run/ja/image.mdx";
 import BranchSelection from "../../../chunks/docs-explanation/bencher-run/ja/branch-selection.mdx";
 import Testbed from "../../../chunks/docs-explanation/bencher-run/ja/testbed.mdx";
@@ -60,11 +60,11 @@ import Help from "../../../chunks/docs-explanation/bencher-run/ja/help.mdx";
 
 <br />
 
-<Token />
+<Key />
 
 <br />
 
-<Key />
+<Token />
 
 <br />
 

--- a/services/console/src/content/docs-explanation/ko/bencher-run.mdx
+++ b/services/console/src/content/docs-explanation/ko/bencher-run.mdx
@@ -3,7 +3,7 @@ title: "bencher run"
 description: "bencher run CLI 하위 명령어 및 모든 플래그, 인수, 기능에 대한 개요"
 heading: "`bencher run` CLI 하위 명령어"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-06-15T00:00:00Z"
+modified: "2026-06-16T00:00:00Z"
 sortOrder: 3
 ---
 
@@ -12,8 +12,8 @@ import Cmd from "../../../chunks/docs-explanation/bencher-run/cmd.mdx";
 import BenchmarkCommand from "../../../chunks/docs-explanation/bencher-run/ko/benchmark-command.mdx";
 import Project from "../../../chunks/docs-explanation/bencher-run/ko/project.mdx";
 import CiOnTheFly from "../../../chunks/docs-explanation/bencher-run/ko/ci-on-the-fly.mdx";
-import Token from "../../../chunks/docs-explanation/bencher-run/ko/token.mdx";
 import Key from "../../../chunks/docs-explanation/bencher-run/ko/key.mdx";
+import Token from "../../../chunks/docs-explanation/bencher-run/ko/token.mdx";
 import Image from "../../../chunks/docs-explanation/bencher-run/ko/image.mdx";
 import BranchSelection from "../../../chunks/docs-explanation/bencher-run/ko/branch-selection.mdx";
 import Testbed from "../../../chunks/docs-explanation/bencher-run/ko/testbed.mdx";
@@ -60,11 +60,11 @@ import Help from "../../../chunks/docs-explanation/bencher-run/ko/help.mdx";
 
 <br />
 
-<Token />
+<Key />
 
 <br />
 
-<Key />
+<Token />
 
 <br />
 

--- a/services/console/src/content/docs-explanation/pt/bencher-run.mdx
+++ b/services/console/src/content/docs-explanation/pt/bencher-run.mdx
@@ -3,7 +3,7 @@ title: "execução bencher"
 description: "Visão geral do subcomando CLI execução bencher e todas as suas flags, argumentos e recursos"
 heading: "Subcomando `bencher run` CLI"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-06-14T00:00:00Z"
+modified: "2026-06-16T00:00:00Z"
 sortOrder: 3
 ---
 
@@ -12,8 +12,8 @@ import Cmd from "../../../chunks/docs-explanation/bencher-run/cmd.mdx";
 import BenchmarkCommand from "../../../chunks/docs-explanation/bencher-run/pt/benchmark-command.mdx";
 import Project from "../../../chunks/docs-explanation/bencher-run/pt/project.mdx";
 import CiOnTheFly from "../../../chunks/docs-explanation/bencher-run/pt/ci-on-the-fly.mdx";
-import Token from "../../../chunks/docs-explanation/bencher-run/pt/token.mdx";
 import Key from "../../../chunks/docs-explanation/bencher-run/pt/key.mdx";
+import Token from "../../../chunks/docs-explanation/bencher-run/pt/token.mdx";
 import Image from "../../../chunks/docs-explanation/bencher-run/pt/image.mdx";
 import BranchSelection from "../../../chunks/docs-explanation/bencher-run/pt/branch-selection.mdx";
 import Testbed from "../../../chunks/docs-explanation/bencher-run/pt/testbed.mdx";
@@ -60,11 +60,11 @@ import Help from "../../../chunks/docs-explanation/bencher-run/pt/help.mdx";
 
 <br />
 
-<Token />
+<Key />
 
 <br />
 
-<Key />
+<Token />
 
 <br />
 

--- a/services/console/src/content/docs-explanation/ru/bencher-run.mdx
+++ b/services/console/src/content/docs-explanation/ru/bencher-run.mdx
@@ -3,7 +3,7 @@ title: "bencher run"
 description: "Обзор команды bencher run CLI, всех её флагов, аргументов и дополнительных возможностей"
 heading: "Подкоманда `bencher run` CLI"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-06-14T00:00:00Z"
+modified: "2026-06-16T00:00:00Z"
 sortOrder: 3
 ---
 
@@ -12,8 +12,8 @@ import Cmd from "../../../chunks/docs-explanation/bencher-run/cmd.mdx";
 import BenchmarkCommand from "../../../chunks/docs-explanation/bencher-run/ru/benchmark-command.mdx";
 import Project from "../../../chunks/docs-explanation/bencher-run/ru/project.mdx";
 import CiOnTheFly from "../../../chunks/docs-explanation/bencher-run/ru/ci-on-the-fly.mdx";
-import Token from "../../../chunks/docs-explanation/bencher-run/ru/token.mdx";
 import Key from "../../../chunks/docs-explanation/bencher-run/ru/key.mdx";
+import Token from "../../../chunks/docs-explanation/bencher-run/ru/token.mdx";
 import Image from "../../../chunks/docs-explanation/bencher-run/ru/image.mdx";
 import BranchSelection from "../../../chunks/docs-explanation/bencher-run/ru/branch-selection.mdx";
 import Testbed from "../../../chunks/docs-explanation/bencher-run/ru/testbed.mdx";
@@ -60,11 +60,11 @@ import Help from "../../../chunks/docs-explanation/bencher-run/ru/help.mdx";
 
 <br />
 
-<Token />
+<Key />
 
 <br />
 
-<Key />
+<Token />
 
 <br />
 

--- a/services/console/src/content/docs-explanation/zh/bencher-run.mdx
+++ b/services/console/src/content/docs-explanation/zh/bencher-run.mdx
@@ -3,7 +3,7 @@ title: "bencher run"
 description: "对 bencher run CLI 子命令及其所有标志、参数和特性的概述"
 heading: "`bencher run` CLI 子命令"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-06-14T00:00:00Z"
+modified: "2026-06-16T00:00:00Z"
 sortOrder: 3
 ---
 
@@ -12,8 +12,8 @@ import Cmd from "../../../chunks/docs-explanation/bencher-run/cmd.mdx";
 import BenchmarkCommand from "../../../chunks/docs-explanation/bencher-run/zh/benchmark-command.mdx";
 import Project from "../../../chunks/docs-explanation/bencher-run/zh/project.mdx";
 import CiOnTheFly from "../../../chunks/docs-explanation/bencher-run/zh/ci-on-the-fly.mdx";
-import Token from "../../../chunks/docs-explanation/bencher-run/zh/token.mdx";
 import Key from "../../../chunks/docs-explanation/bencher-run/zh/key.mdx";
+import Token from "../../../chunks/docs-explanation/bencher-run/zh/token.mdx";
 import Image from "../../../chunks/docs-explanation/bencher-run/zh/image.mdx";
 import BranchSelection from "../../../chunks/docs-explanation/bencher-run/zh/branch-selection.mdx";
 import Testbed from "../../../chunks/docs-explanation/bencher-run/zh/testbed.mdx";
@@ -60,11 +60,11 @@ import Help from "../../../chunks/docs-explanation/bencher-run/zh/help.mdx";
 
 <br />
 
-<Token />
+<Key />
 
 <br />
 
-<Key />
+<Token />
 
 <br />
 


### PR DESCRIPTION
## Summary

Follow-up to #897 (API keys). Three changes:

### Dogfooding: `--token` to `--key`
- All `bencher run` dogfooding now uses `--key`/`BENCHER_API_KEY` (a project-scoped `bencher_run_*` key) instead of `--token`/`BENCHER_API_TOKEN`, across `cli.yml`, `ci.yml`, `test.yml`, `track_benchmarks.yml`, and `track_pr_benchmarks.yml`.
- The project slug is declared once per workflow as a `BENCHER_PROJECT` env var and referenced for both `--project` and the `docker login` username (`-u "$BENCHER_PROJECT"`), since a project-scoped key authenticates to the OCI registry as the project.
- `BENCHER_API_TOKEN` and the now-unused `BENCHER_USER_EMAIL` are retired from these workflows.
- `backup.yml` is unchanged; it uses a separate admin token for an admin-only operation a project key cannot perform.

### Deprecate the remaining user token REST endpoints
- Mark the list, view, update, and revoke `/v0/users/{user}/tokens` endpoints as `deprecated` (POST create was already deprecated). They continue to work for existing tokens.
- `Operation.astro` now renders OpenAPI descriptions as paragraphs with inline markdown links, so the deprecation notes read as their own paragraph and link to the API key docs instead of showing a raw URL.
- Changelog entry added under a new `## Pending v0.6.8` section.

### Docs
- Reorder the `--key` option before the deprecated `--token` in the `bencher run` explanation (all 9 languages).

## Test plan
- [x] `cargo clippy --no-deps --all-targets --all-features -- -Dwarnings`
- [x] `cargo check --no-default-features`
- [x] `cargo nextest run -p api_users` (48 passed)
- [x] `cargo gen-types` (regenerated `openapi.json`; 5 deprecated token operations, both copies synced)
- [x] `biome format` / `lint` clean on the console
