### PR TITLE
Add Pro plan metered usage and split out a Bencher Metrics product

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,17 @@ Otherwise, you will see:
 use of undeclared type `Regex`
 ```
 
+Plus-only crates are gated behind `#![cfg(feature = "plus")]` (e.g. `bencher_billing`), and some
+modules in shared crates are too (e.g. `bencher_json`'s billing config, `bencher_valid`'s
+`plan_level`). Running their tests without the feature compiles an empty target and reports
+`0 tests run` (no error). Pass the `plus` feature (alongside `server` where `Regex` is needed):
+
+```bash
+cargo nextest run -p bencher_billing --features plus
+cargo nextest run -p bencher_json --features "server plus"
+cargo nextest run -p bencher_valid --features "server plus"
+```
+
 ## Formatting
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,17 +72,6 @@ Otherwise, you will see:
 use of undeclared type `Regex`
 ```
 
-Plus-only crates are gated behind `#![cfg(feature = "plus")]` (e.g. `bencher_billing`), and some
-modules in shared crates are too (e.g. `bencher_json`'s billing config, `bencher_valid`'s
-`plan_level`). Running their tests without the feature compiles an empty target and reports
-`0 tests run` (no error). Pass the `plus` feature (alongside `server` where `Regex` is needed):
-
-```bash
-cargo nextest run -p bencher_billing --features plus
-cargo nextest run -p bencher_json --features "server plus"
-cargo nextest run -p bencher_valid --features "server plus"
-```
-
 ## Formatting
 
 ```bash

--- a/lib/api_organizations/src/usage.rs
+++ b/lib/api_organizations/src/usage.rs
@@ -100,7 +100,7 @@ async fn get_inner(
         if let Some(json_plan) = query_plan.to_metered_plan(biller).await? {
             let start_time = json_plan.current_period_start;
             let end_time = json_plan.current_period_end;
-            let (metrics, runner_minutes) = query_metered_usage(
+            let (metrics, runner_minutes) = metered_plan_usage(
                 auth_conn!(context),
                 query_organization.id,
                 start_time,
@@ -193,23 +193,6 @@ fn query_usage(
     Ok((metrics, runner_minutes))
 }
 
-/// Estimate billable usage for a metered (Bencher Cloud) plan.
-///
-/// Only Private Project metrics are metered; Public Project metrics are free and
-/// unlimited (see `PlanKind::check_usage`). Bare metal runner minutes are metered
-/// regardless of visibility.
-fn query_metered_usage(
-    conn: &mut DbConnection,
-    organization_id: OrganizationId,
-    start_time: DateTime,
-    end_time: DateTime,
-) -> Result<(u32, u32), HttpError> {
-    let metrics = QueryMetric::private_usage(conn, organization_id, start_time, end_time)?;
-    let runner_minutes =
-        QueryJob::runner_minutes_usage(conn, organization_id, start_time, end_time)?;
-    Ok((metrics, runner_minutes))
-}
-
 fn free_plan_usage(
     conn: &mut DbConnection,
     query_organization: &QueryOrganization,
@@ -228,4 +211,21 @@ fn free_plan_usage(
         metrics: Some(metrics),
         runner_minutes: Some(runner_minutes),
     })
+}
+
+/// Estimate billable usage for a metered (Bencher Cloud) plan.
+///
+/// Only Private Project metrics are metered; Public Project metrics are free and
+/// unlimited (see `PlanKind::check_usage`). Bare metal runner minutes are metered
+/// regardless of visibility.
+fn metered_plan_usage(
+    conn: &mut DbConnection,
+    organization_id: OrganizationId,
+    start_time: DateTime,
+    end_time: DateTime,
+) -> Result<(u32, u32), HttpError> {
+    let metrics = QueryMetric::private_usage(conn, organization_id, start_time, end_time)?;
+    let runner_minutes =
+        QueryJob::runner_minutes_usage(conn, organization_id, start_time, end_time)?;
+    Ok((metrics, runner_minutes))
 }

--- a/lib/api_organizations/src/usage.rs
+++ b/lib/api_organizations/src/usage.rs
@@ -100,7 +100,7 @@ async fn get_inner(
         if let Some(json_plan) = query_plan.to_metered_plan(biller).await? {
             let start_time = json_plan.current_period_start;
             let end_time = json_plan.current_period_end;
-            let (metrics, runner_minutes) = query_usage(
+            let (metrics, runner_minutes) = query_metered_usage(
                 auth_conn!(context),
                 query_organization.id,
                 start_time,
@@ -188,6 +188,23 @@ fn query_usage(
     end_time: DateTime,
 ) -> Result<(u32, u32), HttpError> {
     let metrics = QueryMetric::usage(conn, organization_id, start_time, end_time)?;
+    let runner_minutes =
+        QueryJob::runner_minutes_usage(conn, organization_id, start_time, end_time)?;
+    Ok((metrics, runner_minutes))
+}
+
+/// Estimate billable usage for a metered (Bencher Cloud) plan.
+///
+/// Only Private Project metrics are metered; Public Project metrics are free and
+/// unlimited (see `PlanKind::check_usage`). Bare metal runner minutes are metered
+/// regardless of visibility.
+fn query_metered_usage(
+    conn: &mut DbConnection,
+    organization_id: OrganizationId,
+    start_time: DateTime,
+    end_time: DateTime,
+) -> Result<(u32, u32), HttpError> {
+    let metrics = QueryMetric::private_usage(conn, organization_id, start_time, end_time)?;
     let runner_minutes =
         QueryJob::runner_minutes_usage(conn, organization_id, start_time, end_time)?;
     Ok((metrics, runner_minutes))

--- a/lib/bencher_json/src/organization/plan.rs
+++ b/lib/bencher_json/src/organization/plan.rs
@@ -45,6 +45,9 @@ pub struct JsonPlan {
     pub card: JsonCardDetails,
     pub level: PlanLevel,
     pub unit_amount: BigInt,
+    /// When the metered subscription was created. The first (free-trial) billing
+    /// period is the one that contains this timestamp.
+    pub created: DateTime,
     pub current_period_start: DateTime,
     pub current_period_end: DateTime,
     pub status: PlanStatus,

--- a/lib/bencher_json/src/system/config/plus/cloud/billing.rs
+++ b/lib/bencher_json/src/system/config/plus/cloud/billing.rs
@@ -25,9 +25,6 @@ pub struct JsonProducts {
     // Legacy self-serve paid tier, retained for grandfathered customers.
     pub team: JsonProduct,
     pub enterprise: JsonProduct,
-    // Holds the Pro plan's metered metrics price. Kept as its own product so
-    // checkout shows a distinct "Bencher Metrics" line item instead of a second
-    // "Bencher Pro".
     pub metrics: JsonProduct,
     pub bare_metal: JsonProduct,
 }
@@ -82,7 +79,6 @@ mod tests {
             Some("price_b"),
         );
         assert_eq!(products.pro.trial_coupon.as_deref(), Some("coupon_x"));
-        // The Pro plan's metered metrics price now lives on the `metrics` product.
         assert!(products.pro.metered.is_empty());
         assert_eq!(
             products.metrics.metered.get("default").map(String::as_str),

--- a/lib/bencher_json/src/system/config/plus/cloud/billing.rs
+++ b/lib/bencher_json/src/system/config/plus/cloud/billing.rs
@@ -25,6 +25,10 @@ pub struct JsonProducts {
     // Legacy self-serve paid tier, retained for grandfathered customers.
     pub team: JsonProduct,
     pub enterprise: JsonProduct,
+    // Holds the Pro plan's metered metrics price. Kept as its own product so
+    // checkout shows a distinct "Bencher Metrics" line item instead of a second
+    // "Bencher Pro".
+    pub metrics: JsonProduct,
     pub bare_metal: JsonProduct,
 }
 
@@ -66,9 +70,10 @@ mod tests {
     #[test]
     fn products_with_pro_base_and_trial_coupon() {
         let json = r#"{
+            "pro": {"id":"p","base":{"default":"price_b"},"trial_coupon":"coupon_x"},
             "team": {"id":"t","metered":{},"licensed":{}},
-            "pro": {"id":"p","metered":{"default":"price_m"},"base":{"default":"price_b"},"trial_coupon":"coupon_x"},
             "enterprise": {"id":"e","metered":{},"licensed":{}},
+            "metrics": {"id":"m","metered":{"default":"price_mm"},"licensed":{"default":"price_ml"}},
             "bare_metal": {"id":"bm","metered":{},"licensed":{}}
         }"#;
         let products: JsonProducts = serde_json::from_str(json).unwrap();
@@ -77,6 +82,12 @@ mod tests {
             Some("price_b"),
         );
         assert_eq!(products.pro.trial_coupon.as_deref(), Some("coupon_x"));
+        // The Pro plan's metered metrics price now lives on the `metrics` product.
+        assert!(products.pro.metered.is_empty());
+        assert_eq!(
+            products.metrics.metered.get("default").map(String::as_str),
+            Some("price_mm"),
+        );
         assert!(products.team.base.is_empty());
         assert!(products.team.trial_coupon.is_none());
     }

--- a/lib/bencher_schema/src/model/project/metric.rs
+++ b/lib/bencher_schema/src/model/project/metric.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "plus")]
+use bencher_json::project::Visibility;
 use bencher_json::{JsonMetric, JsonNewMetric, MetricUuid};
 #[cfg(feature = "plus")]
 use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
@@ -71,6 +73,48 @@ impl QueryMetric {
             })
     }
 
+    /// Count the billable metric usage for an organization over a time window.
+    ///
+    /// Only Private Project Metrics are metered; Public Project Metrics are free
+    /// and unlimited. This mirrors the `visibility.is_public()` skip in
+    /// `PlanKind::check_usage`, so the figure matches what is actually billed.
+    #[cfg(feature = "plus")]
+    pub fn private_usage(
+        conn: &mut DbConnection,
+        organization_id: OrganizationId,
+        start_time: bencher_json::DateTime,
+        end_time: bencher_json::DateTime,
+    ) -> Result<u32, HttpError> {
+        schema::metric::table
+            .inner_join(
+                schema::report_benchmark::table
+                    .inner_join(schema::benchmark::table.inner_join(schema::project::table))
+                    .inner_join(schema::report::table),
+            )
+            .filter(schema::report::project_id.eq(schema::project::id))
+            .filter(schema::project::organization_id.eq(organization_id))
+            .filter(schema::project::visibility.eq(Visibility::Private))
+            .filter(schema::report::end_time.ge(start_time))
+            .filter(schema::report::end_time.le(end_time))
+            .count()
+            .get_result::<i64>(conn)
+            .map_err(|e| {
+                crate::error::issue_error(
+                    "Failed to count private metric usage",
+                    &format!("Failed to count private metric usage for organization ({organization_id}) between {start_time} and {end_time}."),
+                    e,
+                )
+            })?
+            .try_into()
+            .map_err(|e| {
+                crate::error::issue_error(
+                    "Failed to count private metric usage",
+                    &format!("Failed to count private metric usage for organization ({organization_id}) between {start_time} and {end_time}."),
+                    e,
+                )
+            })
+    }
+
     pub fn into_json(self) -> JsonMetric {
         let Self {
             uuid,
@@ -118,5 +162,117 @@ impl InsertMetric {
             lower_value: lower_value.map(Into::into),
             upper_value: upper_value.map(Into::into),
         }
+    }
+}
+
+// `private_usage` and `Visibility::Private` are `plus`-only, so this module
+// compiles with the `plus` feature (as the rest of the test target already does).
+#[cfg(test)]
+mod test {
+    use bencher_json::{DateTime, project::Visibility};
+    use diesel::{ExpressionMethods as _, RunQueryDsl as _};
+
+    use super::QueryMetric;
+    use crate::{
+        context::DbConnection,
+        macros::sql::last_insert_rowid,
+        model::{organization::OrganizationId, project::ProjectId},
+        schema,
+        test_util::{
+            create_base_entities, create_benchmark, create_branch_with_head, create_measure,
+            create_metric, create_report, create_report_benchmark, create_testbed, create_version,
+            setup_test_db,
+        },
+    };
+
+    fn create_private_project(
+        conn: &mut DbConnection,
+        organization_id: OrganizationId,
+    ) -> ProjectId {
+        diesel::insert_into(schema::project::table)
+            .values((
+                schema::project::uuid.eq("00000000-0000-0000-0000-000000000003"),
+                schema::project::organization_id.eq(organization_id),
+                schema::project::name.eq("Private Project"),
+                schema::project::slug.eq("private-project"),
+                schema::project::visibility.eq(Visibility::Private),
+                schema::project::created.eq(DateTime::TEST),
+                schema::project::modified.eq(DateTime::TEST),
+            ))
+            .execute(conn)
+            .expect("Failed to insert private project");
+        diesel::select(last_insert_rowid())
+            .get_result(conn)
+            .expect("Failed to get private project id")
+    }
+
+    // Seed one metric under `project_id`. `base` namespaces the entity UUIDs and
+    // slugs so multiple projects can be seeded into the same database.
+    fn seed_metric(conn: &mut DbConnection, project_id: ProjectId, base: u8) {
+        let uuid = |n: u8| format!("00000000-0000-0000-0000-0000000000{:02x}", base + n);
+        let branch = create_branch_with_head(
+            conn,
+            project_id,
+            &uuid(0),
+            "Main",
+            &format!("main-{base}"),
+            &uuid(1),
+        );
+        let version = create_version(conn, project_id, &uuid(2), 1, None);
+        let testbed = create_testbed(
+            conn,
+            project_id,
+            &uuid(3),
+            "Testbed",
+            &format!("testbed-{base}"),
+        );
+        let measure = create_measure(
+            conn,
+            project_id,
+            &uuid(4),
+            "Latency",
+            &format!("latency-{base}"),
+        );
+        let report = create_report(conn, &uuid(5), project_id, branch.head_id, version, testbed);
+        let benchmark = create_benchmark(
+            conn,
+            project_id,
+            &uuid(6),
+            "Bench",
+            &format!("bench-{base}"),
+        );
+        let report_benchmark = create_report_benchmark(conn, &uuid(7), report, 0, benchmark);
+        create_metric(conn, &uuid(8), report_benchmark, measure, 1.0);
+    }
+
+    #[test]
+    fn private_usage_counts_only_private_projects() {
+        let mut conn = setup_test_db();
+        // `create_base_entities` makes a Public project (visibility 0).
+        let base = create_base_entities(&mut conn);
+        seed_metric(&mut conn, base.project_id, 0x20);
+        let private_project = create_private_project(&mut conn, base.organization_id);
+        seed_metric(&mut conn, private_project, 0x40);
+
+        let all = QueryMetric::usage(
+            &mut conn,
+            base.organization_id,
+            DateTime::TEST,
+            DateTime::TEST,
+        )
+        .unwrap();
+        let private = QueryMetric::private_usage(
+            &mut conn,
+            base.organization_id,
+            DateTime::TEST,
+            DateTime::TEST,
+        )
+        .unwrap();
+
+        assert_eq!(all, 2, "usage counts Public and Private Project metrics");
+        assert_eq!(
+            private, 1,
+            "private_usage counts only Private Project metrics"
+        );
     }
 }

--- a/lib/bencher_schema/src/model/project/metric.rs
+++ b/lib/bencher_schema/src/model/project/metric.rs
@@ -44,33 +44,7 @@ impl QueryMetric {
         start_time: bencher_json::DateTime,
         end_time: bencher_json::DateTime,
     ) -> Result<u32, HttpError> {
-        schema::metric::table
-            .inner_join(
-                schema::report_benchmark::table
-                    .inner_join(schema::benchmark::table.inner_join(schema::project::table))
-                    .inner_join(schema::report::table),
-            )
-            .filter(schema::report::project_id.eq(schema::project::id))
-            .filter(schema::project::organization_id.eq(organization_id))
-            .filter(schema::report::end_time.ge(start_time))
-            .filter(schema::report::end_time.le(end_time))
-            .count()
-            .get_result::<i64>(conn)
-            .map_err(|e| {
-                crate::error::issue_error(
-                    "Failed to count metric usage",
-                    &format!("Failed to count metric usage for organization ({organization_id}) between {start_time} and {end_time}."),
-                    e,
-                )
-            })?
-            .try_into()
-            .map_err(|e| {
-                crate::error::issue_error(
-                    "Failed to count metric usage",
-                    &format!("Failed to count metric usage for organization ({organization_id}) between {start_time} and {end_time}."),
-                    e,
-                )
-            })
+        Self::usage_inner(conn, organization_id, start_time, end_time, None)
     }
 
     /// Count the billable metric usage for an organization over a time window.
@@ -85,7 +59,26 @@ impl QueryMetric {
         start_time: bencher_json::DateTime,
         end_time: bencher_json::DateTime,
     ) -> Result<u32, HttpError> {
-        schema::metric::table
+        Self::usage_inner(
+            conn,
+            organization_id,
+            start_time,
+            end_time,
+            Some(Visibility::Private),
+        )
+    }
+
+    /// Count metric usage for an organization over a time window, optionally
+    /// restricted to projects of a given `visibility`.
+    #[cfg(feature = "plus")]
+    fn usage_inner(
+        conn: &mut DbConnection,
+        organization_id: OrganizationId,
+        start_time: bencher_json::DateTime,
+        end_time: bencher_json::DateTime,
+        visibility: Option<Visibility>,
+    ) -> Result<u32, HttpError> {
+        let mut query = schema::metric::table
             .inner_join(
                 schema::report_benchmark::table
                     .inner_join(schema::benchmark::table.inner_join(schema::project::table))
@@ -93,23 +86,27 @@ impl QueryMetric {
             )
             .filter(schema::report::project_id.eq(schema::project::id))
             .filter(schema::project::organization_id.eq(organization_id))
-            .filter(schema::project::visibility.eq(Visibility::Private))
             .filter(schema::report::end_time.ge(start_time))
             .filter(schema::report::end_time.le(end_time))
-            .count()
+            .select(diesel::dsl::count_star())
+            .into_boxed();
+        if let Some(visibility) = visibility {
+            query = query.filter(schema::project::visibility.eq(visibility));
+        }
+        query
             .get_result::<i64>(conn)
             .map_err(|e| {
                 crate::error::issue_error(
-                    "Failed to count private metric usage",
-                    &format!("Failed to count private metric usage for organization ({organization_id}) between {start_time} and {end_time}."),
+                    "Failed to count metric usage",
+                    &format!("Failed to count metric usage (visibility: {visibility:?}) for organization ({organization_id}) between {start_time} and {end_time}."),
                     e,
                 )
             })?
             .try_into()
             .map_err(|e| {
                 crate::error::issue_error(
-                    "Failed to count private metric usage",
-                    &format!("Failed to count private metric usage for organization ({organization_id}) between {start_time} and {end_time}."),
+                    "Failed to count metric usage",
+                    &format!("Failed to count metric usage (visibility: {visibility:?}) for organization ({organization_id}) between {start_time} and {end_time}."),
                     e,
                 )
             })
@@ -168,7 +165,7 @@ impl InsertMetric {
 // `private_usage` and `Visibility::Private` are `plus`-only, so this module
 // compiles with the `plus` feature (as the rest of the test target already does).
 #[cfg(test)]
-mod test {
+mod tests {
     use bencher_json::{DateTime, project::Visibility};
     use diesel::{ExpressionMethods as _, RunQueryDsl as _};
 

--- a/lib/bencher_valid/src/plus/plan_level.rs
+++ b/lib/bencher_valid/src/plus/plan_level.rs
@@ -17,6 +17,9 @@ const ENTERPRISE: &str = "enterprise";
 const BENCHER_PRO: &str = "Bencher Pro";
 const BENCHER_TEAM: &str = "Bencher Team";
 const BENCHER_ENTERPRISE: &str = "Bencher Enterprise";
+// The Pro plan's metered metrics usage is billed via its own "Bencher Metrics"
+// product, so that product name also resolves to `PlanLevel::Pro`.
+const BENCHER_METRICS: &str = "Bencher Metrics";
 
 #[typeshare::typeshare]
 #[derive(
@@ -51,7 +54,7 @@ impl TryFrom<String> for PlanLevel {
     fn try_from(plan_level: String) -> Result<Self, Self::Error> {
         match plan_level.as_str() {
             FREE => Ok(Self::Free),
-            PRO | BENCHER_PRO => Ok(Self::Pro),
+            PRO | BENCHER_PRO | BENCHER_METRICS => Ok(Self::Pro),
             TEAM | BENCHER_TEAM => Ok(Self::Team),
             ENTERPRISE | BENCHER_ENTERPRISE => Ok(Self::Enterprise),
             _ => Err(ValidError::PlanLevel(plan_level)),
@@ -92,7 +95,13 @@ impl From<PlanLevel> for String {
 pub fn is_valid_plan_level(plan_level: &str) -> bool {
     matches!(
         plan_level,
-        FREE | PRO | TEAM | ENTERPRISE | BENCHER_PRO | BENCHER_TEAM | BENCHER_ENTERPRISE
+        FREE | PRO
+            | TEAM
+            | ENTERPRISE
+            | BENCHER_PRO
+            | BENCHER_TEAM
+            | BENCHER_ENTERPRISE
+            | BENCHER_METRICS
     )
 }
 
@@ -110,6 +119,7 @@ mod tests {
         assert_eq!(true, is_valid_plan_level("Bencher Pro"));
         assert_eq!(true, is_valid_plan_level("Bencher Team"));
         assert_eq!(true, is_valid_plan_level("Bencher Enterprise"));
+        assert_eq!(true, is_valid_plan_level("Bencher Metrics"));
 
         assert_eq!(false, is_valid_plan_level(""));
         assert_eq!(false, is_valid_plan_level("one"));
@@ -134,5 +144,30 @@ mod tests {
         assert_eq!(json, "\"pro\"");
 
         serde_json::from_str::<PlanLevel>("\"invalid\"").unwrap_err();
+    }
+
+    #[test]
+    fn plan_level_from_product_name() {
+        use super::PlanLevel;
+
+        assert_eq!(
+            PlanLevel::try_from("Bencher Pro".to_owned()).unwrap(),
+            PlanLevel::Pro,
+        );
+        // The Pro plan's metered metrics item lives on the "Bencher Metrics"
+        // product, which must resolve back to `PlanLevel::Pro`.
+        assert_eq!(
+            PlanLevel::try_from("Bencher Metrics".to_owned()).unwrap(),
+            PlanLevel::Pro,
+        );
+        assert_eq!(
+            PlanLevel::try_from("Bencher Team".to_owned()).unwrap(),
+            PlanLevel::Team,
+        );
+        assert_eq!(
+            PlanLevel::try_from("Bencher Enterprise".to_owned()).unwrap(),
+            PlanLevel::Enterprise,
+        );
+        PlanLevel::try_from("Bencher Bare Metal".to_owned()).unwrap_err();
     }
 }

--- a/plus/bencher_billing/src/biller.rs
+++ b/plus/bencher_billing/src/biller.rs
@@ -995,16 +995,16 @@ impl Biller {
         // The list-check above handles dedup across periods (beyond the key's TTL).
         let idempotency_key =
             IdempotencyKey::new(format!("bencher-credit:{customer_id}:{period_start}"))?;
-        CreateBillingCreditGrant::new(
-            amount,
-            CreateBillingCreditGrantApplicabilityConfig { scope },
-        )
-        .customer(customer_id.to_string())
         // Do not set `effective_at`. Stripe rejects a timestamp before its server
         // "now", and `period_start` is in the past for an already-active
         // subscription. Omitting it defaults to Stripe's "now" (also sidestepping
         // clock skew between us and Stripe). The credit still covers this period's
         // metered usage, which is invoiced at `expires_at` (period end).
+        CreateBillingCreditGrant::new(
+            amount,
+            CreateBillingCreditGrantApplicabilityConfig { scope },
+        )
+        .customer(customer_id.to_string())
         .expires_at(period_end)
         .metadata(metadata)
         .name(CREDIT_NAME)

--- a/plus/bencher_billing/src/biller.rs
+++ b/plus/bencher_billing/src/biller.rs
@@ -623,6 +623,10 @@ impl Biller {
                 )
             })?;
 
+        let created = subscription.created.try_into().map_err(|e| {
+            BillingError::DateTime(subscription_id.clone(), subscription.created, e)
+        })?;
+
         let customer = Self::get_plan_customer(&subscription.customer)?;
         let card = Self::get_plan_card(
             subscription_id,
@@ -638,6 +642,7 @@ impl Biller {
             card,
             level,
             unit_amount: unit_amount.into(),
+            created,
             current_period_start,
             current_period_end,
             status,

--- a/plus/bencher_billing/src/biller.rs
+++ b/plus/bencher_billing/src/biller.rs
@@ -114,8 +114,10 @@ impl fmt::Display for PriceName {
 enum PlusPlan {
     Free,
     // Bencher Cloud metered tier with a flat monthly base fee and an included
-    // usage credit. Carries the metered metrics price name; the base price is
-    // looked up separately. This tier has no licensed (Self-Hosted) form.
+    // usage credit. Carries the metered metrics price name, which resolves
+    // against the `metrics` product; the base price and trial coupon come from
+    // the `pro` product and are looked up separately. This tier has no licensed
+    // (Self-Hosted) form.
     Pro(PriceName),
     Team(PlusUsage),
     Enterprise(PlusUsage),
@@ -199,7 +201,7 @@ impl PlusPlan {
             PlusPlan::Free => return Err(BillingError::ProductLevelFree),
             PlusPlan::Pro(price_name) => (
                 products
-                    .pro
+                    .metrics
                     .metered
                     .get(price_name.as_str())
                     .ok_or_else(|| BillingError::PriceNotFound(price_name.to_string()))?,
@@ -736,7 +738,9 @@ impl Biller {
         let Some(product_info) = price.product.as_object() else {
             return Err(BillingError::NoProductInfo(price.product.id().clone()));
         };
-        // `Bencher Team` or `Bencher Enterprise`
+        // The metered plan item's product name maps to a `PlanLevel`:
+        // `Bencher Team`/`Bencher Enterprise`, or `Bencher Metrics` for the Pro
+        // plan (whose metered metrics item lives on the `metrics` product).
         let plan_level = product_info.name.parse()?;
 
         Ok((plan_level, unit_amount))
@@ -1173,9 +1177,7 @@ mod tests {
         JsonProducts {
             pro: JsonProduct {
                 id: "prod_UizgEJP4gIENBi".into(),
-                metered: hmap! {
-                    "default".to_owned() => "price_1TjXq8Kal5vzTlmhBD8plpc7".to_owned(),
-                },
+                metered: HashMap::new(),
                 licensed: HashMap::new(),
                 base: hmap! {
                     "default".to_owned() => "price_1TjXgeKal5vzTlmhZzr88bki".to_owned(),
@@ -1200,6 +1202,17 @@ mod tests {
                 },
                 licensed: hmap! {
                     "default".to_owned() => "price_1O4Xo1Kal5vzTlmh1KrcEbq0".to_owned(),
+                },
+                base: HashMap::new(),
+                trial_coupon: None,
+            },
+            metrics: JsonProduct {
+                id: "prod_UjlAPYSw7n3RDq".into(),
+                metered: hmap! {
+                    "default".to_owned() => "price_1TkHeSKal5vzTlmhijDCkWDe".to_owned(),
+                },
+                licensed: hmap! {
+                    "default".to_owned() => "price_1TkHeSKal5vzTlmhPKXPOW7c".to_owned(),
                 },
                 base: HashMap::new(),
                 trial_coupon: None,

--- a/plus/bencher_billing/src/biller.rs
+++ b/plus/bencher_billing/src/biller.rs
@@ -1000,7 +1000,11 @@ impl Biller {
             CreateBillingCreditGrantApplicabilityConfig { scope },
         )
         .customer(customer_id.to_string())
-        .effective_at(period_start)
+        // Do not set `effective_at`. Stripe rejects a timestamp before its server
+        // "now", and `period_start` is in the past for an already-active
+        // subscription. Omitting it defaults to Stripe's "now" (also sidestepping
+        // clock skew between us and Stripe). The credit still covers this period's
+        // metered usage, which is invoiced at `expires_at` (period end).
         .expires_at(period_end)
         .metadata(metadata)
         .name(CREDIT_NAME)
@@ -1117,7 +1121,7 @@ mod tests {
 
     use rustls::crypto::aws_lc_rs::default_provider;
 
-    use crate::Biller;
+    use crate::{Biller, PeriodCredit};
 
     use super::{METER_CUSTOMER_KEY, METER_VALUE_KEY, matched_base_cents, period_already_granted};
 
@@ -1231,6 +1235,50 @@ mod tests {
         }
     }
 
+    async fn setup_customer_payment_method(biller: &Biller) -> (CustomerId, PaymentMethodId) {
+        // Customer
+        let name = "Muriel Bagge".parse().unwrap();
+        let email = format!("muriel.bagge.{}@nowhere.com", rand::random::<u64>())
+            .parse()
+            .unwrap();
+        let json_customer = JsonCustomer {
+            uuid: UserUuid::new(),
+            name,
+            email,
+        };
+        assert!(
+            biller
+                .get_customer(&json_customer.email)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        let create_customer_id = biller.create_customer(&json_customer).await.unwrap();
+        let get_customer_id = biller
+            .get_customer(&json_customer.email)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(create_customer_id, get_customer_id);
+        let customer_id = create_customer_id;
+        let get_or_create_customer_id =
+            biller.get_or_create_customer(&json_customer).await.unwrap();
+        assert_eq!(customer_id, get_or_create_customer_id);
+
+        // Payment Method
+        let json_card = JsonCard {
+            number: "3530111333300000".parse().unwrap(),
+            exp_year: (Utc::now().year() + 1).try_into().unwrap(),
+            exp_month: 1.try_into().unwrap(),
+            cvc: "123".parse().unwrap(),
+        };
+        let payment_method_id = biller
+            .create_payment_method(customer_id.clone(), json_card.clone())
+            .await
+            .unwrap();
+        (customer_id, payment_method_id)
+    }
+
     #[expect(clippy::too_many_arguments, reason = "test helper")]
     async fn metered_subscription(
         biller: &Biller,
@@ -1258,13 +1306,30 @@ mod tests {
         assert_eq!(create_subscription.id, get_subscription.id);
 
         let metered_plan_id = &subscription_id.as_ref().parse().unwrap();
-        biller.get_metered_plan(metered_plan_id).await.unwrap();
+        let json_plan = biller.get_metered_plan(metered_plan_id).await.unwrap();
+        // The plan level is derived from the metered plan item's Stripe product
+        // name. For Pro that item lives on the `metrics` product, exercising the
+        // "Bencher Metrics" -> PlanLevel::Pro mapping.
+        assert_eq!(json_plan.level, plan_level);
 
         let (plan_status, customer_id) = biller
             .get_metered_plan_status(metered_plan_id)
             .await
             .unwrap();
         assert_eq!(plan_status, PlanStatus::Active);
+
+        // Only Pro carries a flat base fee, so only Pro grants an included-usage
+        // credit; the call is a no-op for Team/Enterprise. Granting twice must be
+        // idempotent (regression: a past `effective_at` was rejected by Stripe).
+        let first_credit = biller.ensure_period_credit(metered_plan_id).await.unwrap();
+        let second_credit = biller.ensure_period_credit(metered_plan_id).await.unwrap();
+        if plan_level == PlanLevel::Pro {
+            assert_eq!(first_credit, PeriodCredit::Granted);
+            assert_eq!(second_credit, PeriodCredit::AlreadyGranted);
+        } else {
+            assert_eq!(first_credit, PeriodCredit::NotApplicable);
+            assert_eq!(second_credit, PeriodCredit::NotApplicable);
+        }
 
         record_runner_usage(biller, &customer_id, runner_minutes).await;
         record_metrics_usage(biller, &customer_id, metrics_quantity).await;
@@ -1570,46 +1635,21 @@ mod tests {
         };
         let biller = Biller::new(json_billing).await.unwrap();
 
-        // Customer
-        let name = "Muriel Bagge".parse().unwrap();
-        let email = format!("muriel.bagge.{}@nowhere.com", rand::random::<u64>())
-            .parse()
-            .unwrap();
-        let json_customer = JsonCustomer {
-            uuid: UserUuid::new(),
-            name,
-            email,
-        };
-        assert!(
-            biller
-                .get_customer(&json_customer.email)
-                .await
-                .unwrap()
-                .is_none()
-        );
-        let create_customer_id = biller.create_customer(&json_customer).await.unwrap();
-        let get_customer_id = biller
-            .get_customer(&json_customer.email)
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(create_customer_id, get_customer_id);
-        let customer_id = create_customer_id;
-        let get_or_create_customer_id =
-            biller.get_or_create_customer(&json_customer).await.unwrap();
-        assert_eq!(customer_id, get_or_create_customer_id);
+        let (customer_id, payment_method_id) = setup_customer_payment_method(&biller).await;
 
-        // Payment Method
-        let json_card = JsonCard {
-            number: "3530111333300000".parse().unwrap(),
-            exp_year: (Utc::now().year() + 1).try_into().unwrap(),
-            exp_month: 1.try_into().unwrap(),
-            cvc: "123".parse().unwrap(),
-        };
-        let payment_method_id = biller
-            .create_payment_method(customer_id.clone(), json_card.clone())
-            .await
-            .unwrap();
+        // Pro Metered Plan
+        let organization = OrganizationUuid::new();
+        metered_subscription(
+            &biller,
+            organization,
+            customer_id.clone(),
+            payment_method_id.clone(),
+            PlanLevel::Pro,
+            DEFAULT_PRICE_NAME.into(),
+            3,
+            7,
+        )
+        .await;
 
         // Team Metered Plan
         let organization = OrganizationUuid::new();

--- a/plus/bencher_billing/src/products.rs
+++ b/plus/bencher_billing/src/products.rs
@@ -18,6 +18,9 @@ pub struct Products {
     // Legacy self-serve paid tier, retained for grandfathered customers.
     pub team: Product,
     pub enterprise: Product,
+    // Holds the Pro plan's metered metrics price (its own product so checkout
+    // shows a distinct "Bencher Metrics" line item).
+    pub metrics: Product,
     pub bare_metal: Product,
 }
 
@@ -27,6 +30,7 @@ impl Products {
             pro,
             team,
             enterprise,
+            metrics,
             bare_metal,
         } = products;
 
@@ -34,13 +38,16 @@ impl Products {
             pro: Product::new(client, pro).await?,
             team: Product::new(client, team).await?,
             enterprise: Product::new(client, enterprise).await?,
+            metrics: Product::new(client, metrics).await?,
             bare_metal: Product::new(client, bare_metal).await?,
         })
     }
 
-    // Returns the price IDs for the Pro, Team, and Enterprise plans only
-    // (excluding bare_metal), used by `get_plan` to filter subscription items to
-    // the main plan item.
+    // Returns the price IDs that identify a subscription's main plan item
+    // (excluding flat base fees and bare_metal), used by `get_plan` to filter
+    // subscription items down to that one item. These are the Team and Enterprise
+    // metered/licensed prices and the Pro plan's metered metrics price, which
+    // lives on the `metrics` product rather than the `pro` product.
     //
     // During the metered billing migration, a subscription may temporarily have
     // multiple subscription items (old metered + new metered). The config holds
@@ -52,7 +59,7 @@ impl Products {
     // Once the migration cutover is complete and the old subscription items are
     // removed, this filtering becomes a no-op (one item in, one item out).
     pub fn plan_price_ids(&self, preferred: &str) -> HashSet<&PriceId> {
-        self.pro
+        self.metrics
             .preferred_price_ids(preferred)
             .into_iter()
             .chain(self.team.preferred_price_ids(preferred))

--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -14913,6 +14913,14 @@
           "card": {
             "$ref": "#/components/schemas/JsonCardDetails"
           },
+          "created": {
+            "description": "When the metered subscription was created. The first (free-trial) billing period is the one that contains this timestamp.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTime"
+              }
+            ]
+          },
           "current_period_end": {
             "$ref": "#/components/schemas/DateTime"
           },
@@ -14946,6 +14954,7 @@
         "required": [
           "cancel_at_period_end",
           "card",
+          "created",
           "current_period_end",
           "current_period_start",
           "customer",

--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -15230,6 +15230,9 @@
           "enterprise": {
             "$ref": "#/components/schemas/JsonProduct"
           },
+          "metrics": {
+            "$ref": "#/components/schemas/JsonProduct"
+          },
           "pro": {
             "$ref": "#/components/schemas/JsonProduct"
           },
@@ -15240,6 +15243,7 @@
         "required": [
           "bare_metal",
           "enterprise",
+          "metrics",
           "pro",
           "team"
         ]

--- a/services/console/src/types/bencher.ts
+++ b/services/console/src/types/bencher.ts
@@ -934,6 +934,11 @@ export interface JsonPlan {
 	card: JsonCardDetails;
 	level: PlanLevel;
 	unit_amount: number;
+	/**
+	 * When the metered subscription was created. The first (free-trial) billing
+	 * period is the one that contains this timestamp.
+	 */
+	created: string;
 	current_period_start: string;
 	current_period_end: string;
 	status: PlanStatus;


### PR DESCRIPTION
## Summary

Two changes continuing the Pro plan backend (both included here):

### Add Pro plan metered usage and `JsonPlan.created`

Records metered metrics usage for the Pro plan and exposes a `created` timestamp on `JsonPlan`. Touches `api_organizations/usage.rs`, `bencher_json/organization/plan.rs`, `bencher_schema/model/project/metric.rs`, and the billing layer, with regenerated OpenAPI and TypeScript types.

### Split the metered metrics price into a `Bencher Metrics` product

A Pro checkout produced three line items, but two showed the product name "Bencher Pro" (the flat base fee and the metered metrics usage shared one Stripe product). This moves the metered metrics price onto a dedicated `metrics` product so checkout shows three distinct names: Bencher Pro (base fee), Bencher Metrics (metered usage), and Bencher Bare Metal (runner minutes).

- `JsonProducts` / `Products` gain a `metrics` product; the Pro plan's metered price and `plan_price_ids` resolve against it.
- `get_plan` derives a subscription's tier from the surviving plan item's Stripe product name, so `"Bencher Metrics"` now maps to `PlanLevel::Pro`, keeping GET plan working for Pro subscriptions.
- A `licensed` price is added to `metrics` for parity and future-proofing (unused by code today).
- OpenAPI regenerated; `bencher.ts` is unchanged (these config types are not typeshared).

Clean cutover: no existing live Pro subscribers to grandfather, so `pro` drops `metered` entirely.

## Operational note (before deploy)

The production billing config must add the `metrics` block with the live product/price IDs and bind the metered price to the existing "metrics" Stripe meter. The IDs in the test fixture are Stripe test-mode.

## Verification

`cargo build`, `clippy --all-features -Dwarnings`, `check --no-default-features`, `fmt` (no drift), and tests: bencher_billing 12, bencher_json 90, bencher_valid 196, doctests 0. `cargo gen-types` confirmed no `bencher.ts` change.
