### PR TITLE
Resolve plan tier by base-fee presence instead of the Stripe product name

### DIFF
--- a/lib/bencher_valid/src/plus/plan_level.rs
+++ b/lib/bencher_valid/src/plus/plan_level.rs
@@ -13,13 +13,6 @@ const FREE: &str = "free";
 const PRO: &str = "pro";
 const TEAM: &str = "team";
 const ENTERPRISE: &str = "enterprise";
-// These are the Stripe product names
-const BENCHER_PRO: &str = "Bencher Pro";
-const BENCHER_TEAM: &str = "Bencher Team";
-const BENCHER_ENTERPRISE: &str = "Bencher Enterprise";
-// The Pro plan's metered metrics usage is billed via its own "Bencher Metrics"
-// product, so that product name also resolves to `PlanLevel::Pro`.
-const BENCHER_METRICS: &str = "Bencher Metrics";
 
 #[typeshare::typeshare]
 #[derive(
@@ -54,9 +47,9 @@ impl TryFrom<String> for PlanLevel {
     fn try_from(plan_level: String) -> Result<Self, Self::Error> {
         match plan_level.as_str() {
             FREE => Ok(Self::Free),
-            PRO | BENCHER_PRO | BENCHER_METRICS => Ok(Self::Pro),
-            TEAM | BENCHER_TEAM => Ok(Self::Team),
-            ENTERPRISE | BENCHER_ENTERPRISE => Ok(Self::Enterprise),
+            PRO => Ok(Self::Pro),
+            TEAM => Ok(Self::Team),
+            ENTERPRISE => Ok(Self::Enterprise),
             _ => Err(ValidError::PlanLevel(plan_level)),
         }
     }
@@ -93,16 +86,7 @@ impl From<PlanLevel> for String {
     expect(dead_code, reason = "exported only for wasm and tests")
 )]
 pub fn is_valid_plan_level(plan_level: &str) -> bool {
-    matches!(
-        plan_level,
-        FREE | PRO
-            | TEAM
-            | ENTERPRISE
-            | BENCHER_PRO
-            | BENCHER_TEAM
-            | BENCHER_ENTERPRISE
-            | BENCHER_METRICS
-    )
+    matches!(plan_level, FREE | PRO | TEAM | ENTERPRISE)
 }
 
 #[cfg(test)]
@@ -116,10 +100,15 @@ mod tests {
         assert_eq!(true, is_valid_plan_level("pro"));
         assert_eq!(true, is_valid_plan_level("team"));
         assert_eq!(true, is_valid_plan_level("enterprise"));
-        assert_eq!(true, is_valid_plan_level("Bencher Pro"));
-        assert_eq!(true, is_valid_plan_level("Bencher Team"));
-        assert_eq!(true, is_valid_plan_level("Bencher Enterprise"));
-        assert_eq!(true, is_valid_plan_level("Bencher Metrics"));
+
+        // Stripe product names are no longer valid plan levels: the plan level is
+        // resolved authoritatively, not by parsing a product name. These guard
+        // against re-introducing that conflation.
+        assert_eq!(false, is_valid_plan_level("Bencher Pro"));
+        assert_eq!(false, is_valid_plan_level("Bencher Team"));
+        assert_eq!(false, is_valid_plan_level("Bencher Enterprise"));
+        assert_eq!(false, is_valid_plan_level("Bencher Metrics"));
+        assert_eq!(false, is_valid_plan_level("Bencher Bare Metal"));
 
         assert_eq!(false, is_valid_plan_level(""));
         assert_eq!(false, is_valid_plan_level("one"));
@@ -144,30 +133,5 @@ mod tests {
         assert_eq!(json, "\"pro\"");
 
         serde_json::from_str::<PlanLevel>("\"invalid\"").unwrap_err();
-    }
-
-    #[test]
-    fn plan_level_from_product_name() {
-        use super::PlanLevel;
-
-        assert_eq!(
-            PlanLevel::try_from("Bencher Pro".to_owned()).unwrap(),
-            PlanLevel::Pro,
-        );
-        // The Pro plan's metered metrics item lives on the "Bencher Metrics"
-        // product, which must resolve back to `PlanLevel::Pro`.
-        assert_eq!(
-            PlanLevel::try_from("Bencher Metrics".to_owned()).unwrap(),
-            PlanLevel::Pro,
-        );
-        assert_eq!(
-            PlanLevel::try_from("Bencher Team".to_owned()).unwrap(),
-            PlanLevel::Team,
-        );
-        assert_eq!(
-            PlanLevel::try_from("Bencher Enterprise".to_owned()).unwrap(),
-            PlanLevel::Enterprise,
-        );
-        PlanLevel::try_from("Bencher Bare Metal".to_owned()).unwrap_err();
     }
 }

--- a/plus/bencher_billing/src/biller.rs
+++ b/plus/bencher_billing/src/biller.rs
@@ -208,9 +208,12 @@ impl PlusPlan {
                 None,
             ),
             PlusPlan::Team(plus_usage) => match plus_usage {
+                // Metered metrics bill on the shared `metrics` ("Bencher Metrics")
+                // product across paid tiers; only the licensed price stays on the
+                // tier's own product.
                 PlusUsage::Metered(price_name) => (
                     products
-                        .team
+                        .metrics
                         .metered
                         .get(price_name.as_str())
                         .ok_or_else(|| BillingError::PriceNotFound(price_name.to_string()))?,
@@ -226,9 +229,10 @@ impl PlusPlan {
                 ),
             },
             PlusPlan::Enterprise(plus_usage) => match plus_usage {
+                // Metered metrics bill on the shared `metrics` product (see Team).
                 PlusUsage::Metered(price_name) => (
                     products
-                        .enterprise
+                        .metrics
                         .metered
                         .get(price_name.as_str())
                         .ok_or_else(|| BillingError::PriceNotFound(price_name.to_string()))?,
@@ -583,7 +587,6 @@ impl Biller {
                     "customer".into(),
                     "default_payment_method".into(),
                     "items".into(),
-                    "items.data.price.product".into(),
                 ],
             )
             .await?;
@@ -595,7 +598,22 @@ impl Biller {
             .parse()
             .map_err(|e| BillingError::BadOrganizationUuid(organization.clone(), e))?;
 
-        let plan_price_ids = self.products.plan_price_ids(METRICS_METER_NAME);
+        // Pro is the only paid tier with a flat base fee, so a Pro base-fee item
+        // identifies the plan level without relying on the metered product.
+        let pro_base_price_ids: HashSet<&PriceId> = self
+            .products
+            .pro
+            .base
+            .values()
+            .map(|price| &price.id)
+            .collect();
+        let has_base_fee = subscription
+            .items
+            .data
+            .iter()
+            .any(|item| pro_base_price_ids.contains(&item.price.id));
+
+        let plan_price_ids = self.products.plan_price_ids();
         let subscription_items = Self::filter_subscription_items(
             subscription_id,
             subscription.items.data,
@@ -634,7 +652,8 @@ impl Biller {
             subscription_id,
             subscription.default_payment_method.as_ref(),
         )?;
-        let (level, unit_amount) = Self::get_plan_price(&subscription_item)?;
+        let unit_amount = Self::get_plan_unit_amount(&subscription_item)?;
+        let level = plan_level_from_base_fee(has_base_fee);
 
         let status = Self::map_status(&subscription.status);
 
@@ -725,25 +744,12 @@ impl Biller {
         })
     }
 
-    fn get_plan_price(
-        subscription_item: &SubscriptionItem,
-    ) -> Result<(PlanLevel, u64), BillingError> {
+    fn get_plan_unit_amount(subscription_item: &SubscriptionItem) -> Result<u64, BillingError> {
         let price = &subscription_item.price;
-
         let Some(unit_amount) = price.unit_amount else {
             return Err(BillingError::NoUnitAmount(price.id.clone()));
         };
-        let unit_amount = u64::try_from(unit_amount)?;
-
-        let Some(product_info) = price.product.as_object() else {
-            return Err(BillingError::NoProductInfo(price.product.id().clone()));
-        };
-        // The metered plan item's product name maps to a `PlanLevel`:
-        // `Bencher Team`/`Bencher Enterprise`, or `Bencher Metrics` for the Pro
-        // plan (whose metered metrics item lives on the `metrics` product).
-        let plan_level = product_info.name.parse()?;
-
-        Ok((plan_level, unit_amount))
+        u64::try_from(unit_amount).map_err(Into::into)
     }
 
     fn get_subscription_item(
@@ -1064,6 +1070,18 @@ impl Biller {
     }
 }
 
+/// A paid subscription's plan level. Pro is the only paid tier that carries a flat
+/// base fee (see `PlusPlan::base_price`), so a subscription with a configured
+/// base-fee item is Pro; any other paid metered subscription is Team. This is
+/// independent of which Stripe product the metered-metrics item sits on.
+fn plan_level_from_base_fee(has_base_fee: bool) -> PlanLevel {
+    if has_base_fee {
+        PlanLevel::Pro
+    } else {
+        PlanLevel::Team
+    }
+}
+
 /// The included-credit amount (the matched flat base price's cents) for a
 /// subscription, given a map of configured base price ID to cents. `None` if the
 /// subscription carries no configured base fee. Gates the included-usage credit to
@@ -1123,7 +1141,10 @@ mod tests {
 
     use crate::{Biller, PeriodCredit};
 
-    use super::{METER_CUSTOMER_KEY, METER_VALUE_KEY, matched_base_cents, period_already_granted};
+    use super::{
+        METER_CUSTOMER_KEY, METER_VALUE_KEY, matched_base_cents, period_already_granted,
+        plan_level_from_base_fee,
+    };
 
     #[test]
     fn matched_base_cents_returns_base_fee() {
@@ -1169,6 +1190,29 @@ mod tests {
             std::iter::empty::<(Option<&str>, Option<&str>)>(),
             "100",
         ));
+    }
+
+    #[test]
+    fn plan_level_from_base_fee_resolves_tier() {
+        // Pro is the only paid tier with a base fee, so it resolves to Pro; any
+        // other paid metered subscription resolves to Team.
+        assert_eq!(plan_level_from_base_fee(true), PlanLevel::Pro);
+        assert_eq!(plan_level_from_base_fee(false), PlanLevel::Team);
+    }
+
+    #[test]
+    fn get_plan_unit_amount_reads_price() {
+        let mut item = make_subscription_item("price_metrics");
+        item.price.unit_amount = Some(1);
+        assert_eq!(Biller::get_plan_unit_amount(&item).unwrap(), 1);
+    }
+
+    #[test]
+    fn get_plan_unit_amount_missing_errors() {
+        // `make_subscription_item` builds a price with `unit_amount: None`.
+        let item = make_subscription_item("price_metrics");
+        let err = Biller::get_plan_unit_amount(&item).unwrap_err();
+        assert!(matches!(err, crate::BillingError::NoUnitAmount(_)));
     }
 
     const TEST_BILLING_KEY: &str = "TEST_BILLING_KEY";
@@ -1307,10 +1351,14 @@ mod tests {
 
         let metered_plan_id = &subscription_id.as_ref().parse().unwrap();
         let json_plan = biller.get_metered_plan(metered_plan_id).await.unwrap();
-        // The plan level is derived from the metered plan item's Stripe product
-        // name. For Pro that item lives on the `metrics` product, exercising the
-        // "Bencher Metrics" -> PlanLevel::Pro mapping.
-        assert_eq!(json_plan.level, plan_level);
+        // The plan level is derived from base-fee presence: Pro carries a flat base
+        // fee and resolves to Pro; tiers without a base fee resolve to Team.
+        let expected_level = if plan_level == PlanLevel::Pro {
+            PlanLevel::Pro
+        } else {
+            PlanLevel::Team
+        };
+        assert_eq!(json_plan.level, expected_level);
 
         let (plan_status, customer_id) = biller
             .get_metered_plan_status(metered_plan_id)

--- a/plus/bencher_billing/src/error.rs
+++ b/plus/bencher_billing/src/error.rs
@@ -2,7 +2,7 @@ use stripe_billing::{Subscription, SubscriptionId, SubscriptionItem};
 use stripe_checkout::CheckoutSession;
 use stripe_payment::PaymentMethodId;
 use stripe_product::PriceId;
-use stripe_shared::{Customer, CustomerId, ProductId};
+use stripe_shared::{Customer, CustomerId};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -59,6 +59,4 @@ pub enum BillingError {
     NoCardDetails(PaymentMethodId),
     #[error("No unit amount for {0}")]
     NoUnitAmount(PriceId),
-    #[error("No product info for {0}")]
-    NoProductInfo(ProductId),
 }

--- a/plus/bencher_billing/src/products.rs
+++ b/plus/bencher_billing/src/products.rs
@@ -1,9 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use bencher_json::{
-    organization::plan::DEFAULT_PRICE_NAME,
-    system::config::{JsonProduct, JsonProducts},
-};
+use bencher_json::system::config::{JsonProduct, JsonProducts};
 use stripe::Client as StripeClient;
 use stripe_product::{
     Price as StripePrice, PriceId, Product as StripeProduct, ProductId, price::RetrievePrice,
@@ -43,27 +40,17 @@ impl Products {
         })
     }
 
-    // Returns the price IDs that identify a subscription's main plan item
-    // (excluding flat base fees and bare_metal), used by `get_plan` to filter
-    // subscription items down to that one item. These are the Team and Enterprise
-    // metered/licensed prices and the Pro plan's metered metrics price, which
-    // lives on the `metrics` product rather than the `pro` product.
-    //
-    // During the metered billing migration, a subscription may temporarily have
-    // multiple subscription items (old metered + new metered). The config holds
-    // both price IDs under different keys: the currently-active price under
-    // "default" and the upcoming price under "metrics".
-    //
-    // This method returns only the price IDs for the given `preferred` key,
-    // falling back to "default" if the preferred key is not found.
-    // Once the migration cutover is complete and the old subscription items are
-    // removed, this filtering becomes a no-op (one item in, one item out).
-    pub fn plan_price_ids(&self, preferred: &str) -> HashSet<&PriceId> {
-        self.metrics
-            .preferred_price_ids(preferred)
+    // The price IDs that identify a subscription's plan item (excluding flat base
+    // fees and bare_metal), used by `get_plan` to filter subscription items down to
+    // that one item. These are the metered + licensed prices across the `metrics`
+    // (shared metered metrics), `team`, and `enterprise` products. The Team and
+    // Enterprise metered prices are retained so a subscription still on its own
+    // product (not yet moved to `metrics`) continues to resolve.
+    pub fn plan_price_ids(&self) -> HashSet<&PriceId> {
+        [&self.metrics, &self.team, &self.enterprise]
             .into_iter()
-            .chain(self.team.preferred_price_ids(preferred))
-            .chain(self.enterprise.preferred_price_ids(preferred))
+            .flat_map(|product| product.metered.values().chain(product.licensed.values()))
+            .map(|price| &price.id)
             .collect()
     }
 
@@ -90,9 +77,9 @@ pub struct Product {
     // Stripe coupon ID for this product's free trial (waives the first month's
     // base fee). `None` if the product has no trial.
     pub trial_coupon: Option<String>,
-    // Flat recurring base prices. Deliberately excluded from `preferred_price_ids`
-    // so it is never treated as the metered "plan item" when resolving a
-    // subscription's plan level.
+    // Flat recurring base prices. Excluded from `plan_price_ids` (never the metered
+    // "plan item"), but used by `get_plan` to detect the Pro base fee and so resolve
+    // the plan level.
     pub base: HashMap<String, StripePrice>,
     pub metered: HashMap<String, StripePrice>,
     pub licensed: HashMap<String, StripePrice>,
@@ -121,23 +108,6 @@ impl Product {
             metered,
             licensed,
         })
-    }
-
-    // Returns the price IDs for the given `preferred` key, falling back to
-    // "default" if the preferred key is not found.
-    // See `Products::plan_price_ids` for migration context.
-    fn preferred_price_ids(&self, preferred: &str) -> Vec<&PriceId> {
-        let metered_id = self
-            .metered
-            .get(preferred)
-            .or_else(|| self.metered.get(DEFAULT_PRICE_NAME))
-            .map(|p| &p.id);
-        let licensed_id = self
-            .licensed
-            .get(preferred)
-            .or_else(|| self.licensed.get(DEFAULT_PRICE_NAME))
-            .map(|p| &p.id);
-        metered_id.into_iter().chain(licensed_id).collect()
     }
 
     async fn pricing(


### PR DESCRIPTION
## Summary

Removes the PR #909 shim where the Stripe product name "Bencher Metrics" resolved to `PlanLevel::Pro`. That treated a Stripe product as a plan level, which blocks making "Bencher Metrics" the single metered-metrics product shared across paid plans.

`Biller::get_plan` now resolves the plan tier by **base-fee presence**: Pro is the only paid tier with a flat base fee, so a subscription carrying a configured base-fee item is Pro and any other paid metered subscription is Team. This is independent of which Stripe product the metered-metrics item sits on, so it stays correct whether a Team subscription remains on its own product or later moves to "Bencher Metrics".

## Changes

- `bencher_valid`: `PlanLevel` no longer accepts Stripe product-name strings (`Bencher Pro`/`Team`/`Enterprise`/`Metrics`); it reverts to the wire forms only, with rejection tests.
- `bencher_billing`:
  - `get_plan` resolves the tier from base-fee presence (`plan_level_from_base_fee`); `get_plan_price` is split into `get_plan_unit_amount`; the `items.data.price.product` expand is dropped.
  - Team/Enterprise metered checkouts route to the shared `metrics` product.
  - `Products::plan_price_ids` is now a pure identity set for locating the plan item (removes the `preferred`/`DEFAULT_PRICE_NAME` overlap machinery).
  - Removes the unused `NoProductInfo` error variant.

The resolved level is display-only; entitlement enforcement uses the plan kind and the license JWT claims. There are no live Pro subscribers, and Pro resolves via its base fee.

## Follow-up (separate PR)

Moving existing Team subscriptions onto the "Bencher Metrics" product is deferred. Because the `metrics` Stripe meter aggregates per customer, that migration will swap each subscription's metered price at its next renewal via a Subscription Schedule (an in-place mid-cycle swap would drop pre-swap usage, and two items on one meter would double-bill).

## Verification

- `cargo nextest run` for `bencher_billing` (15), `bencher_valid` (89), `bencher_json` (15)
- `cargo clippy --no-deps --all-targets --all-features -- -Dwarnings` clean
- `cargo fmt`, `cargo check --no-default-features`, `cargo test --doc`
- `cargo gen-types`: no change to `openapi.json` or `bencher.ts`
