### PR TITLE
Add Pro plan with prepaid usage-credit pricing

### DIFF
--- a/lib/api_checkout/src/checkout.rs
+++ b/lib/api_checkout/src/checkout.rs
@@ -2,6 +2,7 @@
 
 use bencher_endpoint::{CorsResponse, Endpoint, Post, ResponseCreated};
 use bencher_json::{
+    PlanLevel,
     organization::plan::DEFAULT_PRICE_NAME,
     system::payment::{JsonCheckout, JsonNewCheckout},
 };
@@ -67,6 +68,15 @@ async fn checkouts_post_inner(
     if entitlements.is_some() && self_hosted.is_none() {
         return Err(bad_request_error(
             "Licensed plans are only available for Bencher Self-Hosted",
+        ));
+    }
+
+    // Enterprise is no longer self-serve: it is "Contact us" with custom hardware.
+    // Reject metered (self-serve) Enterprise checkouts; licensed Enterprise for
+    // Self-Hosted (sales-issued) remains available via the check above.
+    if level == PlanLevel::Enterprise && entitlements.is_none() {
+        return Err(bad_request_error(
+            "Enterprise plans are not self-serve. Please contact Bencher to set up an Enterprise plan.",
         ));
     }
 

--- a/lib/api_organizations/src/lib.rs
+++ b/lib/api_organizations/src/lib.rs
@@ -76,6 +76,7 @@ impl bencher_endpoint::Registrar for Api {
                 }
                 api_description.register(plan::org_plan_get)?;
                 api_description.register(plan::org_plan_post)?;
+                api_description.register(plan::org_plan_patch)?;
                 api_description.register(plan::org_plan_delete)?;
             }
 

--- a/lib/api_organizations/src/plan.rs
+++ b/lib/api_organizations/src/plan.rs
@@ -2,11 +2,11 @@
 
 use bencher_billing::Biller;
 use bencher_endpoint::{
-    CorsResponse, Delete, Endpoint, Get, Post, ResponseCreated, ResponseDeleted, ResponseOk,
+    CorsResponse, Delete, Endpoint, Get, Patch, Post, ResponseCreated, ResponseDeleted, ResponseOk,
 };
 use bencher_json::{
-    DateTime, OrganizationResourceId,
-    organization::plan::{JsonNewPlan, JsonPlan},
+    DateTime, MeteredPlanId, OrganizationResourceId,
+    organization::plan::{JsonNewPlan, JsonPlan, JsonUpdatePlan, PRO_INCLUDED_CREDIT_CENTS},
 };
 use bencher_rbac::organization::Permission;
 use bencher_schema::{
@@ -45,7 +45,12 @@ pub async fn org_plan_options(
     _rqctx: RequestContext<ApiContext>,
     _path_params: Path<OrgPlanParams>,
 ) -> Result<CorsResponse, HttpError> {
-    Ok(Endpoint::cors(&[Get.into(), Post.into(), Delete.into()]))
+    Ok(Endpoint::cors(&[
+        Get.into(),
+        Post.into(),
+        Patch.into(),
+        Delete.into(),
+    ]))
 }
 
 #[endpoint {
@@ -127,6 +132,82 @@ pub async fn org_plan_post(
         let _ = e;
     })?;
     Ok(Post::auth_response_created(json))
+}
+
+#[endpoint {
+    method = PATCH,
+    path =  "/v0/organizations/{organization}/plan",
+    tags = ["organizations", "plan"]
+}]
+pub async fn org_plan_patch(
+    rqctx: RequestContext<ApiContext>,
+    bearer_token: BearerToken,
+    path_params: Path<OrgPlanParams>,
+    body: TypedBody<JsonUpdatePlan>,
+) -> Result<ResponseOk<JsonPlan>, HttpError> {
+    let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
+    let json = patch_inner(
+        rqctx.context(),
+        path_params.into_inner(),
+        body.into_inner(),
+        &auth_user,
+    )
+    .await?;
+    Ok(Patch::auth_response_ok(json))
+}
+
+/// Update the organization's metered (Pro) subscription: schedule or clear a
+/// cancel-at-period-end. Returns the refreshed plan.
+async fn patch_inner(
+    context: &ApiContext,
+    path_params: OrgPlanParams,
+    json_plan: JsonUpdatePlan,
+    auth_user: &AuthUser,
+) -> Result<JsonPlan, HttpError> {
+    let biller = context.biller()?;
+
+    // Get the organization
+    let query_organization =
+        QueryOrganization::from_resource_id(auth_conn!(context), &path_params.organization)?;
+    // Check to see if user has permission to manage the organization
+    context
+        .rbac
+        .is_allowed_organization(auth_user, Permission::Manage, &query_organization)
+        .map_err(forbidden_error)?;
+    // Get the plan for the organization
+    let query_plan = QueryPlan::belonging_to(&query_organization)
+        .first::<QueryPlan>(auth_conn!(context))
+        .map_err(resource_not_found_err!(Plan, query_organization))?;
+
+    // The cancel-at-period-end schedule only applies to a metered (Pro)
+    // subscription; licensed plans are canceled immediately and have no
+    // period-end schedule to change.
+    let Some(metered_plan_id) = query_plan.metered_plan.as_ref() else {
+        return Err(bad_request_error(
+            "Only a metered plan's cancellation can be updated; this organization has no metered subscription",
+        ));
+    };
+    if json_plan.cancel_at_period_end {
+        biller
+            .cancel_metered_subscription(metered_plan_id)
+            .await
+            .map_err(resource_conflict_err!(Plan, query_plan))?;
+    } else {
+        biller
+            .resume_metered_subscription(metered_plan_id)
+            .await
+            .map_err(resource_conflict_err!(Plan, query_plan))?;
+    }
+
+    query_plan.to_metered_plan(biller).await?.ok_or_else(|| {
+        issue_error(
+            "Failed to find subscription for updated plan",
+            &format!(
+                "Failed to find metered plan for organization ({query_organization:?}) after update even though plan exists ({query_plan:?})."
+            ),
+            "Failed to find subscription for updated plan",
+        )
+    })
 }
 
 async fn post_inner(
@@ -221,6 +302,9 @@ async fn post_inner(
             .as_ref()
             .parse()
             .map_err(resource_not_found_err!(Plan, subscription_id))?;
+        // Grant the first period's included usage credit so a new Pro org has its
+        // credit immediately (best-effort; the daily sweep handles later periods).
+        grant_initial_pro_credit(biller, &metered_plan_id).await;
         InsertPlan::metered_plan(write_conn!(context), metered_plan_id, &query_organization)?;
         QueryPlan::belonging_to(&query_organization)
             .first::<QueryPlan>(auth_conn!(context))
@@ -300,11 +384,32 @@ async fn delete_inner(
             let _ = e;
         });
 
-    diesel::delete(schema::plan::table.filter(schema::plan::id.eq(query_plan.id)))
-        .execute(write_conn!(context))
-        .map_err(resource_conflict_err!(Plan, query_plan))?;
+    // Keep the local plan row only when we scheduled a remote cancel-at-period-end
+    // on a metered (Pro) subscription (see `cancel_metered_subscription`): the org
+    // retains access until the subscription lapses, when the daily sweep prunes it.
+    // Otherwise — licensed plans (canceled immediately), or a `remote=false` local
+    // detach — remove the row now.
+    if !(query_plan.metered_plan.is_some() && remote) {
+        diesel::delete(schema::plan::table.filter(schema::plan::id.eq(query_plan.id)))
+            .execute(write_conn!(context))
+            .map_err(resource_conflict_err!(Plan, query_plan))?;
+    }
 
     delete_plan_result
+}
+
+/// Best-effort grant of the first period's included usage credit for a new Pro
+/// subscription. Idempotent and Pro-self-guarding; never blocks plan creation.
+async fn grant_initial_pro_credit(biller: &Biller, metered_plan_id: &MeteredPlanId) {
+    let _credit = biller
+        .ensure_period_credit(metered_plan_id, PRO_INCLUDED_CREDIT_CENTS)
+        .await
+        .inspect_err(|e| {
+            #[cfg(feature = "sentry")]
+            sentry::capture_error(e);
+            #[cfg(not(feature = "sentry"))]
+            let _ = e;
+        });
 }
 
 async fn delete_plan(

--- a/lib/bencher_config/src/config_tx.rs
+++ b/lib/bencher_config/src/config_tx.rs
@@ -24,7 +24,7 @@ use bencher_schema::{
     context::RateLimiting,
     model::{
         runner::job::{reprocess_completed_jobs, spawn_heartbeat_timeout},
-        server::QueryServer,
+        server::{QueryServer, spawn_pro_credit_grants},
     },
     write_conn,
 };
@@ -172,6 +172,22 @@ impl ConfigTx {
 
         #[cfg(feature = "plus")]
         spawn_stats(log, server.app_private()).await?;
+
+        // Bencher Cloud only (a Biller is configured): keep each Pro
+        // subscription's monthly usage credit granted and reconcile lapses on a
+        // daily sweep, off the report-ingestion path.
+        #[cfg(feature = "plus")]
+        {
+            let context = server.app_private();
+            if let Some(biller) = context.biller.clone() {
+                spawn_pro_credit_grants(
+                    log.clone(),
+                    context.database.path.clone(),
+                    context.database.busy_timeout,
+                    biller,
+                );
+            }
+        }
 
         Ok(server)
     }

--- a/lib/bencher_json/src/organization/plan.rs
+++ b/lib/bencher_json/src/organization/plan.rs
@@ -14,6 +14,10 @@ pub const DEFAULT_PRICE_NAME: &str = "default";
 pub const METRICS_METER_NAME: &str = "metrics";
 pub const RUNNER_MINUTES_METER_NAME: &str = "runner_minutes";
 
+/// The fungible usage credit included with Pro each billing period, in cents (`$20.00`).
+/// Drawn down across metrics and bare metal; expires at period end.
+pub const PRO_INCLUDED_CREDIT_CENTS: i64 = 2_000;
+
 #[typeshare::typeshare]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -28,6 +32,17 @@ pub struct JsonNewPlan {
 #[typeshare::typeshare]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub struct JsonUpdatePlan {
+    /// Update the subscription's scheduled cancellation. Set to `false` to resume
+    /// a plan scheduled to cancel at period end, or `true` to schedule it to
+    /// cancel at the end of the current period. Only applies to metered (Pro)
+    /// plans.
+    pub cancel_at_period_end: bool,
+}
+
+#[typeshare::typeshare]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct JsonPlan {
     pub organization: OrganizationUuid,
     pub customer: JsonCustomer,
@@ -37,6 +52,9 @@ pub struct JsonPlan {
     pub current_period_start: DateTime,
     pub current_period_end: DateTime,
     pub status: PlanStatus,
+    /// Whether the subscription is set to cancel at the end of the current period
+    /// (the org keeps access until `current_period_end`, then downgrades to Free).
+    pub cancel_at_period_end: bool,
     pub license: Option<JsonLicense>,
 }
 

--- a/lib/bencher_json/src/system/config/plus/cloud/billing.rs
+++ b/lib/bencher_json/src/system/config/plus/cloud/billing.rs
@@ -21,7 +21,9 @@ impl Sanitize for JsonBilling {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct JsonProducts {
+    // Legacy self-serve paid tier, retained for grandfathered customers.
     pub team: JsonProduct,
+    pub pro: JsonProduct,
     pub enterprise: JsonProduct,
     pub bare_metal: JsonProduct,
 }
@@ -30,6 +32,56 @@ pub struct JsonProducts {
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct JsonProduct {
     pub id: String,
+    #[serde(default)]
     pub metered: HashMap<String, String>,
+    #[serde(default)]
     pub licensed: HashMap<String, String>,
+    // Flat recurring base prices (e.g. the Pro `$20/mo` platform fee).
+    // Empty for products with no flat base fee (team, enterprise, bare_metal).
+    #[serde(default)]
+    pub base: HashMap<String, String>,
+    // Stripe coupon ID (`duration: once`, `percent_off: 100`) applied to new
+    // subscriptions for this product to waive the first month's base fee (the
+    // free trial). Metered usage still bills, offset by the monthly credit.
+    // Only the Pro product sets this today.
+    #[serde(default)]
+    pub trial_coupon: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{JsonProduct, JsonProducts};
+
+    // Existing team/enterprise/bare_metal config has no `base` key; it must still
+    // deserialize, defaulting `base` to an empty map (backward compatibility).
+    #[test]
+    fn product_without_base_defaults_empty() {
+        let json =
+            r#"{"id":"prod_x","metered":{"default":"price_m"},"licensed":{"default":"price_l"}}"#;
+        let product: JsonProduct = serde_json::from_str(json).unwrap();
+        assert!(product.base.is_empty());
+        assert!(product.trial_coupon.is_none());
+        assert_eq!(
+            product.metered.get("default").map(String::as_str),
+            Some("price_m"),
+        );
+    }
+
+    #[test]
+    fn products_with_pro_base_and_trial_coupon() {
+        let json = r#"{
+            "team": {"id":"t","metered":{},"licensed":{}},
+            "pro": {"id":"p","metered":{"default":"price_m"},"base":{"default":"price_b"},"trial_coupon":"coupon_x"},
+            "enterprise": {"id":"e","metered":{},"licensed":{}},
+            "bare_metal": {"id":"bm","metered":{},"licensed":{}}
+        }"#;
+        let products: JsonProducts = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            products.pro.base.get("default").map(String::as_str),
+            Some("price_b"),
+        );
+        assert_eq!(products.pro.trial_coupon.as_deref(), Some("coupon_x"));
+        assert!(products.team.base.is_empty());
+        assert!(products.team.trial_coupon.is_none());
+    }
 }

--- a/lib/bencher_schema/src/model/organization/plan.rs
+++ b/lib/bencher_schema/src/model/organization/plan.rs
@@ -111,14 +111,29 @@ impl QueryPlan {
             .await
             .map_err(not_found_error)?;
 
+        // A canceled/lapsed (inactive) subscription gracefully downgrades to
+        // Free: return `None` so the caller falls through to the public/no-plan
+        // logic instead of hard-erroring.
         if plan_status.is_active() {
             Ok(Some(customer_id))
         } else {
-            Err(payment_required_error(PlanKindError::InactiveMeteredPlan {
-                organization: query_organization.clone(),
-                metered_plan_id,
-            }))
+            Ok(None)
         }
+    }
+
+    /// All organization plans with a metered (Stripe) subscription. Used by the
+    /// daily billing sweep to ensure each period's credit and reconcile canceled
+    /// subscriptions.
+    pub fn all_metered(conn: &mut DbConnection) -> diesel::QueryResult<Vec<Self>> {
+        schema::plan::table
+            .filter(schema::plan::metered_plan.is_not_null())
+            .load::<Self>(conn)
+    }
+
+    /// Delete a plan row by id. Used by the daily billing sweep to prune a plan
+    /// whose subscription has fully lapsed.
+    pub fn delete(conn: &mut DbConnection, plan_id: PlanId) -> diesel::QueryResult<usize> {
+        diesel::delete(schema::plan::table.filter(schema::plan::id.eq(plan_id))).execute(conn)
     }
 }
 
@@ -219,11 +234,6 @@ pub enum PlanKind {
 
 #[derive(Debug, thiserror::Error)]
 pub enum PlanKindError {
-    #[error("Organization ({uuid}) has an inactive metered plan ({metered_plan_id})", uuid = organization.uuid)]
-    InactiveMeteredPlan {
-        organization: QueryOrganization,
-        metered_plan_id: MeteredPlanId,
-    },
     #[error("License usage exceeded for organization ({uuid}). {usage} > {entitlements}", uuid = organization.uuid)]
     LicensePlanOverage {
         organization: QueryOrganization,
@@ -253,7 +263,7 @@ impl PlanKind {
             Self::Metered(_) => Priority::Plus,
             Self::Licensed(license_usage) => match license_usage.level {
                 PlanLevel::Free => Priority::Free,
-                PlanLevel::Team | PlanLevel::Enterprise => Priority::Plus,
+                PlanLevel::Team | PlanLevel::Pro | PlanLevel::Enterprise => Priority::Plus,
             },
         }
     }
@@ -394,6 +404,12 @@ impl PlanKind {
                         PlanKindError::NoBiller,
                     ));
                 };
+                // Public Project Metrics are free and unlimited; only Private
+                // Project Metrics are metered. Bare metal runner time is metered
+                // separately (regardless of visibility) via the runner channel.
+                if project.visibility.is_public() {
+                    return Ok(());
+                }
                 if let Err(e) = biller.record_metrics_usage(&customer_id, usage).await {
                     #[cfg(feature = "otel")]
                     bencher_otel::ApiMeter::increment(

--- a/lib/bencher_schema/src/model/server/mod.rs
+++ b/lib/bencher_schema/src/model/server/mod.rs
@@ -3,4 +3,4 @@ mod plus;
 
 pub use backup::{ServerBackup, ServerBackupError};
 #[cfg(feature = "plus")]
-pub use plus::{QueryServer, ServerId};
+pub use plus::{QueryServer, ServerId, spawn_pro_credit_grants};

--- a/lib/bencher_schema/src/model/server/plus/mod.rs
+++ b/lib/bencher_schema/src/model/server/plus/mod.rs
@@ -4,13 +4,14 @@ use std::cmp;
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
+use bencher_billing::Biller;
 use bencher_json::system::server::SelfHostedStats;
 use bencher_json::{
     BENCHER_API_URL, BENCHER_API_VERSION, BooleanParam, DateTime, JsonServer, JsonServerStats,
-    PlanLevel, SelfHostedStartup, ServerUuid,
+    PlanLevel, SelfHostedStartup, ServerUuid, organization::plan::PRO_INCLUDED_CREDIT_CENTS,
 };
 use bencher_license::Licensor;
-use chrono::{Duration, Utc};
+use chrono::{Duration, NaiveTime, Utc};
 use diesel::{Connection as _, RunQueryDsl as _, connection::SimpleConnection as _};
 use dropshot::HttpError;
 use slog::Logger;
@@ -22,7 +23,10 @@ use crate::{
     context::{Body, DbConnection, Message, Messenger, ServerStatsBody},
     error::{request_timeout_error, resource_conflict_err},
     macros::fn_get::fn_get,
-    model::{organization::plan::LicenseUsage, user::QueryUser},
+    model::{
+        organization::plan::{LicenseUsage, QueryPlan},
+        user::QueryUser,
+    },
     schema::{self, server as server_table},
 };
 
@@ -33,6 +37,19 @@ crate::macros::typed_id::typed_id!(ServerId);
 const SERVER_ID: ServerId = ServerId(1);
 
 const LICENSE_GRACE_PERIOD: usize = 7;
+
+/// Time of day (UTC) at which the daily Pro credit sweep runs. A fixed time so
+/// the sweep happens at the same time every day rather than drifting with
+/// server restarts.
+const CREDIT_SWEEP_TIME: NaiveTime = NaiveTime::MIN;
+
+/// How long to wait before retrying a failed database connection during the
+/// daily credit sweep, so a transient failure does not skip the whole day's run.
+const CREDIT_SWEEP_RETRY_DELAY: std::time::Duration = std::time::Duration::from_mins(1);
+
+/// Maximum number of connection attempts for a single daily sweep before giving
+/// up until the next scheduled run.
+const CREDIT_SWEEP_RETRY_LIMIT: usize = 5;
 
 #[expect(clippy::panic, reason = "valid constant URL with known path")]
 static BENCHER_STATS_API_URL: LazyLock<Url> = LazyLock::new(|| {
@@ -327,6 +344,106 @@ impl Default for InsertServer {
             created: DateTime::now(),
         }
     }
+}
+
+/// Daily background sweep (Bencher Cloud only) that keeps each Pro
+/// subscription's included usage credit granted for the current billing period
+/// and prunes the local plan row once a subscription has fully lapsed. This
+/// replaces granting credit on the report-ingestion path, keeping that hot path
+/// free of billing-side Stripe calls.
+pub fn spawn_pro_credit_grants(log: Logger, db_path: PathBuf, busy_timeout: u32, biller: Biller) {
+    tokio::spawn(async move {
+        loop {
+            // Sleep until the next occurrence of the daily sweep time (UTC) so the
+            // sweep runs at a fixed time of day, not relative to server start.
+            let now = Utc::now().naive_utc().time();
+            let sleep_time = match now.cmp(&CREDIT_SWEEP_TIME) {
+                cmp::Ordering::Less => CREDIT_SWEEP_TIME - now,
+                cmp::Ordering::Equal => Duration::days(1),
+                cmp::Ordering::Greater => Duration::days(1) - (now - CREDIT_SWEEP_TIME),
+            }
+            .to_std()
+            .unwrap_or(std::time::Duration::from_hours(24));
+            tokio::time::sleep(sleep_time).await;
+
+            // Open a configured connection for this sweep, retrying briefly on a
+            // transient failure rather than skipping the whole day's run.
+            let mut attempt = 0;
+            let conn = loop {
+                attempt += 1;
+                match DbConnection::establish(db_path.to_string_lossy().as_ref()) {
+                    Ok(mut conn) => {
+                        match configure_standalone_connection(&mut conn, busy_timeout) {
+                            Ok(()) => break Some(conn),
+                            Err(e) => slog::error!(
+                                log,
+                                "Failed to configure database connection PRAGMAs for credit sweep: {e}"
+                            ),
+                        }
+                    },
+                    Err(e) => slog::error!(
+                        log,
+                        "Failed to establish database connection for credit sweep: {e}"
+                    ),
+                }
+                if attempt >= CREDIT_SWEEP_RETRY_LIMIT {
+                    break None;
+                }
+                tokio::time::sleep(CREDIT_SWEEP_RETRY_DELAY).await;
+            };
+            let Some(mut conn) = conn else {
+                slog::error!(
+                    log,
+                    "Giving up on credit sweep until the next scheduled run after {CREDIT_SWEEP_RETRY_LIMIT} failed connection attempts"
+                );
+                continue;
+            };
+
+            let plans = match QueryPlan::all_metered(&mut conn) {
+                Ok(plans) => plans,
+                Err(e) => {
+                    slog::error!(log, "Failed to load metered plans for credit sweep: {e}");
+                    continue;
+                },
+            };
+
+            for plan in plans {
+                let Some(metered_plan_id) = plan.metered_plan.clone() else {
+                    continue;
+                };
+                let plan_id = plan.id;
+                match biller.get_metered_plan_status(&metered_plan_id).await {
+                    // Active (or trialing): ensure this period's included credit.
+                    // Idempotent, and a no-op for grandfathered Team metered plans.
+                    Ok((status, _)) if status.is_active() => {
+                        if let Err(e) = biller
+                            .ensure_period_credit(&metered_plan_id, PRO_INCLUDED_CREDIT_CENTS)
+                            .await
+                        {
+                            slog::warn!(
+                                log,
+                                "Failed to ensure period credit for {metered_plan_id}: {e}"
+                            );
+                            #[cfg(feature = "sentry")]
+                            sentry::capture_error(&e);
+                        }
+                    },
+                    // Lapsed (canceled/past due/unpaid): prune the local plan row so
+                    // the org reads as Free and we stop querying a dead subscription.
+                    Ok(_) => {
+                        if let Err(e) = QueryPlan::delete(&mut conn, plan_id) {
+                            slog::warn!(log, "Failed to prune lapsed plan {metered_plan_id}: {e}");
+                        }
+                    },
+                    Err(e) => {
+                        slog::warn!(log, "Failed to fetch status for {metered_plan_id}: {e}");
+                        #[cfg(feature = "sentry")]
+                        sentry::capture_error(&e);
+                    },
+                }
+            }
+        }
+    });
 }
 
 fn configure_standalone_connection(

--- a/lib/bencher_valid/src/plus/plan_level.rs
+++ b/lib/bencher_valid/src/plus/plan_level.rs
@@ -11,9 +11,11 @@ use crate::ValidError;
 
 const FREE: &str = "free";
 const TEAM: &str = "team";
+const PRO: &str = "pro";
 const ENTERPRISE: &str = "enterprise";
 // These are the Stripe product names
 const BENCHER_TEAM: &str = "Bencher Team";
+const BENCHER_PRO: &str = "Bencher Pro";
 const BENCHER_ENTERPRISE: &str = "Bencher Enterprise";
 
 #[typeshare::typeshare]
@@ -36,7 +38,10 @@ const BENCHER_ENTERPRISE: &str = "Bencher Enterprise";
 pub enum PlanLevel {
     #[default]
     Free,
+    // Legacy self-serve paid tier, retained for grandfathered customers.
+    // New self-serve signups use `Pro`.
     Team,
+    Pro,
     Enterprise,
 }
 
@@ -47,6 +52,7 @@ impl TryFrom<String> for PlanLevel {
         match plan_level.as_str() {
             FREE => Ok(Self::Free),
             TEAM | BENCHER_TEAM => Ok(Self::Team),
+            PRO | BENCHER_PRO => Ok(Self::Pro),
             ENTERPRISE | BENCHER_ENTERPRISE => Ok(Self::Enterprise),
             _ => Err(ValidError::PlanLevel(plan_level)),
         }
@@ -66,6 +72,7 @@ impl AsRef<str> for PlanLevel {
         match self {
             Self::Free => FREE,
             Self::Team => TEAM,
+            Self::Pro => PRO,
             Self::Enterprise => ENTERPRISE,
         }
     }
@@ -85,7 +92,7 @@ impl From<PlanLevel> for String {
 pub fn is_valid_plan_level(plan_level: &str) -> bool {
     matches!(
         plan_level,
-        FREE | TEAM | ENTERPRISE | BENCHER_TEAM | BENCHER_ENTERPRISE
+        FREE | TEAM | PRO | ENTERPRISE | BENCHER_TEAM | BENCHER_PRO | BENCHER_ENTERPRISE
     )
 }
 
@@ -98,8 +105,10 @@ mod tests {
     fn plan_level() {
         assert_eq!(true, is_valid_plan_level("free"));
         assert_eq!(true, is_valid_plan_level("team"));
+        assert_eq!(true, is_valid_plan_level("pro"));
         assert_eq!(true, is_valid_plan_level("enterprise"));
         assert_eq!(true, is_valid_plan_level("Bencher Team"));
+        assert_eq!(true, is_valid_plan_level("Bencher Pro"));
         assert_eq!(true, is_valid_plan_level("Bencher Enterprise"));
 
         assert_eq!(false, is_valid_plan_level(""));
@@ -118,6 +127,11 @@ mod tests {
         assert_eq!(level, PlanLevel::Team);
         let json = serde_json::to_string(&level).unwrap();
         assert_eq!(json, "\"team\"");
+
+        let level: PlanLevel = serde_json::from_str("\"pro\"").unwrap();
+        assert_eq!(level, PlanLevel::Pro);
+        let json = serde_json::to_string(&level).unwrap();
+        assert_eq!(json, "\"pro\"");
 
         serde_json::from_str::<PlanLevel>("\"invalid\"").unwrap_err();
     }

--- a/plus/bencher_billing/Cargo.toml
+++ b/plus/bencher_billing/Cargo.toml
@@ -26,7 +26,7 @@ plus = [
 
 [dependencies]
 async-stripe = { workspace = true, optional = true, features = ["rustls-aws-lc-rs", "rustls-tls-webpki-roots"] }
-async-stripe-billing = { workspace = true, optional = true, features = ["billing_meter_event", "subscription", "subscription_item"] }
+async-stripe-billing = { workspace = true, optional = true, features = ["billing_credit_grant", "billing_meter_event", "subscription", "subscription_item"] }
 async-stripe-checkout = { workspace = true, optional = true, features = ["checkout_session"] }
 async-stripe-core = { workspace = true, optional = true, features = ["customer"] }
 async-stripe-payment = { workspace = true, optional = true, features = ["payment_method"] }

--- a/plus/bencher_billing/src/biller.rs
+++ b/plus/bencher_billing/src/biller.rs
@@ -6,28 +6,38 @@ use std::{
 use bencher_json::{
     Email, Entitlements, LicensedPlanId, MeteredPlanId, OrganizationUuid, PlanLevel, PlanStatus,
     organization::plan::{
-        JsonCardDetails, JsonPlan, METRICS_METER_NAME, RUNNER_MINUTES_METER_NAME,
+        DEFAULT_PRICE_NAME, JsonCardDetails, JsonPlan, METRICS_METER_NAME,
+        RUNNER_MINUTES_METER_NAME,
     },
     system::{
         config::JsonBilling,
         payment::{JsonCard, JsonCheckout, JsonCustomer},
     },
 };
-use stripe::Client as StripeClient;
+use stripe::{Client as StripeClient, IdempotencyKey, RequestStrategy, StripeRequest as _};
 use stripe_billing::{
     BillingMeterEvent, Subscription, SubscriptionId, SubscriptionItem, SubscriptionStatus,
+    billing_credit_grant::{
+        CreateBillingCreditGrant, CreateBillingCreditGrantAmount,
+        CreateBillingCreditGrantAmountMonetary, CreateBillingCreditGrantAmountType,
+        CreateBillingCreditGrantApplicabilityConfig,
+        CreateBillingCreditGrantApplicabilityConfigScope,
+        CreateBillingCreditGrantApplicabilityConfigScopePrices, ListBillingCreditGrant,
+    },
     billing_meter_event::CreateBillingMeterEvent,
     subscription::{
-        CancelSubscription, CreateSubscription, CreateSubscriptionItems, RetrieveSubscription,
+        CancelSubscription, CreateSubscription, CreateSubscriptionItems, DiscountsDataParam,
+        RetrieveSubscription, UpdateSubscription,
     },
 };
 use stripe_checkout::{
     CheckoutSessionId, CheckoutSessionMode, CheckoutSessionUiMode,
     checkout_session::{
         CreateCheckoutSession, CreateCheckoutSessionConsentCollection,
-        CreateCheckoutSessionConsentCollectionTermsOfService, CreateCheckoutSessionLineItems,
-        CreateCheckoutSessionLineItemsAdjustableQuantity, CreateCheckoutSessionPaymentMethodTypes,
-        CreateCheckoutSessionSubscriptionData, RetrieveCheckoutSession,
+        CreateCheckoutSessionConsentCollectionTermsOfService, CreateCheckoutSessionDiscounts,
+        CreateCheckoutSessionLineItems, CreateCheckoutSessionLineItemsAdjustableQuantity,
+        CreateCheckoutSessionPaymentMethodTypes, CreateCheckoutSessionSubscriptionData,
+        RetrieveCheckoutSession,
     },
 };
 use stripe_core::customer::{CreateCustomer, ListCustomer};
@@ -53,6 +63,15 @@ const METER_CUSTOMER_KEY: &str = "stripe_customer_id";
 /// Stripe meter event payload key for the usage value.
 const METER_VALUE_KEY: &str = "value";
 
+/// Credit grant metadata key marking a grant as Bencher-managed.
+const CREDIT_MANAGED_KEY: &str = "bencher_managed";
+/// Credit grant metadata key holding the billing-period start, used to
+/// idempotently grant exactly one included-usage credit per period.
+const CREDIT_PERIOD_KEY: &str = "period_start";
+/// Descriptive name shown in the Stripe Dashboard for the Pro usage credit.
+const PRO_CREDIT_NAME: &str = "Bencher Pro included usage credit";
+
+#[derive(Clone)]
 pub struct Biller {
     client: StripeClient,
     products: Products,
@@ -62,6 +81,10 @@ pub struct Biller {
 enum PlusPlan {
     Free,
     Team(PlusUsage),
+    // Bencher Cloud metered tier with a flat monthly base fee and an included
+    // usage credit. The `String` is the price name for the metrics meter; the
+    // base price is looked up separately. Pro has no licensed (self-hosted) form.
+    Pro(String),
     Enterprise(PlusUsage),
 }
 
@@ -76,6 +99,7 @@ impl PlusPlan {
         match plan_level {
             PlanLevel::Free => Self::Free,
             PlanLevel::Team => Self::Team(PlusUsage::Metered(price_name)),
+            PlanLevel::Pro => Self::Pro(price_name),
             PlanLevel::Enterprise => Self::Enterprise(PlusUsage::Metered(price_name)),
         }
     }
@@ -84,6 +108,9 @@ impl PlusPlan {
         match plan_level {
             PlanLevel::Free => Self::Free,
             PlanLevel::Team => Self::Team(PlusUsage::Licensed(price_name, entitlements)),
+            // Pro is a Bencher Cloud metered tier only; it has no licensed form.
+            // The API layer rejects licensed Pro before reaching here.
+            PlanLevel::Pro => Self::Pro(price_name),
             PlanLevel::Enterprise => {
                 Self::Enterprise(PlusUsage::Licensed(price_name, entitlements))
             },
@@ -91,17 +118,35 @@ impl PlusPlan {
     }
 
     fn bare_metal_price<'a>(&self, products: &'a Products) -> Result<&'a Price, BillingError> {
-        let usage = match self {
+        let (pricing, price_name) = match self {
             Self::Free => return Err(BillingError::ProductLevelFree),
-            Self::Team(usage) | Self::Enterprise(usage) => usage,
-        };
-        let (pricing, price_name) = match usage {
-            PlusUsage::Metered(price_name) => (&products.bare_metal.metered, price_name),
-            PlusUsage::Licensed(price_name, _) => (&products.bare_metal.licensed, price_name),
+            Self::Team(usage) | Self::Enterprise(usage) => match usage {
+                PlusUsage::Metered(price_name) => (&products.bare_metal.metered, price_name),
+                PlusUsage::Licensed(price_name, _) => (&products.bare_metal.licensed, price_name),
+            },
+            Self::Pro(price_name) => (&products.bare_metal.metered, price_name),
         };
         pricing
             .get(price_name.as_str())
             .ok_or_else(|| BillingError::PriceNotFound(price_name.clone()))
+    }
+
+    // The flat recurring base fee for this plan, if any. Only Pro has one.
+    fn base_price<'a>(&self, products: &'a Products) -> Result<Option<&'a Price>, BillingError> {
+        match self {
+            Self::Pro(price_name) => products
+                .pro
+                .base
+                .get(price_name.as_str())
+                .map(Some)
+                .ok_or_else(|| BillingError::PriceNotFound(price_name.clone())),
+            Self::Free | Self::Team(_) | Self::Enterprise(_) => Ok(None),
+        }
+    }
+
+    // Whether this is the Pro tier (gets the free-trial coupon and monthly credit).
+    fn is_pro(&self) -> bool {
+        matches!(self, Self::Pro(_))
     }
 
     fn into_plus_price(
@@ -128,6 +173,14 @@ impl PlusPlan {
                     Some(entitlements),
                 ),
             },
+            PlusPlan::Pro(price_name) => (
+                products
+                    .pro
+                    .metered
+                    .get(&price_name)
+                    .ok_or(BillingError::PriceNotFound(price_name))?,
+                None,
+            ),
             PlusPlan::Enterprise(plus_usage) => match plus_usage {
                 PlusUsage::Metered(price_name) => (
                     products
@@ -215,6 +268,8 @@ impl Biller {
             PlusPlan::metered(plan_level, price_name)
         };
         let bare_metal_price = plus_plan.bare_metal_price(&self.products)?;
+        let base_price = plus_plan.base_price(&self.products)?;
+        let is_pro = plus_plan.is_pro();
         let (plus_price, entitlements) = plus_plan.into_plus_price(&self.products)?;
 
         let mut plus_line_item = CreateCheckoutSessionLineItems {
@@ -234,6 +289,18 @@ impl Biller {
             ..Default::default()
         };
 
+        // Pro adds a flat monthly base fee billed alongside the metered usage.
+        let mut line_items = Vec::new();
+        if let Some(base_price) = base_price {
+            line_items.push(CreateCheckoutSessionLineItems {
+                price: Some(base_price.id.to_string()),
+                quantity: Some(1),
+                ..Default::default()
+            });
+        }
+        line_items.push(plus_line_item);
+        line_items.push(bare_metal_line_item);
+
         let mut consent = CreateCheckoutSessionConsentCollection::new();
         // https://bencher.dev/legal/subscription/
         consent.terms_of_service =
@@ -246,18 +313,26 @@ impl Biller {
                 .collect(),
         );
 
-        let mut checkout_session = CreateCheckoutSession::new()
+        let mut create_checkout_session = CreateCheckoutSession::new()
             .ui_mode(CheckoutSessionUiMode::HostedPage)
             .customer(customer.to_string())
             .payment_method_types(vec![CreateCheckoutSessionPaymentMethodTypes::Card])
             .currency(Currency::USD)
             .mode(CheckoutSessionMode::Subscription)
-            .line_items(vec![plus_line_item, bare_metal_line_item])
+            .line_items(line_items)
             .consent_collection(consent)
             .subscription_data(sub_data)
-            .success_url(return_url)
-            .send(&self.client)
-            .await?;
+            .success_url(return_url);
+        // Pro free trial: waive the first month's base fee via a one-time coupon.
+        // Metered usage still bills, offset by the monthly included-usage credit.
+        if let Some(coupon) = self.products.pro.trial_coupon.as_ref().filter(|_| is_pro) {
+            create_checkout_session =
+                create_checkout_session.discounts(vec![CreateCheckoutSessionDiscounts {
+                    coupon: Some(coupon.clone()),
+                    promotion_code: None,
+                }]);
+        }
+        let mut checkout_session = create_checkout_session.send(&self.client).await?;
 
         Ok(JsonCheckout {
             session: checkout_session.id.to_string(),
@@ -397,24 +472,44 @@ impl Biller {
         plus_plan: PlusPlan,
     ) -> Result<Subscription, BillingError> {
         let bare_metal_price = plus_plan.bare_metal_price(&self.products)?;
+        let base_price = plus_plan.base_price(&self.products)?;
+        let is_pro = plus_plan.is_pro();
         let (plus_price, entitlements) = plus_plan.into_plus_price(&self.products)?;
 
+        // Pro adds a flat monthly base fee billed alongside the metered usage.
+        let mut items = Vec::new();
+        if let Some(base_price) = base_price {
+            let mut base_item = CreateSubscriptionItems::new();
+            base_item.price = Some(base_price.id.to_string());
+            base_item.quantity = Some(1);
+            items.push(base_item);
+        }
         let mut plus_item = CreateSubscriptionItems::new();
         plus_item.price = Some(plus_price.id.to_string());
         plus_item.quantity = entitlements.map(Into::into);
-
+        items.push(plus_item);
         let mut bare_metal_item = CreateSubscriptionItems::new();
         bare_metal_item.price = Some(bare_metal_price.id.to_string());
+        items.push(bare_metal_item);
 
-        CreateSubscription::new()
+        let mut create_subscription = CreateSubscription::new()
             .customer(customer_id.to_string())
-            .items(vec![plus_item, bare_metal_item])
+            .items(items)
             .default_payment_method(payment_method_id.to_string())
             .metadata(
                 [(METADATA_ORGANIZATION.to_owned(), organization.to_string())]
                     .into_iter()
                     .collect::<HashMap<String, String>>(),
-            )
+            );
+        // Pro free trial: waive the first month's base fee via a one-time coupon.
+        if let Some(coupon) = self.products.pro.trial_coupon.as_ref().filter(|_| is_pro) {
+            create_subscription = create_subscription.discounts(vec![DiscountsDataParam {
+                coupon: Some(coupon.clone()),
+                discount: None,
+                promotion_code: None,
+            }]);
+        }
+        create_subscription
             .send(&self.client)
             .await
             .map_err(Into::into)
@@ -504,6 +599,7 @@ impl Biller {
             current_period_start,
             current_period_end,
             status,
+            cancel_at_period_end: subscription.cancel_at_period_end,
             license: None,
         })
     }
@@ -716,12 +812,166 @@ impl Biller {
         .map_err(Into::into)
     }
 
+    /// Idempotently grant the current billing period's included usage credit for
+    /// a metered (Pro) subscription. The credit is a single fungible pool scoped
+    /// to the metrics and runner meters, expiring at period end
+    /// (use-it-or-lose-it). A no-op if this period's grant already exists.
+    /// Returns whether a new grant was created.
+    pub async fn ensure_period_credit(
+        &self,
+        metered_plan_id: &MeteredPlanId,
+        value_cents: i64,
+    ) -> Result<bool, BillingError> {
+        let subscription_id: SubscriptionId = metered_plan_id.as_ref().into();
+        let subscription = self
+            .get_subscription_expand(&subscription_id, vec!["items".into()])
+            .await?;
+
+        // Only Pro subscriptions (which include the flat base item) receive the
+        // included usage credit. Grandfathered Team metered plans have no base
+        // item, so this is a safe no-op for them.
+        let base_price_ids: HashSet<&PriceId> = self
+            .products
+            .pro
+            .base
+            .values()
+            .map(|price| &price.id)
+            .collect();
+        let is_pro = subscription_has_base(
+            subscription.items.data.iter().map(|item| &item.price.id),
+            &base_price_ids,
+        );
+        if !is_pro {
+            return Ok(false);
+        }
+
+        let customer_id = subscription.customer.id().clone();
+        // All subscription items share the same billing period.
+        let item = subscription
+            .items
+            .data
+            .first()
+            .ok_or_else(|| BillingError::NoSubscriptionItem(subscription_id.clone()))?;
+        let period_start = item.current_period_start;
+        let period_end = item.current_period_end;
+
+        // Dedup: skip if this period's credit has already been granted.
+        let marker = period_start.to_string();
+        let grants = ListBillingCreditGrant::new()
+            .customer(customer_id.to_string())
+            .limit(100)
+            .send(&self.client)
+            .await?;
+        if period_already_granted(
+            grants
+                .data
+                .iter()
+                .map(|grant| grant.metadata.get(CREDIT_PERIOD_KEY).map(String::as_str)),
+            &marker,
+        ) {
+            return Ok(false);
+        }
+
+        self.create_credit_grant(&customer_id, value_cents, period_start, period_end)
+            .await?;
+        Ok(true)
+    }
+
+    async fn create_credit_grant(
+        &self,
+        customer_id: &CustomerId,
+        value_cents: i64,
+        period_start: stripe_types::Timestamp,
+        period_end: stripe_types::Timestamp,
+    ) -> Result<(), BillingError> {
+        let prices = self
+            .pro_credit_price_ids()?
+            .into_iter()
+            .map(CreateBillingCreditGrantApplicabilityConfigScopePrices::new)
+            .collect();
+        let scope = CreateBillingCreditGrantApplicabilityConfigScope {
+            price_type: None,
+            prices: Some(prices),
+        };
+        let amount = CreateBillingCreditGrantAmount {
+            monetary: Some(CreateBillingCreditGrantAmountMonetary::new(
+                Currency::USD,
+                value_cents,
+            )),
+            type_: CreateBillingCreditGrantAmountType::Monetary,
+        };
+        let metadata = HashMap::from([
+            (CREDIT_MANAGED_KEY.to_owned(), "true".to_owned()),
+            (CREDIT_PERIOD_KEY.to_owned(), period_start.to_string()),
+        ]);
+        // Idempotency key from customer + period so concurrent grant attempts
+        // (e.g. plan creation overlapping the daily sweep) collapse to one grant.
+        // The list-check above handles dedup across periods (beyond the key's TTL).
+        let idempotency_key =
+            IdempotencyKey::new(format!("bencher-credit:{customer_id}:{period_start}"))?;
+        CreateBillingCreditGrant::new(
+            amount,
+            CreateBillingCreditGrantApplicabilityConfig { scope },
+        )
+        .customer(customer_id.to_string())
+        .effective_at(period_start)
+        .expires_at(period_end)
+        .metadata(metadata)
+        .name(PRO_CREDIT_NAME)
+        .customize()
+        .request_strategy(RequestStrategy::Idempotent(idempotency_key))
+        .send(&self.client)
+        .await
+        .map(|_grant| ())
+        .map_err(Into::into)
+    }
+
+    // Price IDs the Pro included usage credit applies to: the metrics meter and
+    // the bare-metal runner meter, forming a single fungible pool.
+    fn pro_credit_price_ids(&self) -> Result<Vec<String>, BillingError> {
+        let metrics = self
+            .products
+            .pro
+            .metered
+            .get(DEFAULT_PRICE_NAME)
+            .ok_or_else(|| BillingError::PriceNotFound(DEFAULT_PRICE_NAME.to_owned()))?;
+        let runner = self
+            .products
+            .bare_metal
+            .metered
+            .get(DEFAULT_PRICE_NAME)
+            .ok_or_else(|| BillingError::PriceNotFound(DEFAULT_PRICE_NAME.to_owned()))?;
+        Ok(vec![metrics.id.to_string(), runner.id.to_string()])
+    }
+
+    /// Schedule a metered (Pro) subscription to cancel at the end of the current
+    /// billing period. The customer keeps access through the period they have
+    /// already paid for; the subscription stays active until it then lapses
+    /// (reconciled lazily on read and by the daily sweep).
     pub async fn cancel_metered_subscription(
         &self,
         metered_plan_id: &MeteredPlanId,
     ) -> Result<Subscription, BillingError> {
         let subscription_id: SubscriptionId = metered_plan_id.as_ref().into();
-        self.cancel_subscription(&subscription_id).await
+        UpdateSubscription::new(subscription_id)
+            .cancel_at_period_end(true)
+            .send(&self.client)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Clear a scheduled cancellation on a metered (Pro) subscription, resuming
+    /// it before the current period ends.
+    pub async fn resume_metered_subscription(
+        &self,
+        metered_plan_id: &MeteredPlanId,
+    ) -> Result<Subscription, BillingError> {
+        let subscription_id: SubscriptionId = metered_plan_id.as_ref().into();
+        UpdateSubscription::new(subscription_id)
+            .cancel_at_period_end(false)
+            .send(&self.client)
+            .await
+            .map_err(Into::into)
     }
 
     pub async fn cancel_licensed_subscription(
@@ -743,6 +993,25 @@ impl Biller {
     }
 }
 
+/// Whether a subscription (by its item price IDs) includes one of the given base
+/// prices — i.e. it carries a flat base fee (the Pro tier). Gates included-usage
+/// credit to base-fee subscriptions only.
+fn subscription_has_base<'a>(
+    mut item_price_ids: impl Iterator<Item = &'a PriceId>,
+    base_price_ids: &HashSet<&'a PriceId>,
+) -> bool {
+    item_price_ids.any(|id| base_price_ids.contains(id))
+}
+
+/// Whether a credit grant for the given billing-period marker already exists
+/// (per-period dedup for `ensure_period_credit`).
+fn period_already_granted<'a>(
+    mut grant_period_markers: impl Iterator<Item = Option<&'a str>>,
+    marker: &'a str,
+) -> bool {
+    grant_period_markers.any(|m| m == Some(marker))
+}
+
 fn into_payment_card(card: JsonCard) -> CreatePaymentMethodCardDetailsParams {
     let JsonCard {
         number,
@@ -760,7 +1029,7 @@ fn into_payment_card(card: JsonCard) -> CreatePaymentMethodCardDetailsParams {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
 
     use bencher_json::{
         Entitlements, OrganizationUuid, PlanLevel, PlanStatus, UserUuid,
@@ -779,7 +1048,43 @@ mod tests {
 
     use crate::Biller;
 
-    use super::{METER_CUSTOMER_KEY, METER_VALUE_KEY};
+    use super::{
+        METER_CUSTOMER_KEY, METER_VALUE_KEY, period_already_granted, subscription_has_base,
+    };
+
+    #[test]
+    fn subscription_has_base_detects_base_fee() {
+        let base: stripe_product::PriceId = "price_base".parse().unwrap();
+        let metered: stripe_product::PriceId = "price_metered".parse().unwrap();
+        let other: stripe_product::PriceId = "price_other".parse().unwrap();
+        let base_price_ids: HashSet<&stripe_product::PriceId> = std::iter::once(&base).collect();
+        // A subscription carrying the base price is detected as a base-fee (Pro) plan.
+        assert!(subscription_has_base(
+            [&metered, &base].into_iter(),
+            &base_price_ids,
+        ));
+        // A subscription without the base price (e.g. grandfathered Team) is not.
+        assert!(!subscription_has_base(
+            [&metered, &other].into_iter(),
+            &base_price_ids,
+        ));
+    }
+
+    #[test]
+    fn period_already_granted_matches_marker() {
+        assert!(period_already_granted(
+            [Some("100"), None].into_iter(),
+            "100"
+        ));
+        assert!(!period_already_granted(
+            [Some("100"), None].into_iter(),
+            "200"
+        ));
+        assert!(!period_already_granted(
+            std::iter::empty::<Option<&str>>(),
+            "100",
+        ));
+    }
 
     const TEST_BILLING_KEY: &str = "TEST_BILLING_KEY";
 
@@ -797,6 +1102,23 @@ mod tests {
                 licensed: hmap! {
                     "default".to_owned() => "price_1O4XlwKal5vzTlmh0n0wtplQ".to_owned(),
                 },
+                base: HashMap::new(),
+                trial_coupon: None,
+            },
+            // TODO: replace with a dedicated `Bencher Pro` Stripe test product +
+            // `$20/mo` flat base price + `$0.01` metrics meter. For now this reuses
+            // Team's test product/prices (metered metrics + a flat licensed price as
+            // the base) so `Products::new` resolves in Stripe test mode.
+            pro: JsonProduct {
+                id: "prod_NKz5B9dGhDiSY1".into(),
+                metered: hmap! {
+                    "default".to_owned() => "price_1T8NRdKal5vzTlmhBfL9IdMi".to_owned(),
+                },
+                licensed: HashMap::new(),
+                base: hmap! {
+                    "default".to_owned() => "price_1O4XlwKal5vzTlmh0n0wtplQ".to_owned(),
+                },
+                trial_coupon: None,
             },
             enterprise: JsonProduct {
                 id: "prod_NLC7fDet2C8Nmk".into(),
@@ -806,6 +1128,8 @@ mod tests {
                 licensed: hmap! {
                     "default".to_owned() => "price_1O4Xo1Kal5vzTlmh1KrcEbq0".to_owned(),
                 },
+                base: HashMap::new(),
+                trial_coupon: None,
             },
             bare_metal: JsonProduct {
                 id: "prod_U6a28ecwqRZHYz".into(),
@@ -815,6 +1139,8 @@ mod tests {
                 licensed: hmap! {
                     "default".to_owned() => "price_1TCWdkKal5vzTlmh9fdahWqY".to_owned(),
                 },
+                base: HashMap::new(),
+                trial_coupon: None,
             },
         }
     }
@@ -857,15 +1183,18 @@ mod tests {
         record_runner_usage(biller, &customer_id, runner_minutes).await;
         record_metrics_usage(biller, &customer_id, metrics_quantity).await;
 
-        biller
+        let canceled = biller
             .cancel_metered_subscription(&subscription_id.parse().unwrap())
             .await
             .unwrap();
+        // Cancellation is scheduled for period end: the subscription stays active
+        // (the customer keeps access) but is flagged to cancel at period end.
+        assert!(canceled.cancel_at_period_end);
         let (plan_status, _) = biller
             .get_metered_plan_status(metered_plan_id)
             .await
             .unwrap();
-        assert_eq!(plan_status, PlanStatus::Canceled);
+        assert!(plan_status.is_active());
     }
 
     async fn licensed_subscription(
@@ -953,7 +1282,7 @@ mod tests {
             id: price_id.parse().unwrap(),
             livemode: false,
             lookup_key: None,
-            metadata: std::collections::HashMap::new(),
+            metadata: HashMap::new(),
             nickname: None,
             product: stripe_types::Expandable::Id(
                 "prod_test".parse::<stripe_shared::ProductId>().unwrap(),
@@ -1001,7 +1330,7 @@ mod tests {
             current_period_start: 0,
             discounts: vec![],
             id: format!("si_test_{price_id}").parse().unwrap(),
-            metadata: std::collections::HashMap::new(),
+            metadata: HashMap::new(),
             plan: make_plan(),
             price: make_price(price_id),
             quantity: None,

--- a/plus/bencher_billing/src/error.rs
+++ b/plus/bencher_billing/src/error.rs
@@ -23,6 +23,8 @@ pub enum BillingError {
     IntError(#[from] std::num::TryFromIntError),
     #[error("Failed to send billing request: {0}")]
     Stripe(#[from] stripe::StripeError),
+    #[error("Failed to build idempotency key: {0}")]
+    IdempotencyKey(#[from] stripe::IdempotentKeyError),
     #[error("Email collision: {0:#?} {1:#?}")]
     EmailCollision(Box<Customer>, Vec<Customer>),
     #[error("Failed to find price: {0}")]

--- a/plus/bencher_billing/src/products.rs
+++ b/plus/bencher_billing/src/products.rs
@@ -12,8 +12,11 @@ use stripe_product::{
 
 use crate::BillingError;
 
+#[derive(Clone)]
 pub struct Products {
+    // Legacy self-serve paid tier, retained for grandfathered customers.
     pub team: Product,
+    pub pro: Product,
     pub enterprise: Product,
     pub bare_metal: Product,
 }
@@ -22,12 +25,14 @@ impl Products {
     pub async fn new(client: &StripeClient, products: JsonProducts) -> Result<Self, BillingError> {
         let JsonProducts {
             team,
+            pro,
             enterprise,
             bare_metal,
         } = products;
 
         Ok(Self {
             team: Product::new(client, team).await?,
+            pro: Product::new(client, pro).await?,
             enterprise: Product::new(client, enterprise).await?,
             bare_metal: Product::new(client, bare_metal).await?,
         })
@@ -50,11 +55,13 @@ impl Products {
         self.team
             .preferred_price_ids(preferred)
             .into_iter()
+            .chain(self.pro.preferred_price_ids(preferred))
             .chain(self.enterprise.preferred_price_ids(preferred))
             .collect()
     }
 }
 
+#[derive(Clone)]
 pub struct Product {
     #[expect(
         dead_code,
@@ -64,6 +71,13 @@ pub struct Product {
     pub product: StripeProduct,
     pub metered: HashMap<String, StripePrice>,
     pub licensed: HashMap<String, StripePrice>,
+    // Flat recurring base prices (e.g. the Pro `$20/mo` platform fee).
+    // Deliberately excluded from `preferred_price_ids` so it is never treated
+    // as the metered "plan item" when resolving a subscription's plan level.
+    pub base: HashMap<String, StripePrice>,
+    // Stripe coupon ID for this product's free trial (waives the first month's
+    // base fee). `None` if the product has no trial. Only Pro uses it today.
+    pub trial_coupon: Option<String>,
 }
 
 impl Product {
@@ -72,17 +86,22 @@ impl Product {
             id,
             metered,
             licensed,
+            base,
+            trial_coupon,
         } = product;
 
         let product_id: ProductId = id.as_str().into();
         let product = RetrieveProduct::new(product_id).send(client).await?;
         let metered = Self::pricing(client, metered).await?;
         let licensed = Self::pricing(client, licensed).await?;
+        let base = Self::pricing(client, base).await?;
 
         Ok(Self {
             product,
             metered,
             licensed,
+            base,
+            trial_coupon,
         })
     }
 

--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -2201,6 +2201,89 @@
             "$ref": "#/components/responses/Error"
           }
         }
+      },
+      "patch": {
+        "tags": [
+          "organizations",
+          "plan"
+        ],
+        "operationId": "org_plan_patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization",
+            "description": "The slug or UUID for an organization.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ResourceId"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonUpdatePlan"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "headers": {
+              "access-control-allow-headers": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-allow-methods": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-allow-origin": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-expose-headers": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "x-total-count": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonPlan"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
       }
     },
     "/v0/organizations/{organization}/projects": {
@@ -14819,6 +14902,10 @@
       "JsonPlan": {
         "type": "object",
         "properties": {
+          "cancel_at_period_end": {
+            "description": "Whether the subscription is set to cancel at the end of the current period (the org keeps access until `current_period_end`, then downgrades to Free).",
+            "type": "boolean"
+          },
           "card": {
             "$ref": "#/components/schemas/JsonCardDetails"
           },
@@ -14853,6 +14940,7 @@
           }
         },
         "required": [
+          "cancel_at_period_end",
           "card",
           "current_period_end",
           "current_period_start",
@@ -15086,26 +15174,38 @@
       "JsonProduct": {
         "type": "object",
         "properties": {
+          "base": {
+            "default": {},
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
           "id": {
             "type": "string"
           },
           "licensed": {
+            "default": {},
             "type": "object",
             "additionalProperties": {
               "type": "string"
             }
           },
           "metered": {
+            "default": {},
             "type": "object",
             "additionalProperties": {
               "type": "string"
             }
+          },
+          "trial_coupon": {
+            "nullable": true,
+            "default": null,
+            "type": "string"
           }
         },
         "required": [
-          "id",
-          "licensed",
-          "metered"
+          "id"
         ]
       },
       "JsonProducts": {
@@ -15117,6 +15217,9 @@
           "enterprise": {
             "$ref": "#/components/schemas/JsonProduct"
           },
+          "pro": {
+            "$ref": "#/components/schemas/JsonProduct"
+          },
           "team": {
             "$ref": "#/components/schemas/JsonProduct"
           }
@@ -15124,6 +15227,7 @@
         "required": [
           "bare_metal",
           "enterprise",
+          "pro",
           "team"
         ]
       },
@@ -17364,6 +17468,18 @@
           }
         ]
       },
+      "JsonUpdatePlan": {
+        "type": "object",
+        "properties": {
+          "cancel_at_period_end": {
+            "description": "Update the subscription's scheduled cancellation. Set to `false` to resume a plan scheduled to cancel at period end, or `true` to schedule it to cancel at the end of the current period. Only applies to metered (Pro) plans.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "cancel_at_period_end"
+        ]
+      },
       "JsonUpdatePlot": {
         "anyOf": [
           {
@@ -18056,6 +18172,7 @@
         "enum": [
           "free",
           "team",
+          "pro",
           "enterprise"
         ]
       },

--- a/services/cli/src/bencher/sub/organization/plan/create.rs
+++ b/services/cli/src/bencher/sub/organization/plan/create.rs
@@ -48,6 +48,7 @@ impl From<CliPlanLevel> for PlanLevel {
         match level {
             CliPlanLevel::Free => Self::Free,
             CliPlanLevel::Team => Self::Team,
+            CliPlanLevel::Pro => Self::Pro,
             CliPlanLevel::Enterprise => Self::Enterprise,
         }
     }

--- a/services/cli/src/parser/organization/plan.rs
+++ b/services/cli/src/parser/organization/plan.rs
@@ -76,6 +76,8 @@ pub enum CliPlanLevel {
     Free,
     /// Team
     Team,
+    /// Pro
+    Pro,
     /// Enterprise
     Enterprise,
 }

--- a/services/console/src/components/console/billing/BillingPanel.tsx
+++ b/services/console/src/components/console/billing/BillingPanel.tsx
@@ -16,10 +16,13 @@ import {
 	type JsonAuthUser,
 	type JsonUsage,
 	type Jwt,
+	PlanLevel,
 	UsageKind,
 } from "../../../types/bencher";
 import { authUser } from "../../../util/auth";
 import {
+	PRO_BASE_USD,
+	PRO_INCLUDED_CREDIT_USD,
 	fmtDate,
 	fmtUsd,
 	fmtUsdPrecise,
@@ -28,7 +31,7 @@ import {
 	runnerMinutePrice,
 	suggestedMetrics,
 } from "../../../util/convert";
-import { httpGet, httpPatch } from "../../../util/http";
+import { httpDelete, httpGet, httpPatch } from "../../../util/http";
 import { NotifyKind, pageNotify } from "../../../util/notify";
 import { type InitValid, init_valid, validJwt } from "../../../util/valid";
 import Field from "../../field/Field";
@@ -154,7 +157,12 @@ const BillingPanelSwitch = (props: {
 				/>
 			</Match>
 			<Match when={props.usage()?.kind === UsageKind.CloudMetered}>
-				<CloudMeteredPanel usage={props.usage} />
+				<CloudMeteredPanel
+					apiUrl={props.apiUrl}
+					user={props.user}
+					usage={props.usage}
+					handleRefresh={props.handleRefresh}
+				/>
 			</Match>
 			<Match when={props.usage()?.kind === UsageKind.CloudSelfHostedLicensed}>
 				<CloudSelfHostedLicensedPanel
@@ -186,8 +194,154 @@ const manageSubscription = (
 	</a>
 );
 
+const CancelPlanButton = (props: {
+	apiUrl: string;
+	user: JsonAuthUser;
+	organization: undefined | string;
+	handleRefresh: () => void;
+}) => {
+	const [clicked, setClicked] = createSignal(false);
+	const [canceling, setCanceling] = createSignal(false);
+
+	const sendCancel = () => {
+		const token = props.user?.token;
+		const organization = props.organization;
+		if (!validJwt(token) || !organization) {
+			return;
+		}
+		setCanceling(true);
+		httpDelete(props.apiUrl, `/v0/organizations/${organization}/plan`, token)
+			.then((_resp) => {
+				setCanceling(false);
+				setClicked(false);
+				props.handleRefresh();
+				pageNotify(
+					NotifyKind.OK,
+					"Your Pro plan will cancel at the end of the current billing period. You keep access until then.",
+				);
+			})
+			.catch((error) => {
+				setCanceling(false);
+				console.error(error);
+				Sentry.captureException(error);
+				pageNotify(
+					NotifyKind.ERROR,
+					"Lettuce romaine calm! Failed to cancel your plan. Please, try again.",
+				);
+			});
+	};
+
+	return (
+		<Switch>
+			<Match when={!clicked()}>
+				<button
+					class="button is-small"
+					type="button"
+					onMouseDown={(e) => {
+						e.preventDefault();
+						setClicked(true);
+					}}
+				>
+					Cancel plan
+				</button>
+			</Match>
+			<Match when={clicked()}>
+				<div class="content">
+					<p>
+						Cancel your plan? It stays active until the end of the current
+						billing period, then downgrades to Free. Private projects will no
+						longer be accessible after that.
+					</p>
+				</div>
+				<div class="columns">
+					<div class="column">
+						<button
+							class="button is-fullwidth"
+							type="submit"
+							disabled={canceling()}
+							onMouseDown={(e) => {
+								e.preventDefault();
+								sendCancel();
+							}}
+						>
+							Yes, cancel at period end
+						</button>
+					</div>
+					<div class="column">
+						<button
+							class="button is-primary is-fullwidth"
+							type="button"
+							onMouseDown={(e) => {
+								e.preventDefault();
+								setClicked(false);
+							}}
+						>
+							Keep plan
+						</button>
+					</div>
+				</div>
+			</Match>
+		</Switch>
+	);
+};
+
+const ResumePlanButton = (props: {
+	apiUrl: string;
+	user: JsonAuthUser;
+	organization: undefined | string;
+	handleRefresh: () => void;
+}) => {
+	const [resuming, setResuming] = createSignal(false);
+
+	const sendResume = () => {
+		const token = props.user?.token;
+		const organization = props.organization;
+		if (!validJwt(token) || !organization) {
+			return;
+		}
+		setResuming(true);
+		httpPatch(props.apiUrl, `/v0/organizations/${organization}/plan`, token, {
+			cancel_at_period_end: false,
+		})
+			.then((_resp) => {
+				setResuming(false);
+				props.handleRefresh();
+				pageNotify(
+					NotifyKind.OK,
+					"Your Pro plan has been resumed. It will keep renewing each billing period.",
+				);
+			})
+			.catch((error) => {
+				setResuming(false);
+				console.error(error);
+				Sentry.captureException(error);
+				pageNotify(
+					NotifyKind.ERROR,
+					"Lettuce romaine calm! Failed to resume your plan. Please, try again.",
+				);
+			});
+	};
+
+	return (
+		<button
+			class="button is-primary is-small"
+			type="button"
+			disabled={resuming()}
+			onMouseDown={(e) => {
+				e.preventDefault();
+				sendResume();
+			}}
+		>
+			Resume plan
+		</button>
+	);
+};
+
 const CloudMeteredPanel = (props: {
+	apiUrl: string;
+	user: JsonAuthUser;
 	usage: Resource<null | JsonUsage>;
+	handleRefresh: () => void;
 }) => {
 	const metricPrice = createMemo(() =>
 		planLevelPrice(props.usage()?.plan?.level),
@@ -202,6 +356,14 @@ const CloudMeteredPanel = (props: {
 		() => (props.usage()?.runner_minutes ?? 0) * minutePrice(),
 	);
 	const estTotalCost = createMemo(() => estMetricsCost() + estRunnerCost());
+	const isPro = createMemo(() => props.usage()?.plan?.level === PlanLevel.Pro);
+	const creditRemaining = createMemo(() =>
+		Math.max(0, PRO_INCLUDED_CREDIT_USD - estTotalCost()),
+	);
+	// Pro bill = $20 base + overage at the same rates = max($20, usage).
+	const estProBill = createMemo(
+		() => PRO_BASE_USD + Math.max(0, estTotalCost() - PRO_INCLUDED_CREDIT_USD),
+	);
 
 	return (
 		<div class="content">
@@ -212,6 +374,17 @@ const CloudMeteredPanel = (props: {
 				{fmtDate(props.usage()?.start_time)} -{" "}
 				{fmtDate(props.usage()?.end_time)}
 			</h3>
+			<Show when={isPro()}>
+				<h4>
+					Included Usage Credit: {fmtUsd(PRO_INCLUDED_CREDIT_USD)} / month
+				</h4>
+				<h4>
+					Estimated Credit Used:{" "}
+					{fmtUsd(Math.min(estTotalCost(), PRO_INCLUDED_CREDIT_USD))}
+				</h4>
+				<h4>Estimated Credit Remaining: {fmtUsd(creditRemaining())}</h4>
+				<br />
+			</Show>
 			<h4>Cost per Metric: {fmtUsd(metricPrice())}</h4>
 			<h4>
 				Estimated Metrics Used: {props.usage()?.metrics?.toLocaleString() ?? 0}
@@ -225,11 +398,45 @@ const CloudMeteredPanel = (props: {
 			</h4>
 			<h4>Estimated Runner Cost: {fmtUsd(estRunnerCost())}</h4>
 			<br />
-			<h4>Current Estimated Total: {fmtUsd(estTotalCost())}</h4>
+			<h4>
+				Current Estimated Total:{" "}
+				{fmtUsd(isPro() ? estProBill() : estTotalCost())}
+			</h4>
+			<Show when={isPro()}>
+				<p>
+					$20/mo base includes $20 of usage. Overage bills at the same rates
+					once the included credit is used.
+				</p>
+			</Show>
 			<br />
 			<PaymentMethod usage={props.usage} />
 			<br />
 			{manageSubscription}
+			<br />
+			<br />
+			<Show
+				when={props.usage()?.plan?.cancel_at_period_end}
+				fallback={
+					<CancelPlanButton
+						apiUrl={props.apiUrl}
+						user={props.user}
+						organization={props.usage()?.organization}
+						handleRefresh={props.handleRefresh}
+					/>
+				}
+			>
+				<p class="has-text-grey">
+					Your plan is scheduled to cancel on{" "}
+					{fmtDate(props.usage()?.plan?.current_period_end)}. You keep access
+					until then.
+				</p>
+				<ResumePlanButton
+					apiUrl={props.apiUrl}
+					user={props.user}
+					organization={props.usage()?.organization}
+					handleRefresh={props.handleRefresh}
+				/>
+			</Show>
 		</div>
 	);
 };

--- a/services/console/src/components/console/billing/plan/BillingForm.tsx
+++ b/services/console/src/components/console/billing/plan/BillingForm.tsx
@@ -15,6 +15,7 @@ import {
 	PlanLevel,
 } from "../../../../types/bencher";
 import { fmtDate } from "../../../../util/convert";
+import { BENCHER_CALENDLY_URL } from "../../../../util/ext";
 import { useSearchParams } from "../../../../util/url";
 import {
 	type InitValid,
@@ -30,7 +31,7 @@ import { getThemeColor } from "../../../navbar/theme/util";
 import {
 	ENTERPRISE_TEXT,
 	FREE_TEXT,
-	TEAM_TEXT,
+	PRO_TEXT,
 } from "../../../pricing/ConsoleFallbackPricingTable";
 import Checkout from "./Checkout";
 
@@ -65,6 +66,7 @@ const BillingForm = (props: Props) => {
 			case PlanLevel.Free:
 				return null;
 			case PlanLevel.Team:
+			case PlanLevel.Pro:
 			case PlanLevel.Enterprise:
 				return entitlements() * 10_000;
 		}
@@ -74,6 +76,7 @@ const BillingForm = (props: Props) => {
 			case PlanLevel.Free:
 				return 0.0;
 			case PlanLevel.Team:
+			case PlanLevel.Pro:
 				return (entitlementsAnnual() ?? 0.0) * 0.01;
 			case PlanLevel.Enterprise:
 				return (entitlementsAnnual() ?? 0.0) * 0.05;
@@ -118,9 +121,9 @@ const BillingForm = (props: Props) => {
 			return;
 		}
 		if (!validPlanLevel(searchParams[PLAN_PARAM])) {
-			setPlanLevel(props.onboard ? PlanLevel.Team : PlanLevel.Free);
+			setPlanLevel(props.onboard ? PlanLevel.Pro : PlanLevel.Free);
 		} else if (props.onboard && plan() === PlanLevel.Free) {
-			setPlanLevel(PlanLevel.Team);
+			setPlanLevel(PlanLevel.Pro);
 		}
 	});
 
@@ -132,8 +135,8 @@ const BillingForm = (props: Props) => {
 				freeText={FREE_TEXT}
 				handleFree={() => setPlanLevel(PlanLevel.Free)}
 				hideFree={props.onboard}
-				teamText={TEAM_TEXT}
-				handleTeam={() => setPlanLevel(PlanLevel.Team)}
+				proText={PRO_TEXT}
+				handlePro={() => setPlanLevel(PlanLevel.Pro)}
 				enterpriseText={ENTERPRISE_TEXT}
 				handleEnterprise={() => setPlanLevel(PlanLevel.Enterprise)}
 			/>
@@ -165,21 +168,56 @@ const BillingForm = (props: Props) => {
 					organizationUuidValid={organizationUuidValidJson}
 					handleRefresh={props.handleRefresh}
 				/> */}
-				<Checkout
-					apiUrl={props.apiUrl}
-					params={props.params}
-					onboard={props.onboard}
-					bencher_valid={props.bencher_valid}
-					user={props.user}
-					organization={props.usage()?.organization}
-					plan={plan}
-					entitlements={entitlementsAnnualJson}
-					organizationUuid={organizationUuidJson}
-					organizationUuidValid={organizationUuidValidJson}
-					handleRefresh={props.handleRefresh}
-				/>
+				<Show
+					when={
+						plan() === PlanLevel.Enterprise && planKind() === PlanKind.Metered
+					}
+					fallback={
+						<Checkout
+							apiUrl={props.apiUrl}
+							params={props.params}
+							onboard={props.onboard}
+							bencher_valid={props.bencher_valid}
+							user={props.user}
+							organization={props.usage()?.organization}
+							plan={plan}
+							entitlements={entitlementsAnnualJson}
+							organizationUuid={organizationUuidJson}
+							organizationUuidValid={organizationUuidValidJson}
+							handleRefresh={props.handleRefresh}
+						/>
+					}
+				>
+					<ContactUs onboard={props.onboard} />
+				</Show>
 			</Show>
 		</>
+	);
+};
+
+// Metered (Cloud) Enterprise is not self-serve (custom hardware/contract), so
+// the API rejects a checkout for it. Route to a sales conversation instead,
+// matching the marketing pricing table. The self-hosted licensed Enterprise
+// path still uses the normal checkout.
+const ContactUs = (props: { onboard: boolean }) => {
+	return (
+		<div class="columns is-centered" style="margin-top: 1rem;">
+			<div class={`column ${props.onboard ? "" : "is-half"}`}>
+				<a
+					class="button is-primary is-fullwidth"
+					href={BENCHER_CALENDLY_URL}
+					target="_blank"
+					rel="noreferrer"
+				>
+					<span class="icon-text">
+						<span>Contact us</span>
+						<span class="icon">
+							<i class="fas fa-chevron-right" />
+						</span>
+					</span>
+				</a>
+			</div>
+		</div>
 	);
 };
 

--- a/services/console/src/components/console/billing/plan/Pricing.tsx
+++ b/services/console/src/components/console/billing/plan/Pricing.tsx
@@ -6,6 +6,7 @@ export const per_metric_cost = (plan: PlanLevel) => {
 		case PlanLevel.Free:
 			return 0;
 		case PlanLevel.Team:
+		case PlanLevel.Pro:
 			return 1;
 		case PlanLevel.Enterprise:
 			return 5;
@@ -18,8 +19,8 @@ interface Props {
 	freeText: string;
 	handleFree: () => void;
 	hideFree?: undefined | boolean;
-	teamText: string;
-	handleTeam: () => void;
+	proText: string;
+	handlePro: () => void;
 	enterpriseText: string;
 	handleEnterprise: () => void;
 }
@@ -34,13 +35,13 @@ const Pricing = (props: Props) => {
 			handlePlanLevel={props.handleFree}
 		/>
 	);
-	const Team = (
+	const Pro = (
 		<PlanPanel
 			themeColor={props.themeColor}
 			active={props.plan}
-			plan={PlanLevel.Team}
-			buttonText={props.teamText}
-			handlePlanLevel={props.handleTeam}
+			plan={PlanLevel.Pro}
+			buttonText={props.proText}
+			handlePlanLevel={props.handlePro}
 		/>
 	);
 	const Enterprise = (
@@ -59,12 +60,12 @@ const Pricing = (props: Props) => {
 				fallback={
 					<>
 						<div class="column is-3">{Free}</div>
-						<div class="column is-3">{Team}</div>
+						<div class="column is-3">{Pro}</div>
 						<div class="column is-3">{Enterprise}</div>
 					</>
 				}
 			>
-				<div class="column is-6">{Team}</div>
+				<div class="column is-6">{Pro}</div>
 				<div class="column is-6">{Enterprise}</div>
 			</Show>
 		</div>
@@ -73,10 +74,20 @@ const Pricing = (props: Props) => {
 
 const NO_FEATURE = "\xa0";
 
-const PlanCopy = {
+interface PlanCopyEntry {
+	title: string;
+	price: string;
+	priceNote: string;
+	features: string[];
+}
+
+// Keyed by every `PlanLevel` so `PlanCopy[plan]` is always defined. `Team` is
+// retained for grandfathered customers; new self-serve signups use `Pro`.
+const PlanCopy: Record<PlanLevel, PlanCopyEntry> = {
 	[PlanLevel.Free]: {
 		title: "Free",
 		price: "$0",
+		priceNote: "per month",
 		features: [
 			"Public Projects",
 			NO_FEATURE,
@@ -85,9 +96,22 @@ const PlanCopy = {
 			NO_FEATURE,
 		],
 	},
+	[PlanLevel.Pro]: {
+		title: "Pro",
+		price: "$20",
+		priceNote: "per month + usage",
+		features: [
+			"$20 of included usage credit",
+			"Public & Private Projects",
+			"No per-seat pricing",
+			"Customer Support",
+			NO_FEATURE,
+		],
+	},
 	[PlanLevel.Team]: {
 		title: "Team",
 		price: "$0.01",
+		priceNote: "per benchmark result",
 		features: [
 			"Public Projects",
 			"Private Projects",
@@ -98,13 +122,14 @@ const PlanCopy = {
 	},
 	[PlanLevel.Enterprise]: {
 		title: "Enterprise",
-		price: "$0.05",
+		price: "Contact us",
+		priceNote: "custom hardware",
 		features: [
-			"Public Projects",
-			"Private Projects",
+			"Everything in Pro",
 			"Priority Support",
 			"Single Sign-On (SSO)",
 			"Dedicated Onboarding",
+			NO_FEATURE,
 		],
 	},
 };
@@ -124,7 +149,7 @@ const PlanPanel = (props: {
 					<h2 class="title is-2">{plan.title}</h2>
 					<h3 class="subtitle is-1">{plan.price}</h3>
 					<br />
-					<sup>per benchmark result</sup>
+					<sup>{plan.priceNote}</sup>
 				</div>
 			</div>
 			<For each={plan.features}>

--- a/services/console/src/components/pricing/ConsoleFallbackPricingTable.tsx
+++ b/services/console/src/components/pricing/ConsoleFallbackPricingTable.tsx
@@ -1,7 +1,7 @@
 import Pricing from "../console/billing/plan/Pricing";
 
 export const FREE_TEXT = "Stick with Free";
-export const TEAM_TEXT = "Go with Team";
+export const PRO_TEXT = "Go with Pro";
 export const ENTERPRISE_TEXT = "Go with Enterprise";
 
 const ConsoleFallbackPricingTable = (props: { hideFree: boolean }) => {
@@ -11,8 +11,8 @@ const ConsoleFallbackPricingTable = (props: { hideFree: boolean }) => {
 			freeText={FREE_TEXT}
 			handleFree={() => {}}
 			hideFree={props.hideFree}
-			teamText={TEAM_TEXT}
-			handleTeam={() => {}}
+			proText={PRO_TEXT}
+			handlePro={() => {}}
 			enterpriseText={ENTERPRISE_TEXT}
 			handleEnterprise={() => {}}
 		/>

--- a/services/console/src/components/pricing/FallbackPricingTable.tsx
+++ b/services/console/src/components/pricing/FallbackPricingTable.tsx
@@ -4,7 +4,7 @@ const FallbackPricingTable = () => {
 	return (
 		<InnerPricingTable
 			handleFree={() => {}}
-			handleTeam={() => {}}
+			handlePro={() => {}}
 			handleEnterprise={() => {}}
 		/>
 	);

--- a/services/console/src/components/pricing/InnerPricingTable.tsx
+++ b/services/console/src/components/pricing/InnerPricingTable.tsx
@@ -3,7 +3,7 @@ import { PlanLevel } from "../../types/bencher";
 
 interface Props {
 	handleFree: () => void;
-	handleTeam: () => void;
+	handlePro: () => void;
 	handleEnterprise: () => void;
 }
 
@@ -26,7 +26,10 @@ interface Tier {
 	title: string;
 	tagline: string;
 	price: string;
+	priceUnit: string;
 	projectsNote: string;
+	// Decodability note: what the included credit buys, shown under the price.
+	creditNote?: string;
 	popular?: boolean;
 	ctaStyle: "primary" | "outlined";
 	features: Feature[];
@@ -40,6 +43,7 @@ const TIERS: Tier[] = [
 		title: "Free",
 		tagline: "For open source projects",
 		price: "$0",
+		priceUnit: " / month",
 		projectsNote: "Public projects only",
 		ctaStyle: "outlined",
 		features: [
@@ -55,16 +59,20 @@ const TIERS: Tier[] = [
 		},
 	},
 	{
-		plan: PlanLevel.Team,
-		title: "Team",
-		tagline: "For engineering teams",
-		price: "$0.01",
+		plan: PlanLevel.Pro,
+		title: "Pro",
+		tagline: "For teams shipping fast",
+		price: "$20",
+		priceUnit: " / month + usage",
 		projectsNote: "Public & private projects",
+		creditNote:
+			"Includes $20 of usage: ~2,000 metrics or 20 runner-hours, mixed freely",
 		popular: true,
 		ctaStyle: "primary",
 		features: [
-			{ mark: "check", label: "Public projects" },
-			{ mark: "check", label: "Private projects" },
+			{ mark: "check", label: "$20 of included usage credit" },
+			{ mark: "check", label: "Public & private projects" },
+			{ mark: "check", label: "No per-seat pricing" },
 			{ mark: "check", label: "Customer support" },
 		],
 		runners: {
@@ -73,18 +81,19 @@ const TIERS: Tier[] = [
 			queuePriority: "Priority",
 			runnerRate: "$1.00 / hr",
 		},
-		billingFooter: "billed at $0.01666 / min · no minimums",
+		billingFooter:
+			"Private metrics $0.01 each. Overage billed at the same rates. First month free.",
 	},
 	{
 		plan: PlanLevel.Enterprise,
 		title: "Enterprise",
 		tagline: "For performance-critical organizations",
-		price: "$0.05",
+		price: "Contact us",
+		priceUnit: "",
 		projectsNote: "Public & private projects",
 		ctaStyle: "outlined",
 		features: [
-			{ mark: "check", label: "Public projects" },
-			{ mark: "check", label: "Private projects" },
+			{ mark: "check", label: "Everything in Pro" },
 			{ mark: "check", label: "Priority support" },
 			{ mark: "check", label: "Single sign-on (SSO)" },
 			{ mark: "check", label: "Dedicated onboarding" },
@@ -93,30 +102,30 @@ const TIERS: Tier[] = [
 			concurrentJobs: "Unlimited",
 			jobTimeout: "Unlimited",
 			queuePriority: "Priority",
-			runnerRate: "$1.00 / hr",
+			runnerRate: "Custom hardware",
 		},
-		billingFooter: "billed at $0.01666 / min · no minimums",
 	},
 ];
 
 const ctaTextFor = (plan: PlanLevel): string => {
-	if (plan === PlanLevel.Free) {
-		return "Sign up for Free";
+	switch (plan) {
+		case PlanLevel.Pro:
+			return "Start 1-month free trial";
+		case PlanLevel.Enterprise:
+			return "Contact us";
+		default:
+			return "Sign up for Free";
 	}
-	if (plan === PlanLevel.Team) {
-		return "Continue with Team";
-	}
-	return "Continue with Enterprise";
 };
 
 const handlerFor = (plan: PlanLevel, props: Props): (() => void) => {
 	switch (plan) {
-		case PlanLevel.Free:
-			return props.handleFree;
-		case PlanLevel.Team:
-			return props.handleTeam;
+		case PlanLevel.Pro:
+			return props.handlePro;
 		case PlanLevel.Enterprise:
 			return props.handleEnterprise;
+		default:
+			return props.handleFree;
 	}
 };
 
@@ -135,9 +144,12 @@ const InnerPricingTable = (props: Props) => {
 						</div>
 						<div class="pricing-price-row">
 							<span class="pricing-price">{tier.price}</span>
-							<span class="pricing-price-unit"> / benchmark result</span>
+							<span class="pricing-price-unit">{tier.priceUnit}</span>
 						</div>
 						<div class="pricing-projects">{tier.projectsNote}</div>
+						<Show when={tier.creditNote}>
+							<div class="pricing-billing-footer">{tier.creditNote}</div>
+						</Show>
 						<button
 							type="button"
 							class={`pricing-cta pricing-cta-${tier.ctaStyle}`}

--- a/services/console/src/components/pricing/PricingTable.tsx
+++ b/services/console/src/components/pricing/PricingTable.tsx
@@ -1,5 +1,6 @@
-import { useNavigate } from "../../util/url";
 import { PlanLevel } from "../../types/bencher";
+import { BENCHER_CALENDLY_URL } from "../../util/ext";
+import { useNavigate } from "../../util/url";
 import InnerPricingTable from "./InnerPricingTable";
 
 const PricingTable = () => {
@@ -15,11 +16,12 @@ const PricingTable = () => {
 			handleFree={() => {
 				navigate(URL);
 			}}
-			handleTeam={() => {
-				navigate(url(PlanLevel.Team));
+			handlePro={() => {
+				navigate(url(PlanLevel.Pro));
 			}}
 			handleEnterprise={() => {
-				navigate(url(PlanLevel.Enterprise));
+				// Enterprise is "Contact us" (custom hardware), not self-serve.
+				navigate(BENCHER_CALENDLY_URL);
 			}}
 		/>
 	);

--- a/services/console/src/pages/pricing.astro
+++ b/services/console/src/pages/pricing.astro
@@ -69,7 +69,7 @@ const description =
           5 benchmarks × 10 runs = 50 Metrics.
           Even if your harness runs each benchmark 1,000 times internally for accuracy,
           that's still 1 Metric per run.
-          Bencher Bare Metal runner time is billed separately.
+          On Pro, private Metrics and Bencher Bare Metal runner time both draw from one shared monthly usage credit.
         </p>
       </div>
     </section>
@@ -112,13 +112,16 @@ const description =
             A benchmark result (called a Metric) is a single point-in-time measurement. Each benchmark run produces one Metric, so 5 benchmarks × 10 runs = 50 Metrics. Even if your harness samples a benchmark 1,000 times internally for accuracy, that still counts as 1 Metric per run. A benchmark with multiple measures (like latency and throughput) creates one Metric per measure per run, so 5 benchmarks × 2 measures × 10 runs = 100 Metrics.
           </FaqItem>
           <FaqItem id="faq-public-private" q="What is a Public vs. Private Project?">
-            A Public Project is visible to anyone who can reach your Bencher instance. On Bencher Cloud, <a href="/perf" target="_blank" rel="noreferrer">all Public Projects are listed here</a>. A Private Project is only visible to members of your organization and requires an active Bencher Plus plan (Team or Enterprise).
+            A Public Project is visible to anyone who can reach your Bencher instance. On Bencher Cloud, <a href="/perf" target="_blank" rel="noreferrer">all Public Projects are listed here</a>. A Private Project is only visible to members of your organization and requires a paid plan (Pro or Enterprise).
           </FaqItem>
           <FaqItem id="faq-billing" q="How are benchmark results billed?">
-            On Bencher Cloud, benchmark results (called Metrics) are billed monthly based on metered usage. If you create 5,280 Metrics in a month, you're billed for 5,280 Metrics. Bencher Self-Hosted Metrics are billed annually based on a licensed quantity.
+            On Bencher Cloud, the Pro plan is $20/month and includes $20 of usage credit. Private Metrics ($0.01 each) and Bencher Bare Metal runner time ($1.00/hour) both draw from this single monthly credit, so most teams pay exactly $20. If you go past the included credit, additional usage is billed at the same rates, with no spend cliff. Credit is granted fresh each month and does not roll over. Bencher Self-Hosted Metrics are billed annually based on a licensed quantity.
+          </FaqItem>
+          <FaqItem id="faq-trial" q="Is there a free trial for Pro?">
+            Yes. Pro starts with a 1-month free trial: your first month's $20 base fee is waived and you get $20 of usage credit to spend across Metrics and Bare Metal. A credit card is required to start the trial. After 30 days it converts to the standard $20/month. There is no per-seat pricing on any plan.
           </FaqItem>
           <FaqItem id="faq-public-projects" q="Are benchmark results for Public Projects counted?">
-            Yes. On Team or Enterprise, benchmark results (called Metrics) from both Public and Private Projects count toward your plan. The Free plan isn't billed for Metrics, but <a href="#faq-rate-limiting">daily rate limits</a> apply.
+            No. Metrics from Public Projects are always free and unlimited. Only Private Project Metrics draw from your Pro usage credit. The Free plan supports Public Projects only, with <a href="#faq-rate-limiting">daily rate limits</a>.
           </FaqItem>
           <FaqItem id="faq-rate-limiting" q="Is there rate limiting?">
             <ul>
@@ -129,7 +132,7 @@ const description =
           </FaqItem>
           <FaqItem id="faq-support" q="What support do I get with each plan?">
             <p><strong>Community support</strong> (Free): GitHub issues and our Discord community.</p>
-            <p><strong>Customer support</strong> (Team): Email support with responses within 1 business day.</p>
+            <p><strong>Customer support</strong> (Pro): Email support with responses within 1 business day.</p>
             <p><strong>Priority support</strong> (Enterprise): Dedicated Slack channel with direct access to Bencher engineering, priority on bug fixes and feature requests, and dedicated onboarding.</p>
           </FaqItem>
           <FaqItem id="faq-change-plan" q="Can I change or cancel my plan?">
@@ -168,14 +171,14 @@ const description =
             <p>Bencher Self-Hosted runners can run on Linux (x86_64 or ARM64), macOS, and Windows.</p>
             <p>See the <a href="/docs/explanation/bare-metal/#runner">bare metal runner reference</a> for details.</p>
           </FaqItem>
-          <FaqItem id="faq-bare-metal-billing" q="Are Bencher Bare Metal minutes billed separately from Metrics?">
-            <p>Yes. Metrics are billed per result as described above. On Bencher Cloud, Bare Metal runner time is billed separately at $1.00/hr ($0.01666/min) and covers the compute used to execute your benchmarks. You're only billed for the minutes your benchmarks are actively running.</p>
+          <FaqItem id="faq-bare-metal-billing" q="How is Bencher Bare Metal runner time billed?">
+            <p>On Bencher Cloud, Bare Metal On-Demand runner time costs $1.00/hr ($0.01666/min) and draws from the same monthly Pro usage credit as private Metrics. One credit pool covers both, so you reason about a single number. You're only billed for the minutes your benchmarks are actively running, and overage past the included credit is billed at the same rate.</p>
             <p>Bencher Self-Hosted users do not pay for runner minutes.</p>
           </FaqItem>
           <FaqItem id="faq-bare-metal-minimums" q="Is there a minimum commitment for Bencher Bare Metal?">
-            <p>No minimums, no monthly fees.</p>
+            <p>The Pro plan is $20/month and includes $20 of usage credit shared across Metrics and runner time. There is no per-seat pricing and no separate runner minimum.</p>
             <ul>
-              <li><strong>On-Demand</strong> (Team, Enterprise): billed for the minutes your benchmarks are actively running</li>
+              <li><strong>On-Demand</strong> (Pro, Enterprise): billed for the minutes your benchmarks are actively running, drawn from your monthly credit</li>
               <li><strong>Dedicated</strong> (Enterprise): flat monthly rate</li>
               <li><strong>Custom</strong> (Enterprise): usage-based</li>
             </ul>
@@ -183,11 +186,11 @@ const description =
           </FaqItem>
           <FaqItem id="faq-bare-metal-free-tier" q="What's included in the Free tier?">
             <p>Free users get one concurrent Bare Metal job with a 5 minute timeout and Standard queue priority. This is the same for both Bencher Cloud and Bencher Self-Hosted.</p>
-            <p>For Bencher Cloud On-Demand runners, you're running on the same Bare Metal machines as Team and Enterprise customers, just with lower queue position during busy periods.</p>
+            <p>For Bencher Cloud On-Demand runners, you're running on the same Bare Metal machines as Pro and Enterprise customers, just with lower queue position during busy periods.</p>
             <p>Bencher Bare Metal runners usually execute your already-compiled benchmark binaries. Compilation happens locally or in your CI pipeline and is typically the longest step, so most benchmark suites fit well under the 5 minute timeout.</p>
           </FaqItem>
-          <FaqItem id="faq-queue-priority" q="How does queue priority work between Free, Team, and Enterprise?">
-            Team and Enterprise jobs are prioritized ahead of Free jobs in the runner queue and share equal priority with each other. All Bencher Cloud On-Demand jobs run on the same Bare Metal hardware. During idle periods Free jobs run immediately. During busy periods paid jobs are scheduled first, and Free jobs wait for the next available slot.
+          <FaqItem id="faq-queue-priority" q="How does queue priority work between Free, Pro, and Enterprise?">
+            Pro and Enterprise jobs are prioritized ahead of Free jobs in the runner queue and share equal priority with each other. All Bencher Cloud On-Demand jobs run on the same Bare Metal hardware. During idle periods Free jobs run immediately. During busy periods paid jobs are scheduled first, and Free jobs wait for the next available slot.
           </FaqItem>
         </div>
       </div>

--- a/services/console/src/types/bencher.ts
+++ b/services/console/src/types/bencher.ts
@@ -539,6 +539,7 @@ export interface JsonCustomer {
 export enum PlanLevel {
 	Free = "free",
 	Team = "team",
+	Pro = "pro",
 	Enterprise = "enterprise",
 }
 
@@ -936,6 +937,11 @@ export interface JsonPlan {
 	current_period_start: string;
 	current_period_end: string;
 	status: PlanStatus;
+	/**
+	 * Whether the subscription is set to cancel at the end of the current period
+	 * (the org keeps access until `current_period_end`, then downgrades to Free).
+	 */
+	cancel_at_period_end: boolean;
 	license?: JsonLicense;
 }
 
@@ -1076,6 +1082,16 @@ export enum UpdateAlertStatus {
 export interface JsonUpdateAlert {
 	/** The new status of the alert. */
 	status?: UpdateAlertStatus;
+}
+
+export interface JsonUpdatePlan {
+	/**
+	 * Update the subscription's scheduled cancellation. Set to `false` to resume
+	 * a plan scheduled to cancel at period end, or `true` to schedule it to
+	 * cancel at the end of the current period. Only applies to metered (Pro)
+	 * plans.
+	 */
+	cancel_at_period_end: boolean;
 }
 
 export interface JsonUpdateProjectKey {

--- a/services/console/src/util/convert.ts
+++ b/services/console/src/util/convert.ts
@@ -111,12 +111,20 @@ export const isBoolParam = (param: undefined | string): boolean => {
 	return param === "false" || param === "true";
 };
 
+// The flat monthly Pro base fee (USD), which includes an equal amount of usage credit.
+export const PRO_BASE_USD = 20;
+// The fungible usage credit included with Pro each month (USD). Drawn down across
+// metrics and bare metal; expires at month end.
+export const PRO_INCLUDED_CREDIT_USD = 20;
+
 export const planLevel = (level: undefined | PlanLevel) => {
 	switch (level) {
 		case PlanLevel.Free:
 			return "Free";
 		case PlanLevel.Team:
 			return "Team";
+		case PlanLevel.Pro:
+			return "Pro";
 		case PlanLevel.Enterprise:
 			return "Enterprise";
 		default:
@@ -129,6 +137,7 @@ export const planLevelPrice = (level: undefined | PlanLevel) => {
 		case PlanLevel.Free:
 			return 0.0;
 		case PlanLevel.Team:
+		case PlanLevel.Pro:
 			return 0.01;
 		case PlanLevel.Enterprise:
 			return 0.05;
@@ -140,6 +149,7 @@ export const planLevelPrice = (level: undefined | PlanLevel) => {
 export const runnerMinutePrice = (level: undefined | PlanLevel) => {
 	switch (level) {
 		case PlanLevel.Team:
+		case PlanLevel.Pro:
 		case PlanLevel.Enterprise:
 			return 0.01666;
 		default:


### PR DESCRIPTION
## Summary

Moves Bencher Cloud's self-serve paid tier from unbounded per-metric billing (Team) to a bounded **prepaid usage-credit** model (Pro), addressing the cost-predictability uncertainty that discourages sign-ups.

**Pro — $20/month + additional usage**
- Includes **$20 of fungible usage credit** each month, shared across private metrics ($0.01 each) and bare metal runner-hours ($1/hr).
- Overage past the credit bills at the **same rates** (no spend cliff); most teams pay exactly $20. No per-seat pricing.
- Single credit pool, expires monthly (use-it-or-lose-it), via **Stripe-native billing credit grants** scoped to the metered prices.
- 1-month free trial: first month's base fee waived + $20 credit; card required at signup.
- Unlimited bare metal concurrency / no timeout cap (inherits the existing Plus ladder).

**Other changes**
- `PlanLevel::Pro` added; **Team/Enterprise grandfathered** (no forced migration).
- **Public-project metrics are now free/unmetered** on paid plans; only private metrics draw from the credit.
- **Enterprise is contact-only** (custom hardware); self-serve Enterprise checkout is rejected.
- Console: Vercel-style pricing card, onboarding flow, billing-panel credit balance, and pricing FAQ.

## How it works
- The credit grant is created lazily and idempotently on the usage path (`check_usage` -> `Biller::ensure_period_credit`), deduped by billing-period metadata. No Stripe webhook handler exists today; a renewal webhook is future hardening.
- Stripe billing credits apply only to metered prices, so the flat base fee can't be credit-offset — the trial's first-month waiver uses a `duration:once` coupon (`pro_trial_coupon` config).

## Verification
- `cargo clippy --all-targets --all-features -Dwarnings`, `cargo check --no-default-features`, `cargo fmt`, `cargo nextest` (valid/json/schema/billing), and doctests all pass.
- `cargo gen-types` regenerated `openapi.json` + `bencher.ts`; console biome format/lint clean.
- Live Stripe-mode billing flow is **not** verified here (no test key in the dev environment).

## Before merge / follow-ups
- [ ] Create the real "Bencher Pro" Stripe product ($20/mo flat base price + $0.01 metrics meter) and the first-month trial coupon, then set them in the billing config. The example config and the `bencher_billing` test helper currently reuse Team's test product/prices as placeholders.
- [ ] Product decision: public-project metrics are now free for **all** metered plans, including grandfathered Team — confirm Team should also stop being billed for public metrics.
- [ ] Live Stripe test-mode walkthrough: checkout -> 3-item subscription + $20 credit grant -> overage -> trial base waiver.
