### PR TITLE
Add Pro plan backend: billing credits, sweep, plan PATCH, CLI

### DIFF
--- a/lib/api_organizations/src/lib.rs
+++ b/lib/api_organizations/src/lib.rs
@@ -76,6 +76,7 @@ impl bencher_endpoint::Registrar for Api {
                 }
                 api_description.register(plan::org_plan_get)?;
                 api_description.register(plan::org_plan_post)?;
+                api_description.register(plan::org_plan_patch)?;
                 api_description.register(plan::org_plan_delete)?;
             }
 

--- a/lib/api_organizations/src/plan.rs
+++ b/lib/api_organizations/src/plan.rs
@@ -2,11 +2,11 @@
 
 use bencher_billing::Biller;
 use bencher_endpoint::{
-    CorsResponse, Delete, Endpoint, Get, Post, ResponseCreated, ResponseDeleted, ResponseOk,
+    CorsResponse, Delete, Endpoint, Get, Patch, Post, ResponseCreated, ResponseDeleted, ResponseOk,
 };
 use bencher_json::{
-    DateTime, OrganizationResourceId,
-    organization::plan::{JsonNewPlan, JsonPlan},
+    DateTime, MeteredPlanId, OrganizationResourceId,
+    organization::plan::{JsonNewPlan, JsonPlan, JsonUpdatePlan},
 };
 use bencher_rbac::organization::Permission;
 use bencher_schema::{
@@ -21,7 +21,10 @@ use bencher_schema::{
             QueryOrganization, UpdateOrganization,
             plan::{InsertPlan, QueryPlan},
         },
-        user::auth::{AuthUser, BearerToken},
+        user::{
+            admin::AdminUser,
+            auth::{AuthUser, BearerToken},
+        },
     },
     schema, write_conn,
 };
@@ -45,7 +48,12 @@ pub async fn org_plan_options(
     _rqctx: RequestContext<ApiContext>,
     _path_params: Path<OrgPlanParams>,
 ) -> Result<CorsResponse, HttpError> {
-    Ok(Endpoint::cors(&[Get.into(), Post.into(), Delete.into()]))
+    Ok(Endpoint::cors(&[
+        Get.into(),
+        Post.into(),
+        Patch.into(),
+        Delete.into(),
+    ]))
 }
 
 #[endpoint {
@@ -127,6 +135,88 @@ pub async fn org_plan_post(
         let _ = e;
     })?;
     Ok(Post::auth_response_created(json))
+}
+
+/// Update an organization's metered subscription plan.
+/// Schedules or clears a cancel-at-period-end for the organization's metered
+/// subscription. Available to organization managers and must be called with a
+/// user session JWT, not a user API key.
+#[endpoint {
+    method = PATCH,
+    path =  "/v0/organizations/{organization}/plan",
+    tags = ["organizations", "plan"]
+}]
+pub async fn org_plan_patch(
+    rqctx: RequestContext<ApiContext>,
+    bearer_token: BearerToken,
+    path_params: Path<OrgPlanParams>,
+    body: TypedBody<JsonUpdatePlan>,
+) -> Result<ResponseOk<JsonPlan>, HttpError> {
+    let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
+    // A user API key cannot update a subscription plan; require a user session JWT
+    // (mirrors the user-key management endpoints).
+    if auth_user.user_key_id.is_some() {
+        #[cfg(feature = "otel")]
+        bencher_otel::ApiMeter::increment(bencher_otel::ApiCounter::OrganizationPlanUpdateBlocked);
+        return Err(forbidden_error(
+            "A user API key cannot update a subscription plan. Authenticate with a JWT (user session token) instead.",
+        ));
+    }
+    let json = patch_inner(
+        rqctx.context(),
+        path_params.into_inner(),
+        body.into_inner(),
+        &auth_user,
+    )
+    .await?;
+    Ok(Patch::auth_response_ok(json))
+}
+
+/// Update the organization's metered subscription: schedule or clear a
+/// cancel-at-period-end. Returns the refreshed plan.
+async fn patch_inner(
+    context: &ApiContext,
+    path_params: OrgPlanParams,
+    json_plan: JsonUpdatePlan,
+    auth_user: &AuthUser,
+) -> Result<JsonPlan, HttpError> {
+    let biller = context.biller()?;
+
+    // Get the organization
+    let query_organization =
+        QueryOrganization::from_resource_id(auth_conn!(context), &path_params.organization)?;
+    // Check to see if user has permission to manage the organization
+    context
+        .rbac
+        .is_allowed_organization(auth_user, Permission::Manage, &query_organization)
+        .map_err(forbidden_error)?;
+    // Get the plan for the organization
+    let query_plan = QueryPlan::belonging_to(&query_organization)
+        .first::<QueryPlan>(auth_conn!(context))
+        .map_err(resource_not_found_err!(Plan, query_organization))?;
+
+    // The cancel-at-period-end schedule only applies to a metered subscription;
+    // licensed plans are canceled immediately and have no period-end schedule to
+    // change.
+    let Some(metered_plan_id) = query_plan.metered_plan.as_ref() else {
+        return Err(bad_request_error(
+            "Only a metered plan's cancellation can be updated; this organization has no metered subscription",
+        ));
+    };
+    biller
+        .set_metered_cancel_at_period_end(metered_plan_id, json_plan.cancel_at_period_end)
+        .await
+        .map_err(resource_conflict_err!(Plan, query_plan))?;
+
+    query_plan.to_metered_plan(biller).await?.ok_or_else(|| {
+        issue_error(
+            "Failed to find subscription for updated plan",
+            &format!(
+                "Failed to find metered plan for organization ({query_organization:?}) after update even though plan exists ({query_plan:?})."
+            ),
+            "Failed to find subscription for updated plan",
+        )
+    })
 }
 
 async fn post_inner(
@@ -221,6 +311,10 @@ async fn post_inner(
             .as_ref()
             .parse()
             .map_err(resource_not_found_err!(Plan, subscription_id))?;
+        // Grant the first period's included usage credit so a new metered org has
+        // its credit immediately (best-effort; the daily sweep handles later
+        // periods). A no-op for plans without a base fee.
+        grant_initial_credit(biller, &metered_plan_id).await;
         InsertPlan::metered_plan(write_conn!(context), metered_plan_id, &query_organization)?;
         QueryPlan::belonging_to(&query_organization)
             .first::<QueryPlan>(auth_conn!(context))
@@ -240,6 +334,9 @@ pub struct OrgPlanQuery {
     pub remote: Option<bool>,
 }
 
+/// Delete an organization's subscription plan (admin only).
+/// Immediately cancels the organization's subscription and removes the plan.
+/// Restricted to Bencher server administrators.
 #[endpoint {
     method = DELETE,
     path =  "/v0/organizations/{organization}/plan",
@@ -251,12 +348,12 @@ pub async fn org_plan_delete(
     path_params: Path<OrgPlanParams>,
     query_params: Query<OrgPlanQuery>,
 ) -> Result<ResponseDeleted, HttpError> {
-    let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
+    // Admin only: an immediate hard-cancel + plan removal, usable cross-org.
+    AdminUser::from_token(rqctx.context(), bearer_token).await?;
     delete_inner(
         rqctx.context(),
         path_params.into_inner(),
         query_params.into_inner(),
-        &auth_user,
     )
     .await
     .inspect_err(|e| {
@@ -272,18 +369,12 @@ async fn delete_inner(
     context: &ApiContext,
     path_params: OrgPlanParams,
     query_params: OrgPlanQuery,
-    auth_user: &AuthUser,
 ) -> Result<(), HttpError> {
     let biller = context.biller()?;
 
     // Get the organization
     let query_organization =
         QueryOrganization::from_resource_id(auth_conn!(context), &path_params.organization)?;
-    // Check to see if user has permission to manage the organization
-    context
-        .rbac
-        .is_allowed_organization(auth_user, Permission::Manage, &query_organization)
-        .map_err(forbidden_error)?;
     // Get the plan for the organization
     let query_plan = QueryPlan::belonging_to(&query_organization)
         .first::<QueryPlan>(auth_conn!(context))
@@ -300,11 +391,28 @@ async fn delete_inner(
             let _ = e;
         });
 
+    // The metered subscription is canceled immediately (see
+    // `cancel_metered_subscription`); remove the local plan row now.
     diesel::delete(schema::plan::table.filter(schema::plan::id.eq(query_plan.id)))
         .execute(write_conn!(context))
         .map_err(resource_conflict_err!(Plan, query_plan))?;
 
     delete_plan_result
+}
+
+/// Best-effort grant of the first period's included usage credit for a new
+/// metered subscription. Idempotent and self-guarding (a no-op for plans without
+/// a base fee); never blocks plan creation.
+async fn grant_initial_credit(biller: &Biller, metered_plan_id: &MeteredPlanId) {
+    let _credit = biller
+        .ensure_period_credit(metered_plan_id)
+        .await
+        .inspect_err(|e| {
+            #[cfg(feature = "sentry")]
+            sentry::capture_error(e);
+            #[cfg(not(feature = "sentry"))]
+            let _ = e;
+        });
 }
 
 async fn delete_plan(

--- a/lib/api_organizations/tests/plan.rs
+++ b/lib/api_organizations/tests/plan.rs
@@ -5,6 +5,15 @@
     reason = "integration test file"
 )]
 //! Integration tests for organization plan endpoint.
+//!
+//! NOTE: The organization plan endpoints are registered only on Bencher Cloud
+//! (`is_bencher_cloud` in `lib.rs`), so the test harness (not configured as
+//! Cloud) returns 404 for them; the GET tests below accept that. The newer
+//! guards therefore cannot be exercised end-to-end here and are covered by
+//! inspection instead: PATCH rejects user API keys via the same
+//! `auth_user.user_key_id.is_some()` check tested in `api_users`
+//! `user_key_auth.rs`, and DELETE uses the same `AdminUser` extractor tested by
+//! `organizations_hard_delete_requires_admin`.
 
 use bencher_api_tests::TestServer;
 use http::StatusCode;

--- a/lib/bencher_config/src/config_tx.rs
+++ b/lib/bencher_config/src/config_tx.rs
@@ -24,7 +24,7 @@ use bencher_schema::{
     context::RateLimiting,
     model::{
         runner::job::{reprocess_completed_jobs, spawn_heartbeat_timeout},
-        server::QueryServer,
+        server::{QueryServer, spawn_credit_grants},
     },
     write_conn,
 };
@@ -172,6 +172,22 @@ impl ConfigTx {
 
         #[cfg(feature = "plus")]
         spawn_stats(log, server.app_private()).await?;
+
+        // Bencher Cloud only (a Biller is configured): keep each metered
+        // subscription's monthly usage credit granted and reconcile lapses on a
+        // daily sweep, off the report-ingestion path.
+        #[cfg(feature = "plus")]
+        {
+            let context = server.app_private();
+            if let Some(biller) = context.biller.clone() {
+                spawn_credit_grants(
+                    log.clone(),
+                    context.database.path.clone(),
+                    context.database.busy_timeout,
+                    biller,
+                );
+            }
+        }
 
         Ok(server)
     }

--- a/lib/bencher_json/src/organization/plan.rs
+++ b/lib/bencher_json/src/organization/plan.rs
@@ -28,6 +28,17 @@ pub struct JsonNewPlan {
 #[typeshare::typeshare]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub struct JsonUpdatePlan {
+    /// Update the subscription's scheduled cancellation. Set to `false` to resume
+    /// a plan scheduled to cancel at period end, or `true` to schedule it to
+    /// cancel at the end of the current period. Only applies to metered
+    /// subscriptions, not licensed (Self-Hosted) plans.
+    pub cancel_at_period_end: bool,
+}
+
+#[typeshare::typeshare]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct JsonPlan {
     pub organization: OrganizationUuid,
     pub customer: JsonCustomer,
@@ -37,6 +48,9 @@ pub struct JsonPlan {
     pub current_period_start: DateTime,
     pub current_period_end: DateTime,
     pub status: PlanStatus,
+    /// Whether the subscription is set to cancel at the end of the current period
+    /// (the org keeps access until `current_period_end`, then downgrades to Free).
+    pub cancel_at_period_end: bool,
     pub license: Option<JsonLicense>,
 }
 

--- a/lib/bencher_json/src/system/config/plus/cloud/billing.rs
+++ b/lib/bencher_json/src/system/config/plus/cloud/billing.rs
@@ -21,6 +21,8 @@ impl Sanitize for JsonBilling {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct JsonProducts {
+    pub pro: JsonProduct,
+    // Legacy self-serve paid tier, retained for grandfathered customers.
     pub team: JsonProduct,
     pub enterprise: JsonProduct,
     pub bare_metal: JsonProduct,
@@ -30,6 +32,52 @@ pub struct JsonProducts {
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct JsonProduct {
     pub id: String,
+    #[serde(default)]
     pub metered: HashMap<String, String>,
+    #[serde(default)]
     pub licensed: HashMap<String, String>,
+    // Flat recurring base prices.
+    // Empty for products with no flat base fee.
+    #[serde(default)]
+    pub base: HashMap<String, String>,
+    #[serde(default)]
+    pub trial_coupon: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{JsonProduct, JsonProducts};
+
+    // Existing team/enterprise/bare_metal config has no `base` key; it must still
+    // deserialize, defaulting `base` to an empty map (backward compatibility).
+    #[test]
+    fn product_without_base_defaults_empty() {
+        let json =
+            r#"{"id":"prod_x","metered":{"default":"price_m"},"licensed":{"default":"price_l"}}"#;
+        let product: JsonProduct = serde_json::from_str(json).unwrap();
+        assert!(product.base.is_empty());
+        assert!(product.trial_coupon.is_none());
+        assert_eq!(
+            product.metered.get("default").map(String::as_str),
+            Some("price_m"),
+        );
+    }
+
+    #[test]
+    fn products_with_pro_base_and_trial_coupon() {
+        let json = r#"{
+            "team": {"id":"t","metered":{},"licensed":{}},
+            "pro": {"id":"p","metered":{"default":"price_m"},"base":{"default":"price_b"},"trial_coupon":"coupon_x"},
+            "enterprise": {"id":"e","metered":{},"licensed":{}},
+            "bare_metal": {"id":"bm","metered":{},"licensed":{}}
+        }"#;
+        let products: JsonProducts = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            products.pro.base.get("default").map(String::as_str),
+            Some("price_b"),
+        );
+        assert_eq!(products.pro.trial_coupon.as_deref(), Some("coupon_x"));
+        assert!(products.team.base.is_empty());
+        assert!(products.team.trial_coupon.is_none());
+    }
 }

--- a/lib/bencher_schema/src/model/organization/plan.rs
+++ b/lib/bencher_schema/src/model/organization/plan.rs
@@ -111,14 +111,29 @@ impl QueryPlan {
             .await
             .map_err(not_found_error)?;
 
+        // A canceled/lapsed (inactive) subscription gracefully downgrades to
+        // Free: return `None` so the caller falls through to the public/no-plan
+        // logic instead of hard-erroring.
         if plan_status.is_active() {
             Ok(Some(customer_id))
         } else {
-            Err(payment_required_error(PlanKindError::InactiveMeteredPlan {
-                organization: query_organization.clone(),
-                metered_plan_id,
-            }))
+            Ok(None)
         }
+    }
+
+    /// All organization plans with a metered (Stripe) subscription. Used by the
+    /// daily billing sweep to ensure each period's credit and reconcile canceled
+    /// subscriptions.
+    pub fn all_metered(conn: &mut DbConnection) -> diesel::QueryResult<Vec<Self>> {
+        schema::plan::table
+            .filter(schema::plan::metered_plan.is_not_null())
+            .load::<Self>(conn)
+    }
+
+    /// Delete a plan row by id. Used by the daily billing sweep to prune a plan
+    /// whose subscription has fully lapsed.
+    pub fn delete(conn: &mut DbConnection, plan_id: PlanId) -> diesel::QueryResult<usize> {
+        diesel::delete(schema::plan::table.filter(schema::plan::id.eq(plan_id))).execute(conn)
     }
 }
 
@@ -219,11 +234,6 @@ pub enum PlanKind {
 
 #[derive(Debug, thiserror::Error)]
 pub enum PlanKindError {
-    #[error("Organization ({uuid}) has an inactive metered plan ({metered_plan_id})", uuid = organization.uuid)]
-    InactiveMeteredPlan {
-        organization: QueryOrganization,
-        metered_plan_id: MeteredPlanId,
-    },
     #[error("License usage exceeded for organization ({uuid}). {usage} > {entitlements}", uuid = organization.uuid)]
     LicensePlanOverage {
         organization: QueryOrganization,
@@ -253,7 +263,7 @@ impl PlanKind {
             Self::Metered(_) => Priority::Plus,
             Self::Licensed(license_usage) => match license_usage.level {
                 PlanLevel::Free => Priority::Free,
-                PlanLevel::Team | PlanLevel::Enterprise => Priority::Plus,
+                PlanLevel::Pro | PlanLevel::Team | PlanLevel::Enterprise => Priority::Plus,
             },
         }
     }
@@ -394,6 +404,12 @@ impl PlanKind {
                         PlanKindError::NoBiller,
                     ));
                 };
+                // Public Project Metrics are free and unlimited; only Private
+                // Project Metrics are metered. Bare metal runner time is metered
+                // separately (regardless of visibility) via the runner channel.
+                if project.visibility.is_public() {
+                    return Ok(());
+                }
                 if let Err(e) = biller.record_metrics_usage(&customer_id, usage).await {
                     #[cfg(feature = "otel")]
                     bencher_otel::ApiMeter::increment(

--- a/lib/bencher_schema/src/model/server/mod.rs
+++ b/lib/bencher_schema/src/model/server/mod.rs
@@ -3,4 +3,4 @@ mod plus;
 
 pub use backup::{ServerBackup, ServerBackupError};
 #[cfg(feature = "plus")]
-pub use plus::{QueryServer, ServerId};
+pub use plus::{QueryServer, ServerId, spawn_credit_grants};

--- a/lib/bencher_schema/src/model/server/plus/credit.rs
+++ b/lib/bencher_schema/src/model/server/plus/credit.rs
@@ -1,0 +1,196 @@
+#![cfg(feature = "plus")]
+
+use std::cmp;
+use std::path::PathBuf;
+
+use bencher_billing::Biller;
+use bencher_json::PlanStatus;
+use chrono::{Duration, NaiveTime, Utc};
+use diesel::Connection as _;
+use slog::Logger;
+
+use crate::context::DbConnection;
+use crate::model::organization::plan::QueryPlan;
+
+use super::configure_standalone_connection;
+
+/// Time of day (UTC) at which the daily credit sweep runs. A fixed time so the
+/// sweep happens at the same time every day rather than drifting with server
+/// restarts.
+const CREDIT_SWEEP_TIME: NaiveTime = NaiveTime::MIN;
+
+/// How long to wait before retrying a failed database connection during the daily
+/// credit sweep, so a transient failure does not skip the whole day's run.
+const CREDIT_SWEEP_RETRY_DELAY: std::time::Duration = std::time::Duration::from_mins(1);
+
+/// Maximum number of connection attempts for a single daily sweep before giving
+/// up until the next scheduled run.
+const CREDIT_SWEEP_RETRY_LIMIT: usize = 5;
+
+/// Daily background sweep (Bencher Cloud only) that keeps each metered
+/// subscription's included usage credit granted for the current billing period
+/// and prunes the local plan row once a subscription has fully lapsed. This keeps
+/// credit granting off the report-ingestion hot path, free of billing-side Stripe
+/// calls.
+pub fn spawn_credit_grants(log: Logger, db_path: PathBuf, busy_timeout: u32, biller: Biller) {
+    tokio::spawn(async move {
+        loop {
+            // Sleep until the next occurrence of the daily sweep time (UTC) so the
+            // sweep runs at a fixed time of day, not relative to server start.
+            let now = Utc::now().naive_utc().time();
+            let sleep_time = match now.cmp(&CREDIT_SWEEP_TIME) {
+                cmp::Ordering::Less => CREDIT_SWEEP_TIME - now,
+                cmp::Ordering::Equal => Duration::days(1),
+                cmp::Ordering::Greater => Duration::days(1) - (now - CREDIT_SWEEP_TIME),
+            }
+            .to_std()
+            .unwrap_or(std::time::Duration::from_hours(24));
+            tokio::time::sleep(sleep_time).await;
+
+            // Open a configured connection for this sweep, retrying briefly on a
+            // transient failure rather than skipping the whole day's run.
+            let mut attempt = 0;
+            let conn = loop {
+                attempt += 1;
+                match DbConnection::establish(db_path.to_string_lossy().as_ref()) {
+                    Ok(mut conn) => {
+                        match configure_standalone_connection(&mut conn, busy_timeout) {
+                            Ok(()) => break Some(conn),
+                            Err(e) => slog::error!(
+                                log,
+                                "Failed to configure database connection PRAGMAs for credit sweep: {e}"
+                            ),
+                        }
+                    },
+                    Err(e) => slog::error!(
+                        log,
+                        "Failed to establish database connection for credit sweep: {e}"
+                    ),
+                }
+                if attempt >= CREDIT_SWEEP_RETRY_LIMIT {
+                    break None;
+                }
+                tokio::time::sleep(CREDIT_SWEEP_RETRY_DELAY).await;
+            };
+            let Some(mut conn) = conn else {
+                slog::error!(
+                    log,
+                    "Giving up on credit sweep until the next scheduled run after {CREDIT_SWEEP_RETRY_LIMIT} failed connection attempts"
+                );
+                continue;
+            };
+
+            let plans = match QueryPlan::all_metered(&mut conn) {
+                Ok(plans) => plans,
+                Err(e) => {
+                    slog::error!(log, "Failed to load metered plans for credit sweep: {e}");
+                    continue;
+                },
+            };
+
+            for plan in plans {
+                let Some(metered_plan_id) = plan.metered_plan.clone() else {
+                    continue;
+                };
+                let plan_id = plan.id;
+                match biller.get_metered_plan_status(&metered_plan_id).await {
+                    Ok((status, _)) => match credit_sweep_action(status) {
+                        // Active (or trialing): ensure this period's included credit.
+                        // Idempotent, and a no-op for metered plans without a base fee.
+                        CreditSweepAction::EnsureCredit => {
+                            if let Err(e) = biller.ensure_period_credit(&metered_plan_id).await {
+                                slog::warn!(
+                                    log,
+                                    "Failed to ensure period credit for {metered_plan_id}: {e}"
+                                );
+                                #[cfg(feature = "sentry")]
+                                sentry::capture_error(&e);
+                            }
+                        },
+                        // Terminal: prune the local plan row so the org reads as Free
+                        // and we stop querying a dead subscription.
+                        CreditSweepAction::Prune => {
+                            if let Err(e) = QueryPlan::delete(&mut conn, plan_id) {
+                                slog::warn!(
+                                    log,
+                                    "Failed to prune lapsed plan {metered_plan_id}: {e}"
+                                );
+                            }
+                        },
+                        // Recoverable/transient: leave the plan row intact so the
+                        // subscription can recover; grant nothing this run.
+                        CreditSweepAction::Skip => {},
+                    },
+                    Err(e) => {
+                        slog::warn!(log, "Failed to fetch status for {metered_plan_id}: {e}");
+                        #[cfg(feature = "sentry")]
+                        sentry::capture_error(&e);
+                    },
+                }
+            }
+        }
+    });
+}
+
+/// The action the daily sweep takes for a metered plan, derived from its
+/// subscription status. Extracted as a pure function so the branching is
+/// unit-testable without Stripe or a database.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CreditSweepAction {
+    /// Active or trialing: ensure this period's included usage credit.
+    EnsureCredit,
+    /// Terminally dead (canceled or incomplete-expired): prune the local plan row.
+    Prune,
+    /// Recoverable or transient (incomplete, past due, paused, unpaid): leave the
+    /// plan row in place and grant nothing; the subscription may still recover.
+    Skip,
+}
+
+/// Decide the sweep action from the subscription status. Only terminal states are
+/// pruned: deleting the local plan row severs the only org-to-subscription link
+/// (no webhook re-creates it), so a subscription that is merely retrying payment
+/// (`PastDue`/`Unpaid`), awaiting its first charge (`Incomplete`), or paused must
+/// be left intact to recover. The exhaustive match forces a deliberate choice if a
+/// new `PlanStatus` is added.
+fn credit_sweep_action(status: PlanStatus) -> CreditSweepAction {
+    match status {
+        PlanStatus::Active | PlanStatus::Trialing => CreditSweepAction::EnsureCredit,
+        PlanStatus::Canceled | PlanStatus::IncompleteExpired => CreditSweepAction::Prune,
+        PlanStatus::Incomplete | PlanStatus::PastDue | PlanStatus::Paused | PlanStatus::Unpaid => {
+            CreditSweepAction::Skip
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bencher_json::PlanStatus;
+
+    use super::{CreditSweepAction, credit_sweep_action};
+
+    #[test]
+    fn active_statuses_ensure_credit() {
+        for status in [PlanStatus::Active, PlanStatus::Trialing] {
+            assert_eq!(credit_sweep_action(status), CreditSweepAction::EnsureCredit);
+        }
+    }
+
+    #[test]
+    fn terminal_statuses_prune() {
+        for status in [PlanStatus::Canceled, PlanStatus::IncompleteExpired] {
+            assert_eq!(credit_sweep_action(status), CreditSweepAction::Prune);
+        }
+    }
+
+    #[test]
+    fn recoverable_statuses_skip() {
+        for status in [
+            PlanStatus::Incomplete,
+            PlanStatus::PastDue,
+            PlanStatus::Paused,
+            PlanStatus::Unpaid,
+        ] {
+            assert_eq!(credit_sweep_action(status), CreditSweepAction::Skip);
+        }
+    }
+}

--- a/lib/bencher_schema/src/model/server/plus/mod.rs
+++ b/lib/bencher_schema/src/model/server/plus/mod.rs
@@ -26,7 +26,10 @@ use crate::{
     schema::{self, server as server_table},
 };
 
+mod credit;
 mod stats;
+
+pub use credit::spawn_credit_grants;
 
 crate::macros::typed_id::typed_id!(ServerId);
 
@@ -329,7 +332,7 @@ impl Default for InsertServer {
     }
 }
 
-fn configure_standalone_connection(
+pub(super) fn configure_standalone_connection(
     conn: &mut DbConnection,
     busy_timeout: u32,
 ) -> diesel::QueryResult<()> {

--- a/lib/bencher_valid/src/plus/plan_level.rs
+++ b/lib/bencher_valid/src/plus/plan_level.rs
@@ -10,9 +10,11 @@ use serde::{Deserialize, Serialize};
 use crate::ValidError;
 
 const FREE: &str = "free";
+const PRO: &str = "pro";
 const TEAM: &str = "team";
 const ENTERPRISE: &str = "enterprise";
 // These are the Stripe product names
+const BENCHER_PRO: &str = "Bencher Pro";
 const BENCHER_TEAM: &str = "Bencher Team";
 const BENCHER_ENTERPRISE: &str = "Bencher Enterprise";
 
@@ -36,6 +38,9 @@ const BENCHER_ENTERPRISE: &str = "Bencher Enterprise";
 pub enum PlanLevel {
     #[default]
     Free,
+    Pro,
+    // Legacy self-serve paid tier, retained for grandfathered customers.
+    // New self-serve signups use `Pro`.
     Team,
     Enterprise,
 }
@@ -46,6 +51,7 @@ impl TryFrom<String> for PlanLevel {
     fn try_from(plan_level: String) -> Result<Self, Self::Error> {
         match plan_level.as_str() {
             FREE => Ok(Self::Free),
+            PRO | BENCHER_PRO => Ok(Self::Pro),
             TEAM | BENCHER_TEAM => Ok(Self::Team),
             ENTERPRISE | BENCHER_ENTERPRISE => Ok(Self::Enterprise),
             _ => Err(ValidError::PlanLevel(plan_level)),
@@ -65,6 +71,7 @@ impl AsRef<str> for PlanLevel {
     fn as_ref(&self) -> &str {
         match self {
             Self::Free => FREE,
+            Self::Pro => PRO,
             Self::Team => TEAM,
             Self::Enterprise => ENTERPRISE,
         }
@@ -85,7 +92,7 @@ impl From<PlanLevel> for String {
 pub fn is_valid_plan_level(plan_level: &str) -> bool {
     matches!(
         plan_level,
-        FREE | TEAM | ENTERPRISE | BENCHER_TEAM | BENCHER_ENTERPRISE
+        FREE | PRO | TEAM | ENTERPRISE | BENCHER_PRO | BENCHER_TEAM | BENCHER_ENTERPRISE
     )
 }
 
@@ -97,8 +104,10 @@ mod tests {
     #[test]
     fn plan_level() {
         assert_eq!(true, is_valid_plan_level("free"));
+        assert_eq!(true, is_valid_plan_level("pro"));
         assert_eq!(true, is_valid_plan_level("team"));
         assert_eq!(true, is_valid_plan_level("enterprise"));
+        assert_eq!(true, is_valid_plan_level("Bencher Pro"));
         assert_eq!(true, is_valid_plan_level("Bencher Team"));
         assert_eq!(true, is_valid_plan_level("Bencher Enterprise"));
 
@@ -118,6 +127,11 @@ mod tests {
         assert_eq!(level, PlanLevel::Team);
         let json = serde_json::to_string(&level).unwrap();
         assert_eq!(json, "\"team\"");
+
+        let level: PlanLevel = serde_json::from_str("\"pro\"").unwrap();
+        assert_eq!(level, PlanLevel::Pro);
+        let json = serde_json::to_string(&level).unwrap();
+        assert_eq!(json, "\"pro\"");
 
         serde_json::from_str::<PlanLevel>("\"invalid\"").unwrap_err();
     }

--- a/plus/bencher_billing/Cargo.toml
+++ b/plus/bencher_billing/Cargo.toml
@@ -26,7 +26,7 @@ plus = [
 
 [dependencies]
 async-stripe = { workspace = true, optional = true, features = ["rustls-aws-lc-rs", "rustls-tls-webpki-roots"] }
-async-stripe-billing = { workspace = true, optional = true, features = ["billing_meter_event", "subscription", "subscription_item"] }
+async-stripe-billing = { workspace = true, optional = true, features = ["billing_credit_grant", "billing_meter_event", "subscription", "subscription_item"] }
 async-stripe-checkout = { workspace = true, optional = true, features = ["checkout_session"] }
 async-stripe-core = { workspace = true, optional = true, features = ["customer"] }
 async-stripe-payment = { workspace = true, optional = true, features = ["payment_method"] }

--- a/plus/bencher_billing/src/biller.rs
+++ b/plus/bencher_billing/src/biller.rs
@@ -13,21 +13,30 @@ use bencher_json::{
         payment::{JsonCard, JsonCheckout, JsonCustomer},
     },
 };
-use stripe::Client as StripeClient;
+use stripe::{Client as StripeClient, IdempotencyKey, RequestStrategy, StripeRequest as _};
 use stripe_billing::{
     BillingMeterEvent, Subscription, SubscriptionId, SubscriptionItem, SubscriptionStatus,
+    billing_credit_grant::{
+        CreateBillingCreditGrant, CreateBillingCreditGrantAmount,
+        CreateBillingCreditGrantAmountMonetary, CreateBillingCreditGrantAmountType,
+        CreateBillingCreditGrantApplicabilityConfig,
+        CreateBillingCreditGrantApplicabilityConfigScope,
+        CreateBillingCreditGrantApplicabilityConfigScopePrices, ListBillingCreditGrant,
+    },
     billing_meter_event::CreateBillingMeterEvent,
     subscription::{
-        CancelSubscription, CreateSubscription, CreateSubscriptionItems, RetrieveSubscription,
+        CancelSubscription, CreateSubscription, CreateSubscriptionItems, DiscountsDataParam,
+        RetrieveSubscription, UpdateSubscription,
     },
 };
 use stripe_checkout::{
     CheckoutSessionId, CheckoutSessionMode, CheckoutSessionUiMode,
     checkout_session::{
         CreateCheckoutSession, CreateCheckoutSessionConsentCollection,
-        CreateCheckoutSessionConsentCollectionTermsOfService, CreateCheckoutSessionLineItems,
-        CreateCheckoutSessionLineItemsAdjustableQuantity, CreateCheckoutSessionPaymentMethodTypes,
-        CreateCheckoutSessionSubscriptionData, RetrieveCheckoutSession,
+        CreateCheckoutSessionConsentCollectionTermsOfService, CreateCheckoutSessionDiscounts,
+        CreateCheckoutSessionLineItems, CreateCheckoutSessionLineItemsAdjustableQuantity,
+        CreateCheckoutSessionPaymentMethodTypes, CreateCheckoutSessionSubscriptionData,
+        RetrieveCheckoutSession,
     },
 };
 use stripe_core::customer::{CreateCustomer, ListCustomer};
@@ -53,55 +62,133 @@ const METER_CUSTOMER_KEY: &str = "stripe_customer_id";
 /// Stripe meter event payload key for the usage value.
 const METER_VALUE_KEY: &str = "value";
 
+/// Credit grant metadata key marking a grant as set by Bencher Cloud.
+const CREDIT_BENCHER_CLOUD_KEY: &str = "bencher_cloud";
+/// Credit grant metadata key holding the billing-period start, used to
+/// idempotently grant exactly one included-usage credit per period.
+const CREDIT_PERIOD_KEY: &str = "period_start";
+/// Descriptive name shown in the Stripe Dashboard for the included usage credit.
+const CREDIT_NAME: &str = "Bencher Cloud included usage credit";
+
+#[derive(Clone)]
 pub struct Biller {
     client: StripeClient,
     products: Products,
 }
 
+/// Outcome of [`Biller::ensure_period_credit`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeriodCredit {
+    /// A new included-usage credit was granted for the current period.
+    Granted,
+    /// This period's credit already existed; no new grant was created.
+    AlreadyGranted,
+    /// The subscription has no flat base fee, so no credit applies.
+    NotApplicable,
+}
+
+/// The configuration price-name key (e.g. `default`) selecting which configured
+/// price to use. A newtype so a plan carries a typed selector, not a bare `String`.
+#[derive(Debug, Clone)]
+struct PriceName(String);
+
+impl PriceName {
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for PriceName {
+    fn from(price_name: String) -> Self {
+        Self(price_name)
+    }
+}
+
+impl fmt::Display for PriceName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 #[derive(Debug, Clone)]
 enum PlusPlan {
     Free,
+    // Bencher Cloud metered tier with a flat monthly base fee and an included
+    // usage credit. Carries the metered metrics price name; the base price is
+    // looked up separately. This tier has no licensed (Self-Hosted) form.
+    Pro(PriceName),
     Team(PlusUsage),
     Enterprise(PlusUsage),
 }
 
 #[derive(Debug, Clone)]
 enum PlusUsage {
-    Metered(String),
-    Licensed(String, Entitlements),
+    Metered(PriceName),
+    Licensed(PriceName, Entitlements),
 }
 
 impl PlusPlan {
     fn metered(plan_level: PlanLevel, price_name: String) -> Self {
         match plan_level {
             PlanLevel::Free => Self::Free,
-            PlanLevel::Team => Self::Team(PlusUsage::Metered(price_name)),
-            PlanLevel::Enterprise => Self::Enterprise(PlusUsage::Metered(price_name)),
+            PlanLevel::Pro => Self::Pro(price_name.into()),
+            PlanLevel::Team => Self::Team(PlusUsage::Metered(price_name.into())),
+            PlanLevel::Enterprise => Self::Enterprise(PlusUsage::Metered(price_name.into())),
         }
     }
 
     fn licensed(plan_level: PlanLevel, price_name: String, entitlements: Entitlements) -> Self {
         match plan_level {
             PlanLevel::Free => Self::Free,
-            PlanLevel::Team => Self::Team(PlusUsage::Licensed(price_name, entitlements)),
+            // This tier is Bencher Cloud metered only; it has no licensed form.
+            // The API layer rejects a licensed request for it before reaching here.
+            PlanLevel::Pro => Self::Pro(price_name.into()),
+            PlanLevel::Team => Self::Team(PlusUsage::Licensed(price_name.into(), entitlements)),
             PlanLevel::Enterprise => {
-                Self::Enterprise(PlusUsage::Licensed(price_name, entitlements))
+                Self::Enterprise(PlusUsage::Licensed(price_name.into(), entitlements))
             },
         }
     }
 
     fn bare_metal_price<'a>(&self, products: &'a Products) -> Result<&'a Price, BillingError> {
-        let usage = match self {
+        let (pricing, price_name) = match self {
             Self::Free => return Err(BillingError::ProductLevelFree),
-            Self::Team(usage) | Self::Enterprise(usage) => usage,
-        };
-        let (pricing, price_name) = match usage {
-            PlusUsage::Metered(price_name) => (&products.bare_metal.metered, price_name),
-            PlusUsage::Licensed(price_name, _) => (&products.bare_metal.licensed, price_name),
+            Self::Pro(price_name) => (&products.bare_metal.metered, price_name),
+            Self::Team(usage) | Self::Enterprise(usage) => match usage {
+                PlusUsage::Metered(price_name) => (&products.bare_metal.metered, price_name),
+                PlusUsage::Licensed(price_name, _) => (&products.bare_metal.licensed, price_name),
+            },
         };
         pricing
             .get(price_name.as_str())
-            .ok_or_else(|| BillingError::PriceNotFound(price_name.clone()))
+            .ok_or_else(|| BillingError::PriceNotFound(price_name.to_string()))
+    }
+
+    // The flat recurring base fee for this plan, if any.
+    fn base_price<'a>(&self, products: &'a Products) -> Result<Option<&'a Price>, BillingError> {
+        match self {
+            Self::Pro(price_name) => products
+                .pro
+                .base
+                .get(price_name.as_str())
+                .map(Some)
+                .ok_or_else(|| BillingError::PriceNotFound(price_name.to_string())),
+            Self::Free | Self::Team(_) | Self::Enterprise(_) => Ok(None),
+        }
+    }
+
+    // Whether this plan carries a flat recurring base fee (and so receives the
+    // free-trial coupon and the monthly included-usage credit).
+    fn has_base_fee(&self) -> bool {
+        matches!(self, Self::Pro(_))
+    }
+
+    // The configured free-trial coupon for this plan's product, if any.
+    fn trial_coupon<'a>(&self, products: &'a Products) -> Option<&'a str> {
+        match self {
+            Self::Pro(_) => products.pro.trial_coupon.as_deref(),
+            Self::Free | Self::Team(_) | Self::Enterprise(_) => None,
+        }
     }
 
     fn into_plus_price(
@@ -110,21 +197,29 @@ impl PlusPlan {
     ) -> Result<(&Price, Option<Entitlements>), BillingError> {
         Ok(match self {
             PlusPlan::Free => return Err(BillingError::ProductLevelFree),
+            PlusPlan::Pro(price_name) => (
+                products
+                    .pro
+                    .metered
+                    .get(price_name.as_str())
+                    .ok_or_else(|| BillingError::PriceNotFound(price_name.to_string()))?,
+                None,
+            ),
             PlusPlan::Team(plus_usage) => match plus_usage {
                 PlusUsage::Metered(price_name) => (
                     products
                         .team
                         .metered
-                        .get(&price_name)
-                        .ok_or(BillingError::PriceNotFound(price_name))?,
+                        .get(price_name.as_str())
+                        .ok_or_else(|| BillingError::PriceNotFound(price_name.to_string()))?,
                     None,
                 ),
                 PlusUsage::Licensed(price_name, entitlements) => (
                     products
                         .team
                         .licensed
-                        .get(&price_name)
-                        .ok_or(BillingError::PriceNotFound(price_name))?,
+                        .get(price_name.as_str())
+                        .ok_or_else(|| BillingError::PriceNotFound(price_name.to_string()))?,
                     Some(entitlements),
                 ),
             },
@@ -133,16 +228,16 @@ impl PlusPlan {
                     products
                         .enterprise
                         .metered
-                        .get(&price_name)
-                        .ok_or(BillingError::PriceNotFound(price_name))?,
+                        .get(price_name.as_str())
+                        .ok_or_else(|| BillingError::PriceNotFound(price_name.to_string()))?,
                     None,
                 ),
                 PlusUsage::Licensed(price_name, entitlements) => (
                     products
                         .enterprise
                         .licensed
-                        .get(&price_name)
-                        .ok_or(BillingError::PriceNotFound(price_name))?,
+                        .get(price_name.as_str())
+                        .ok_or_else(|| BillingError::PriceNotFound(price_name.to_string()))?,
                     Some(entitlements),
                 ),
             },
@@ -215,6 +310,8 @@ impl Biller {
             PlusPlan::metered(plan_level, price_name)
         };
         let bare_metal_price = plus_plan.bare_metal_price(&self.products)?;
+        let base_price = plus_plan.base_price(&self.products)?;
+        let trial_coupon = self.trial_coupon(&plus_plan);
         let (plus_price, entitlements) = plus_plan.into_plus_price(&self.products)?;
 
         let mut plus_line_item = CreateCheckoutSessionLineItems {
@@ -234,6 +331,18 @@ impl Biller {
             ..Default::default()
         };
 
+        // Flat monthly base fee billed alongside the metered usage.
+        let mut line_items = Vec::new();
+        if let Some(base_price) = base_price {
+            line_items.push(CreateCheckoutSessionLineItems {
+                price: Some(base_price.id.to_string()),
+                quantity: Some(1),
+                ..Default::default()
+            });
+        }
+        line_items.push(plus_line_item);
+        line_items.push(bare_metal_line_item);
+
         let mut consent = CreateCheckoutSessionConsentCollection::new();
         // https://bencher.dev/legal/subscription/
         consent.terms_of_service =
@@ -246,18 +355,26 @@ impl Biller {
                 .collect(),
         );
 
-        let mut checkout_session = CreateCheckoutSession::new()
+        let mut create_checkout_session = CreateCheckoutSession::new()
             .ui_mode(CheckoutSessionUiMode::HostedPage)
             .customer(customer.to_string())
             .payment_method_types(vec![CreateCheckoutSessionPaymentMethodTypes::Card])
             .currency(Currency::USD)
             .mode(CheckoutSessionMode::Subscription)
-            .line_items(vec![plus_line_item, bare_metal_line_item])
+            .line_items(line_items)
             .consent_collection(consent)
             .subscription_data(sub_data)
-            .success_url(return_url)
-            .send(&self.client)
-            .await?;
+            .success_url(return_url);
+        // Free trial: waive the first month's base fee via a one-time coupon.
+        // Metered usage still bills, offset by the monthly included-usage credit.
+        if let Some(coupon) = trial_coupon {
+            create_checkout_session =
+                create_checkout_session.discounts(vec![CreateCheckoutSessionDiscounts {
+                    coupon: Some(coupon),
+                    promotion_code: None,
+                }]);
+        }
+        let mut checkout_session = create_checkout_session.send(&self.client).await?;
 
         Ok(JsonCheckout {
             session: checkout_session.id.to_string(),
@@ -397,24 +514,44 @@ impl Biller {
         plus_plan: PlusPlan,
     ) -> Result<Subscription, BillingError> {
         let bare_metal_price = plus_plan.bare_metal_price(&self.products)?;
+        let base_price = plus_plan.base_price(&self.products)?;
+        let trial_coupon = self.trial_coupon(&plus_plan);
         let (plus_price, entitlements) = plus_plan.into_plus_price(&self.products)?;
 
+        // Flat monthly base fee billed alongside the metered usage.
+        let mut items = Vec::new();
+        if let Some(base_price) = base_price {
+            let mut base_item = CreateSubscriptionItems::new();
+            base_item.price = Some(base_price.id.to_string());
+            base_item.quantity = Some(1);
+            items.push(base_item);
+        }
         let mut plus_item = CreateSubscriptionItems::new();
         plus_item.price = Some(plus_price.id.to_string());
         plus_item.quantity = entitlements.map(Into::into);
-
+        items.push(plus_item);
         let mut bare_metal_item = CreateSubscriptionItems::new();
         bare_metal_item.price = Some(bare_metal_price.id.to_string());
+        items.push(bare_metal_item);
 
-        CreateSubscription::new()
+        let mut create_subscription = CreateSubscription::new()
             .customer(customer_id.to_string())
-            .items(vec![plus_item, bare_metal_item])
+            .items(items)
             .default_payment_method(payment_method_id.to_string())
             .metadata(
                 [(METADATA_ORGANIZATION.to_owned(), organization.to_string())]
                     .into_iter()
                     .collect::<HashMap<String, String>>(),
-            )
+            );
+        // Free trial: waive the first month's base fee via a one-time coupon.
+        if let Some(coupon) = trial_coupon {
+            create_subscription = create_subscription.discounts(vec![DiscountsDataParam {
+                coupon: Some(coupon),
+                discount: None,
+                promotion_code: None,
+            }]);
+        }
+        create_subscription
             .send(&self.client)
             .await
             .map_err(Into::into)
@@ -504,6 +641,7 @@ impl Biller {
             current_period_start,
             current_period_end,
             status,
+            cancel_at_period_end: subscription.cancel_at_period_end,
             license: None,
         })
     }
@@ -716,12 +854,182 @@ impl Biller {
         .map_err(Into::into)
     }
 
+    // The first-period base-fee waiver coupon for this plan: returned only when
+    // the plan has a base fee and its product configures a trial coupon.
+    fn trial_coupon(&self, plus_plan: &PlusPlan) -> Option<String> {
+        if !plus_plan.has_base_fee() {
+            return None;
+        }
+        plus_plan
+            .trial_coupon(&self.products)
+            .map(ToOwned::to_owned)
+    }
+
+    /// Idempotently grant the current billing period's included usage credit for a
+    /// metered subscription that carries a flat base fee. The credit equals that
+    /// base fee and forms a single fungible pool scoped to the subscription's
+    /// metered usage prices, expiring at period end (use-it-or-lose-it). A no-op if
+    /// the subscription has no base fee or this period's grant already exists.
+    pub async fn ensure_period_credit(
+        &self,
+        metered_plan_id: &MeteredPlanId,
+    ) -> Result<PeriodCredit, BillingError> {
+        let subscription_id: SubscriptionId = metered_plan_id.as_ref().into();
+        let subscription = self
+            .get_subscription_expand(&subscription_id, vec!["items".into()])
+            .await?;
+
+        // The included credit equals the subscription's flat base fee. A metered
+        // plan without a configured base price (e.g. a grandfathered Team plan) is
+        // a safe no-op.
+        let base_cents: HashMap<&PriceId, i64> = self
+            .products
+            .all_base_prices()
+            .filter_map(|price| price.unit_amount.map(|cents| (&price.id, cents)))
+            .collect();
+        let Some(value_cents) = matched_base_cents(
+            subscription.items.data.iter().map(|item| &item.price.id),
+            &base_cents,
+        ) else {
+            return Ok(PeriodCredit::NotApplicable);
+        };
+
+        let customer_id = subscription.customer.id().clone();
+        // All subscription items share the same billing period.
+        let item = subscription
+            .items
+            .data
+            .first()
+            .ok_or_else(|| BillingError::NoSubscriptionItem(subscription_id.clone()))?;
+        let period_start = item.current_period_start;
+        let period_end = item.current_period_end;
+
+        // The credit applies to the metered usage prices (every item except the
+        // flat base fee), forming a single fungible pool.
+        let credit_price_ids: Vec<String> = subscription
+            .items
+            .data
+            .iter()
+            .map(|item| &item.price.id)
+            .filter(|id| !base_cents.contains_key(*id))
+            .map(ToString::to_string)
+            .collect();
+
+        // Dedup: skip if a Bencher-managed grant for this period already exists.
+        // Stripe lists grants newest-first by `created` and cannot filter by
+        // metadata, and a customer may have unrelated grants (manual dashboard
+        // credits, refunds), so scan a page of recent grants for our marker plus
+        // period rather than trusting the single newest. Our current-period grant
+        // is recent, so it sits well within one page. The idempotency key guards
+        // concurrent attempts; this guards across the sweep's daily cadence.
+        let marker = period_start.to_string();
+        let grants = ListBillingCreditGrant::new()
+            .customer(customer_id.to_string())
+            .limit(100)
+            .send(&self.client)
+            .await?;
+        if period_already_granted(
+            grants.data.iter().map(|grant| {
+                (
+                    grant
+                        .metadata
+                        .get(CREDIT_BENCHER_CLOUD_KEY)
+                        .map(String::as_str),
+                    grant.metadata.get(CREDIT_PERIOD_KEY).map(String::as_str),
+                )
+            }),
+            &marker,
+        ) {
+            return Ok(PeriodCredit::AlreadyGranted);
+        }
+
+        self.create_credit_grant(
+            &customer_id,
+            value_cents,
+            credit_price_ids,
+            period_start,
+            period_end,
+        )
+        .await?;
+        Ok(PeriodCredit::Granted)
+    }
+
+    async fn create_credit_grant(
+        &self,
+        customer_id: &CustomerId,
+        value_cents: i64,
+        credit_price_ids: Vec<String>,
+        period_start: stripe_types::Timestamp,
+        period_end: stripe_types::Timestamp,
+    ) -> Result<(), BillingError> {
+        let prices = credit_price_ids
+            .into_iter()
+            .map(CreateBillingCreditGrantApplicabilityConfigScopePrices::new)
+            .collect();
+        let scope = CreateBillingCreditGrantApplicabilityConfigScope {
+            price_type: None,
+            prices: Some(prices),
+        };
+        let amount = CreateBillingCreditGrantAmount {
+            monetary: Some(CreateBillingCreditGrantAmountMonetary::new(
+                Currency::USD,
+                value_cents,
+            )),
+            type_: CreateBillingCreditGrantAmountType::Monetary,
+        };
+        let metadata = HashMap::from([
+            (CREDIT_BENCHER_CLOUD_KEY.to_owned(), "true".to_owned()),
+            (CREDIT_PERIOD_KEY.to_owned(), period_start.to_string()),
+        ]);
+        // Idempotency key from customer + period so concurrent grant attempts
+        // (e.g. plan creation overlapping the daily sweep) collapse to one grant.
+        // The list-check above handles dedup across periods (beyond the key's TTL).
+        let idempotency_key =
+            IdempotencyKey::new(format!("bencher-credit:{customer_id}:{period_start}"))?;
+        CreateBillingCreditGrant::new(
+            amount,
+            CreateBillingCreditGrantApplicabilityConfig { scope },
+        )
+        .customer(customer_id.to_string())
+        .effective_at(period_start)
+        .expires_at(period_end)
+        .metadata(metadata)
+        .name(CREDIT_NAME)
+        .customize()
+        .request_strategy(RequestStrategy::Idempotent(idempotency_key))
+        .send(&self.client)
+        .await
+        .map(|_grant| ())
+        .map_err(Into::into)
+    }
+
+    /// Immediately cancel a metered subscription. Used by the admin-only DELETE
+    /// path; the organization downgrades to Free right away.
     pub async fn cancel_metered_subscription(
         &self,
         metered_plan_id: &MeteredPlanId,
     ) -> Result<Subscription, BillingError> {
         let subscription_id: SubscriptionId = metered_plan_id.as_ref().into();
         self.cancel_subscription(&subscription_id).await
+    }
+
+    /// Schedule (`true`) or clear (`false`) a metered subscription's
+    /// cancel-at-period-end. With `true` the customer keeps access through the
+    /// period they have already paid for; the subscription stays active until it
+    /// then lapses (reconciled lazily on read and by the daily sweep). With
+    /// `false` a scheduled cancellation is cleared, resuming the subscription.
+    /// Used by the self-service PATCH path.
+    pub async fn set_metered_cancel_at_period_end(
+        &self,
+        metered_plan_id: &MeteredPlanId,
+        cancel_at_period_end: bool,
+    ) -> Result<Subscription, BillingError> {
+        let subscription_id: SubscriptionId = metered_plan_id.as_ref().into();
+        UpdateSubscription::new(subscription_id)
+            .cancel_at_period_end(cancel_at_period_end)
+            .send(&self.client)
+            .await
+            .map_err(Into::into)
     }
 
     pub async fn cancel_licensed_subscription(
@@ -743,6 +1051,29 @@ impl Biller {
     }
 }
 
+/// The included-credit amount (the matched flat base price's cents) for a
+/// subscription, given a map of configured base price ID to cents. `None` if the
+/// subscription carries no configured base fee. Gates the included-usage credit to
+/// base-fee subscriptions and sizes it to the base fee.
+fn matched_base_cents<'a>(
+    mut item_price_ids: impl Iterator<Item = &'a PriceId>,
+    base_cents: &HashMap<&'a PriceId, i64>,
+) -> Option<i64> {
+    item_price_ids.find_map(|id| base_cents.get(id).copied())
+}
+
+/// Whether a Bencher-managed credit grant for the given billing-period marker
+/// already exists. Each item is `(bencher_cloud_marker, period_start)`; only
+/// grants carrying our marker count, so unrelated grants (manual credits,
+/// refunds) are ignored even when newer. (Per-period dedup for
+/// `ensure_period_credit`.)
+fn period_already_granted<'a>(
+    mut grants: impl Iterator<Item = (Option<&'a str>, Option<&'a str>)>,
+    marker: &'a str,
+) -> bool {
+    grants.any(|(managed, period)| managed == Some("true") && period == Some(marker))
+}
+
 fn into_payment_card(card: JsonCard) -> CreatePaymentMethodCardDetailsParams {
     let JsonCard {
         number,
@@ -760,7 +1091,7 @@ fn into_payment_card(card: JsonCard) -> CreatePaymentMethodCardDetailsParams {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
 
     use bencher_json::{
         Entitlements, OrganizationUuid, PlanLevel, PlanStatus, UserUuid,
@@ -779,7 +1110,53 @@ mod tests {
 
     use crate::Biller;
 
-    use super::{METER_CUSTOMER_KEY, METER_VALUE_KEY};
+    use super::{METER_CUSTOMER_KEY, METER_VALUE_KEY, matched_base_cents, period_already_granted};
+
+    #[test]
+    fn matched_base_cents_returns_base_fee() {
+        let base: stripe_product::PriceId = "price_base".parse().unwrap();
+        let metered: stripe_product::PriceId = "price_metered".parse().unwrap();
+        let other: stripe_product::PriceId = "price_other".parse().unwrap();
+        let base_cents: HashMap<&stripe_product::PriceId, i64> = HashMap::from([(&base, 2_000)]);
+        // A subscription carrying the base price yields that base price's cents.
+        assert_eq!(
+            matched_base_cents([&metered, &base].into_iter(), &base_cents),
+            Some(2_000),
+        );
+        // A subscription without a configured base price yields nothing.
+        assert_eq!(
+            matched_base_cents([&metered, &other].into_iter(), &base_cents),
+            None,
+        );
+    }
+
+    #[test]
+    fn period_already_granted_matches_marker() {
+        // A Bencher-managed grant for the period counts.
+        assert!(period_already_granted(
+            [(Some("true"), Some("100")), (None, None)].into_iter(),
+            "100",
+        ));
+        // A non-Bencher grant on top does not hide a real Bencher grant deeper down.
+        assert!(period_already_granted(
+            [(None, Some("100")), (Some("true"), Some("100"))].into_iter(),
+            "100",
+        ));
+        // A non-Bencher grant for the period (no marker) is not counted as ours.
+        assert!(!period_already_granted(
+            [(None, Some("100"))].into_iter(),
+            "100",
+        ));
+        // A different period does not match.
+        assert!(!period_already_granted(
+            [(Some("true"), Some("100"))].into_iter(),
+            "200",
+        ));
+        assert!(!period_already_granted(
+            std::iter::empty::<(Option<&str>, Option<&str>)>(),
+            "100",
+        ));
+    }
 
     const TEST_BILLING_KEY: &str = "TEST_BILLING_KEY";
 
@@ -789,6 +1166,17 @@ mod tests {
 
     fn products() -> JsonProducts {
         JsonProducts {
+            pro: JsonProduct {
+                id: "prod_UizgEJP4gIENBi".into(),
+                metered: hmap! {
+                    "default".to_owned() => "price_1TjXq8Kal5vzTlmhBD8plpc7".to_owned(),
+                },
+                licensed: HashMap::new(),
+                base: hmap! {
+                    "default".to_owned() => "price_1TjXgeKal5vzTlmhZzr88bki".to_owned(),
+                },
+                trial_coupon: Some("m8uHY6oa".to_owned()),
+            },
             team: JsonProduct {
                 id: "prod_NKz5B9dGhDiSY1".into(),
                 metered: hmap! {
@@ -797,6 +1185,8 @@ mod tests {
                 licensed: hmap! {
                     "default".to_owned() => "price_1O4XlwKal5vzTlmh0n0wtplQ".to_owned(),
                 },
+                base: HashMap::new(),
+                trial_coupon: None,
             },
             enterprise: JsonProduct {
                 id: "prod_NLC7fDet2C8Nmk".into(),
@@ -806,6 +1196,8 @@ mod tests {
                 licensed: hmap! {
                     "default".to_owned() => "price_1O4Xo1Kal5vzTlmh1KrcEbq0".to_owned(),
                 },
+                base: HashMap::new(),
+                trial_coupon: None,
             },
             bare_metal: JsonProduct {
                 id: "prod_U6a28ecwqRZHYz".into(),
@@ -815,6 +1207,8 @@ mod tests {
                 licensed: hmap! {
                     "default".to_owned() => "price_1TCWdkKal5vzTlmh9fdahWqY".to_owned(),
                 },
+                base: HashMap::new(),
+                trial_coupon: None,
             },
         }
     }
@@ -857,6 +1251,20 @@ mod tests {
         record_runner_usage(biller, &customer_id, runner_minutes).await;
         record_metrics_usage(biller, &customer_id, metrics_quantity).await;
 
+        // PATCH path: schedule cancel-at-period-end, then clear it (resume). The
+        // subscription stays active throughout.
+        let scheduled = biller
+            .set_metered_cancel_at_period_end(metered_plan_id, true)
+            .await
+            .unwrap();
+        assert!(scheduled.cancel_at_period_end);
+        let resumed = biller
+            .set_metered_cancel_at_period_end(metered_plan_id, false)
+            .await
+            .unwrap();
+        assert!(!resumed.cancel_at_period_end);
+
+        // DELETE path: immediate cancel.
         biller
             .cancel_metered_subscription(&subscription_id.parse().unwrap())
             .await
@@ -953,7 +1361,7 @@ mod tests {
             id: price_id.parse().unwrap(),
             livemode: false,
             lookup_key: None,
-            metadata: std::collections::HashMap::new(),
+            metadata: HashMap::new(),
             nickname: None,
             product: stripe_types::Expandable::Id(
                 "prod_test".parse::<stripe_shared::ProductId>().unwrap(),
@@ -1001,7 +1409,7 @@ mod tests {
             current_period_start: 0,
             discounts: vec![],
             id: format!("si_test_{price_id}").parse().unwrap(),
-            metadata: std::collections::HashMap::new(),
+            metadata: HashMap::new(),
             plan: make_plan(),
             price: make_price(price_id),
             quantity: None,

--- a/plus/bencher_billing/src/error.rs
+++ b/plus/bencher_billing/src/error.rs
@@ -23,6 +23,8 @@ pub enum BillingError {
     IntError(#[from] std::num::TryFromIntError),
     #[error("Failed to send billing request: {0}")]
     Stripe(#[from] stripe::StripeError),
+    #[error("Failed to build idempotency key: {0}")]
+    IdempotencyKey(#[from] stripe::IdempotentKeyError),
     #[error("Email collision: {0:#?} {1:#?}")]
     EmailCollision(Box<Customer>, Vec<Customer>),
     #[error("Failed to find price: {0}")]

--- a/plus/bencher_billing/src/lib.rs
+++ b/plus/bencher_billing/src/lib.rs
@@ -10,5 +10,5 @@ mod biller;
 mod error;
 mod products;
 
-pub use biller::Biller;
+pub use biller::{Biller, PeriodCredit};
 pub use error::BillingError;

--- a/plus/bencher_billing/src/products.rs
+++ b/plus/bencher_billing/src/products.rs
@@ -12,7 +12,10 @@ use stripe_product::{
 
 use crate::BillingError;
 
+#[derive(Clone)]
 pub struct Products {
+    pub pro: Product,
+    // Legacy self-serve paid tier, retained for grandfathered customers.
     pub team: Product,
     pub enterprise: Product,
     pub bare_metal: Product,
@@ -21,21 +24,23 @@ pub struct Products {
 impl Products {
     pub async fn new(client: &StripeClient, products: JsonProducts) -> Result<Self, BillingError> {
         let JsonProducts {
+            pro,
             team,
             enterprise,
             bare_metal,
         } = products;
 
         Ok(Self {
+            pro: Product::new(client, pro).await?,
             team: Product::new(client, team).await?,
             enterprise: Product::new(client, enterprise).await?,
             bare_metal: Product::new(client, bare_metal).await?,
         })
     }
 
-    // Returns the price IDs for Team and Enterprise plans only (excluding
-    // bare_metal), used by `get_plan` to filter subscription items to the
-    // main plan item.
+    // Returns the price IDs for the Pro, Team, and Enterprise plans only
+    // (excluding bare_metal), used by `get_plan` to filter subscription items to
+    // the main plan item.
     //
     // During the metered billing migration, a subscription may temporarily have
     // multiple subscription items (old metered + new metered). The config holds
@@ -47,14 +52,27 @@ impl Products {
     // Once the migration cutover is complete and the old subscription items are
     // removed, this filtering becomes a no-op (one item in, one item out).
     pub fn plan_price_ids(&self, preferred: &str) -> HashSet<&PriceId> {
-        self.team
+        self.pro
             .preferred_price_ids(preferred)
             .into_iter()
+            .chain(self.team.preferred_price_ids(preferred))
             .chain(self.enterprise.preferred_price_ids(preferred))
             .collect()
     }
+
+    /// All configured flat base prices across every product. The included usage
+    /// credit equals the base fee of whichever base price a subscription carries.
+    pub fn all_base_prices(&self) -> impl Iterator<Item = &StripePrice> {
+        self.pro
+            .base
+            .values()
+            .chain(self.team.base.values())
+            .chain(self.enterprise.base.values())
+            .chain(self.bare_metal.base.values())
+    }
 }
 
+#[derive(Clone)]
 pub struct Product {
     #[expect(
         dead_code,
@@ -62,6 +80,13 @@ pub struct Product {
         reason = "retained for future Stripe API use"
     )]
     pub product: StripeProduct,
+    // Stripe coupon ID for this product's free trial (waives the first month's
+    // base fee). `None` if the product has no trial.
+    pub trial_coupon: Option<String>,
+    // Flat recurring base prices. Deliberately excluded from `preferred_price_ids`
+    // so it is never treated as the metered "plan item" when resolving a
+    // subscription's plan level.
+    pub base: HashMap<String, StripePrice>,
     pub metered: HashMap<String, StripePrice>,
     pub licensed: HashMap<String, StripePrice>,
 }
@@ -72,15 +97,20 @@ impl Product {
             id,
             metered,
             licensed,
+            base,
+            trial_coupon,
         } = product;
 
         let product_id: ProductId = id.as_str().into();
         let product = RetrieveProduct::new(product_id).send(client).await?;
         let metered = Self::pricing(client, metered).await?;
         let licensed = Self::pricing(client, licensed).await?;
+        let base = Self::pricing(client, base).await?;
 
         Ok(Self {
             product,
+            trial_coupon,
+            base,
             metered,
             licensed,
         })

--- a/plus/bencher_otel/src/api_meter.rs
+++ b/plus/bencher_otel/src/api_meter.rs
@@ -75,6 +75,7 @@ pub enum ApiCounter {
 
     OrganizationCreate,
     OrganizationDelete,
+    OrganizationPlanUpdateBlocked,
 
     ProjectCreate,
     ProjectDelete,
@@ -197,7 +198,8 @@ impl ApiCounter {
             | Self::UserKeyCreateBlocked
             | Self::UserKeyViewBlocked
             | Self::UserKeyUpdateBlocked
-            | Self::UserKeyRevokeBlocked => "{attempt}",
+            | Self::UserKeyRevokeBlocked
+            | Self::OrganizationPlanUpdateBlocked => "{attempt}",
             Self::UserCredentialMax(_) | Self::UserTokenCreate | Self::UserTokenRevoke => "{token}",
             Self::UserKeyCreate | Self::UserKeyRevoke | Self::RunnerKeyRotate => "{key}",
             Self::ProjectKeyAuthFailed(_) | Self::UserKeyAuthFailed(_) => "{auth_failure}",
@@ -224,6 +226,7 @@ impl ApiCounter {
 
             Self::OrganizationCreate => "organization.create",
             Self::OrganizationDelete => "organization.delete",
+            Self::OrganizationPlanUpdateBlocked => "organization.plan.update.blocked",
 
             Self::ProjectCreate => "project.create",
             Self::ProjectDelete => "project.delete",
@@ -315,6 +318,9 @@ impl ApiCounter {
 
             Self::OrganizationCreate => "Counts the number of organization creations",
             Self::OrganizationDelete => "Counts the number of organization deletions",
+            Self::OrganizationPlanUpdateBlocked => {
+                "Counts the number of organization plan update attempts blocked because the caller authenticated with a user API key"
+            },
 
             Self::ProjectCreate => "Counts the number of project creations",
             Self::ProjectDelete => "Counts the number of project deletions",
@@ -429,6 +435,7 @@ impl ApiCounter {
             Self::ServerStartup
             | Self::OrganizationCreate
             | Self::OrganizationDelete
+            | Self::OrganizationPlanUpdateBlocked
             | Self::ProjectCreate
             | Self::ProjectDelete
             | Self::ReportCreate

--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -2133,6 +2133,8 @@
           "organizations",
           "plan"
         ],
+        "summary": "Delete an organization's subscription plan (admin only).",
+        "description": "Immediately cancels the organization's subscription and removes the plan. Restricted to Bencher server administrators.",
         "operationId": "org_plan_delete",
         "parameters": [
           {
@@ -2190,6 +2192,91 @@
                 "required": true,
                 "schema": {
                   "type": "string"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "organizations",
+          "plan"
+        ],
+        "summary": "Update an organization's metered subscription plan.",
+        "description": "Schedules or clears a cancel-at-period-end for the organization's metered subscription. Available to organization managers and must be called with a user session JWT, not a user API key.",
+        "operationId": "org_plan_patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization",
+            "description": "The slug or UUID for an organization.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ResourceId"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonUpdatePlan"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "headers": {
+              "access-control-allow-headers": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-allow-methods": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-allow-origin": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-expose-headers": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "x-total-count": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonPlan"
                 }
               }
             }
@@ -14819,6 +14906,10 @@
       "JsonPlan": {
         "type": "object",
         "properties": {
+          "cancel_at_period_end": {
+            "description": "Whether the subscription is set to cancel at the end of the current period (the org keeps access until `current_period_end`, then downgrades to Free).",
+            "type": "boolean"
+          },
           "card": {
             "$ref": "#/components/schemas/JsonCardDetails"
           },
@@ -14853,6 +14944,7 @@
           }
         },
         "required": [
+          "cancel_at_period_end",
           "card",
           "current_period_end",
           "current_period_start",
@@ -15086,26 +15178,38 @@
       "JsonProduct": {
         "type": "object",
         "properties": {
+          "base": {
+            "default": {},
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
           "id": {
             "type": "string"
           },
           "licensed": {
+            "default": {},
             "type": "object",
             "additionalProperties": {
               "type": "string"
             }
           },
           "metered": {
+            "default": {},
             "type": "object",
             "additionalProperties": {
               "type": "string"
             }
+          },
+          "trial_coupon": {
+            "nullable": true,
+            "default": null,
+            "type": "string"
           }
         },
         "required": [
-          "id",
-          "licensed",
-          "metered"
+          "id"
         ]
       },
       "JsonProducts": {
@@ -15117,6 +15221,9 @@
           "enterprise": {
             "$ref": "#/components/schemas/JsonProduct"
           },
+          "pro": {
+            "$ref": "#/components/schemas/JsonProduct"
+          },
           "team": {
             "$ref": "#/components/schemas/JsonProduct"
           }
@@ -15124,6 +15231,7 @@
         "required": [
           "bare_metal",
           "enterprise",
+          "pro",
           "team"
         ]
       },
@@ -17364,6 +17472,18 @@
           }
         ]
       },
+      "JsonUpdatePlan": {
+        "type": "object",
+        "properties": {
+          "cancel_at_period_end": {
+            "description": "Update the subscription's scheduled cancellation. Set to `false` to resume a plan scheduled to cancel at period end, or `true` to schedule it to cancel at the end of the current period. Only applies to metered subscriptions, not licensed (Self-Hosted) plans.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "cancel_at_period_end"
+        ]
+      },
       "JsonUpdatePlot": {
         "anyOf": [
           {
@@ -18055,6 +18175,7 @@
         "type": "string",
         "enum": [
           "free",
+          "pro",
           "team",
           "enterprise"
         ]

--- a/services/cli/src/bencher/sub/organization/plan/create.rs
+++ b/services/cli/src/bencher/sub/organization/plan/create.rs
@@ -47,6 +47,7 @@ impl From<CliPlanLevel> for PlanLevel {
     fn from(level: CliPlanLevel) -> Self {
         match level {
             CliPlanLevel::Free => Self::Free,
+            CliPlanLevel::Pro => Self::Pro,
             CliPlanLevel::Team => Self::Team,
             CliPlanLevel::Enterprise => Self::Enterprise,
         }

--- a/services/cli/src/bencher/sub/organization/plan/mod.rs
+++ b/services/cli/src/bencher/sub/organization/plan/mod.rs
@@ -4,12 +4,14 @@ use crate::{CliError, bencher::sub::SubCmd, parser::organization::plan::CliOrgan
 
 mod create;
 mod delete;
+mod update;
 mod view;
 
 #[derive(Debug)]
 pub enum Plan {
     Create(create::Create),
     View(view::View),
+    Update(update::Update),
     Delete(delete::Delete),
 }
 
@@ -20,6 +22,7 @@ impl TryFrom<CliOrganizationPlan> for Plan {
         Ok(match plan {
             CliOrganizationPlan::Create(create) => Self::Create(create.try_into()?),
             CliOrganizationPlan::View(view) => Self::View(view.try_into()?),
+            CliOrganizationPlan::Update(update) => Self::Update(update.try_into()?),
             CliOrganizationPlan::Delete(delete) => Self::Delete(delete.try_into()?),
         })
     }
@@ -30,6 +33,7 @@ impl SubCmd for Plan {
         match self {
             Self::Create(create) => create.exec().await,
             Self::View(view) => view.exec().await,
+            Self::Update(update) => update.exec().await,
             Self::Delete(delete) => delete.exec().await,
         }
     }

--- a/services/cli/src/bencher/sub/organization/plan/update.rs
+++ b/services/cli/src/bencher/sub/organization/plan/update.rs
@@ -1,0 +1,73 @@
+use bencher_client::types::JsonUpdatePlan;
+use bencher_json::OrganizationResourceId;
+
+use crate::{
+    CliError,
+    bencher::{backend::AuthBackend, sub::SubCmd},
+    parser::organization::plan::CliPlanUpdate,
+};
+
+#[derive(Debug, Clone)]
+pub struct Update {
+    pub organization: OrganizationResourceId,
+    pub cancel_at_period_end: bool,
+    pub backend: AuthBackend,
+}
+
+impl TryFrom<CliPlanUpdate> for Update {
+    type Error = CliError;
+
+    fn try_from(update: CliPlanUpdate) -> Result<Self, Self::Error> {
+        let CliPlanUpdate {
+            organization,
+            cancel,
+            resume,
+            backend,
+        } = update;
+        // `--cancel` schedules cancel-at-period-end; `--resume` clears it. The clap
+        // ArgGroup requires exactly one, so no other combination can occur.
+        let cancel_at_period_end = match (cancel, resume) {
+            (true, false) => true,
+            (false, true) => false,
+            #[expect(
+                clippy::unreachable,
+                reason = "clap ArgGroup requires exactly one of `cancel`/`resume`"
+            )]
+            _ => unreachable!("Exactly one of `cancel` or `resume` is required"),
+        };
+        Ok(Self {
+            organization,
+            cancel_at_period_end,
+            backend: backend.try_into()?,
+        })
+    }
+}
+
+impl From<Update> for JsonUpdatePlan {
+    fn from(update: Update) -> Self {
+        let Update {
+            cancel_at_period_end,
+            ..
+        } = update;
+        Self {
+            cancel_at_period_end,
+        }
+    }
+}
+
+impl SubCmd for Update {
+    async fn exec(&self) -> Result<(), CliError> {
+        let _json = self
+            .backend
+            .send(|client| async move {
+                client
+                    .org_plan_patch()
+                    .organization(self.organization.clone())
+                    .body(self.clone())
+                    .send()
+                    .await
+            })
+            .await?;
+        Ok(())
+    }
+}

--- a/services/cli/src/parser/organization/plan.rs
+++ b/services/cli/src/parser/organization/plan.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "plus")]
 
 use bencher_json::{Entitlements, NonEmpty, OrganizationResourceId, OrganizationUuid};
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{ArgGroup, Parser, Subcommand, ValueEnum};
 
 use crate::parser::CliBackend;
 
@@ -13,6 +13,9 @@ pub enum CliOrganizationPlan {
     /// View a subscription plan
     #[clap(alias = "get")]
     View(CliPlanView),
+    /// Update a subscription plan
+    #[clap(alias = "edit")]
+    Update(CliPlanUpdate),
     /// Delete a subscription plan
     #[clap(alias = "rm")]
     Delete(CliPlanDelete),
@@ -57,6 +60,29 @@ pub struct CliPlanView {
 }
 
 #[derive(Parser, Debug)]
+#[clap(group(
+    ArgGroup::new("cancellation")
+        .multiple(false)
+        .required(true)
+        .args(&["cancel", "resume"]),
+))]
+pub struct CliPlanUpdate {
+    /// Organization slug or UUID
+    pub organization: OrganizationResourceId,
+
+    /// Schedule the metered subscription to cancel at the end of the current billing period
+    #[clap(long)]
+    pub cancel: bool,
+
+    /// Resume a metered subscription scheduled to cancel at the end of the current billing period
+    #[clap(long)]
+    pub resume: bool,
+
+    #[clap(flatten)]
+    pub backend: CliBackend,
+}
+
+#[derive(Parser, Debug)]
 pub struct CliPlanDelete {
     /// Organization slug or UUID
     pub organization: OrganizationResourceId,
@@ -74,6 +100,8 @@ pub struct CliPlanDelete {
 pub enum CliPlanLevel {
     /// Free
     Free,
+    /// Pro
+    Pro,
     /// Team
     Team,
     /// Enterprise

--- a/services/console/src/types/bencher.ts
+++ b/services/console/src/types/bencher.ts
@@ -538,6 +538,7 @@ export interface JsonCustomer {
 
 export enum PlanLevel {
 	Free = "free",
+	Pro = "pro",
 	Team = "team",
 	Enterprise = "enterprise",
 }
@@ -936,6 +937,11 @@ export interface JsonPlan {
 	current_period_start: string;
 	current_period_end: string;
 	status: PlanStatus;
+	/**
+	 * Whether the subscription is set to cancel at the end of the current period
+	 * (the org keeps access until `current_period_end`, then downgrades to Free).
+	 */
+	cancel_at_period_end: boolean;
 	license?: JsonLicense;
 }
 
@@ -1076,6 +1082,16 @@ export enum UpdateAlertStatus {
 export interface JsonUpdateAlert {
 	/** The new status of the alert. */
 	status?: UpdateAlertStatus;
+}
+
+export interface JsonUpdatePlan {
+	/**
+	 * Update the subscription's scheduled cancellation. Set to `false` to resume
+	 * a plan scheduled to cancel at period end, or `true` to schedule it to
+	 * cancel at the end of the current period. Only applies to metered
+	 * subscriptions, not licensed (Self-Hosted) plans.
+	 */
+	cancel_at_period_end: boolean;
 }
 
 export interface JsonUpdateProjectKey {


### PR DESCRIPTION
Splits the backend half of #903 so it can land and deploy to the API server ahead of the console go-live. (#903 bundled backend, generated artifacts, CLI, and the full console rework into one change.)

## What's here
- `PlanLevel::Pro` plus the Stripe billing-credit-grant logic (`ensure_period_credit`, `create_credit_grant`), the flat `$20/mo` base fee, and the first-month trial coupon.
- A daily Cloud-only credit sweep (`spawn_pro_credit_grants`) that idempotently grants each period's included credit and prunes lapsed plans, keeping the report-ingestion hot path free of billing-side Stripe calls.
- `PATCH /v0/organizations/{organization}/plan` to schedule or clear cancel-at-period-end (`JsonUpdatePlan`); `cancel_at_period_end` is now reported on `JsonPlan`.
- Public-project metrics are free/unmetered on metered plans; self-serve (metered) Enterprise checkout is rejected (contact-only).
- CLI `--level pro`; regenerated `openapi.json` and `bencher.ts`.

## Deployability
Pro is reachable via the REST API and CLI but is not surfaced anywhere in the console, so it stays inert for users until the frontend PR ships. Requires the Bencher Cloud billing config to include a `pro` product (id, metered `$0.01` price, `$20` base price, optional trial coupon). Self-hosted is unaffected (no billing config).

## Verification
`cargo clippy --no-deps --all-targets --all-features -- -Dwarnings`, `cargo check --no-default-features`, `cargo nextest run --all-features`, `cargo test --doc --all-features`, `cargo fmt --check`, `cargo deny check`, and `cargo gen-types` (no diff) all pass. Live Stripe-mode flow is not verified here (no test key in this environment).

Frontend go-live follows in a stacked PR. Supersedes the backend portion of #903.