### PR TITLE
Fix GitHub Check creation failing to parse response (#894)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4478,6 +4478,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-serde"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
+dependencies = [
+ "http 1.4.1",
+ "serde",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5742,9 +5752,9 @@ dependencies = [
 
 [[package]]
 name = "octocrab"
-version = "0.51.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2ad8abffe4e2b05f9cdc7e061de63d305a6dca0af81ca1064a7d98e0b78267"
+checksum = "fe45bd53ce50c9e85e8a27259675f65d772165fe5eef3e278c1b6168c3f97623"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -5759,12 +5769,12 @@ dependencies = [
  "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
+ "http-serde",
  "hyper",
  "hyper-rustls",
  "hyper-timeout",
  "hyper-util",
  "jsonwebtoken",
- "once_cell",
  "percent-encoding",
  "pin-project",
  "secrecy",
@@ -7847,7 +7857,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ notify-rust = "4.12"
 oauth2 = { version = "5.0", default-features = false }
 oauth2-reqwest = "0.1.0-alpha.3"
 oci-spec = "0.9"
-octocrab = { version = "0.51", default-features = false, features = ["follow-redirect", "retry", "rustls", "timeout", "tracing", "default-client", "rustls-aws-lc-rs", "jwt-rust-crypto", "rustls-webpki-tokio"] }
+octocrab = { version = "0.53", default-features = false, features = ["follow-redirect", "retry", "rustls", "timeout", "tracing", "default-client", "rustls-aws-lc-rs", "jwt-rust-crypto", "rustls-webpki-tokio"] }
 opentelemetry = "0.32"
 opentelemetry-otlp = "0.32"
 opentelemetry_sdk = "0.32"

--- a/services/cli/src/bencher/sub/run/ci/github_actions.rs
+++ b/services/cli/src/bencher/sub/run/ci/github_actions.rs
@@ -308,6 +308,7 @@ impl GitHubActions {
                 },
             )
         } else {
+            cli_println_quietable!(log, "Created GitHub Check.");
             Ok(())
         }
     }
@@ -578,6 +579,36 @@ mod tests {
         assert_eq!(
             check_run_name(Some("embedded")),
             "Bencher Report (embedded)"
+        );
+    }
+
+    #[test]
+    fn octocrab_pull_request_accepts_minimal_check_run_payload() {
+        use octocrab::models::pulls::PullRequest;
+
+        // GitHub's check-run response `pull_requests` items are the minimal/simple PR
+        // representation (no `node_id`, etc.). octocrab >= 0.52 models these as optional.
+        // Guards against an octocrab downgrade reintroducing
+        // https://github.com/bencherdev/bencher/issues/894
+        let minimal = serde_json::json!([{
+            "url": "https://api.github.com/repos/owner/repo/pulls/1",
+            "id": 1934,
+            "number": 1,
+            "head": {
+                "ref": "feature",
+                "sha": "f1e2d3c4b5a697887766554433221100ffeeddcc",
+                "repo": { "id": 1, "url": "https://api.github.com/repos/owner/repo", "name": "repo" }
+            },
+            "base": {
+                "ref": "main",
+                "sha": "0011223344556677889900aabbccddeeff001122",
+                "repo": { "id": 1, "url": "https://api.github.com/repos/owner/repo", "name": "repo" }
+            }
+        }]);
+        let parsed: Result<Vec<PullRequest>, _> = serde_json::from_value(minimal);
+        assert!(
+            parsed.is_ok(),
+            "octocrab PullRequest must accept GitHub's minimal check-run payload: {parsed:?}"
         );
     }
 }


### PR DESCRIPTION
## Problem

`bencher run --github-actions` creates a `Bencher Report` GitHub Check on the PR head commit. The check was actually created (GitHub returns `201 Created`), but octocrab `0.51` failed to deserialize the *response*, surfacing as a misleading failure:

```
Failed to create GitHub Check: JSON Error in pull_requests[0]: missing field `node_id` at line 1 column 4954
```

Reported in #894 (https://github.com/bencherdev/bencher/issues/894#issuecomment-4722568576) and reproduced at NomicFoundation/slang#1873.

## Root cause

octocrab's `CheckRun` model deserializes the response `pull_requests` array into the full `models::pulls::PullRequest` type. In octocrab `0.51`, `PullRequest.node_id` was a required `String`, but GitHub's create-check-run response returns only a minimal pull request representation (no `node_id`), so deserialization failed. The `pull_requests` array is only populated when the check is attached to a PR, which is why a plain push never surfaced it.

Bug: https://github.com/XAMPPRocky/octocrab/pull/902

## Fix

octocrab `0.52` relaxed `PullRequest` fields to `Option` to accept GitHub's `SimplePullRequest` payload, so the minimal check-run `pull_requests` objects now deserialize. This bumps octocrab `0.51` -> `0.53.1`; the existing `create_check_run().send()` path then just works.

- None of the octocrab APIs in use changed across `0.51` -> `0.53.1` (builder, `create_check_run`, issue comments, `CommentId`, `CheckRunConclusion`/`CheckRunOutput`). The one relevant breaking change (PR fields -> `Option`) does not touch Bencher, which never reads `PullRequest` fields directly. The only new transitive dependency is `http-serde 2.1.1` (MIT/Apache-2.0).
- Added a regression test that deserializes GitHub's minimal check-run `pull_requests` payload, guarding against an octocrab downgrade reintroducing the bug.
- Log on successful check creation (previously the path only logged on failure).

Release with fix: https://github.com/XAMPPRocky/octocrab/releases/tag/v0.52.0

## Verification

- `cargo build -p bencher_cli` (no breaking API changes)
- `cargo test -p bencher_cli` (17 pass, including the new test; doc tests pass)
- `cargo clippy --no-deps -p bencher_cli --all-targets --all-features -- -Dwarnings` (clean)
- `cargo clippy` on `bencher_github_client` (the other octocrab consumer; clean)
- `cargo fmt` (no changes)

`cargo deny check` was not run locally (`cargo-deny` not installed in this environment); worth confirming in CI for the new `http-serde` dependency.