### PR TITLE
Bill Team (metered) plans for public metrics

### DIFF
--- a/lib/api_organizations/src/usage.rs
+++ b/lib/api_organizations/src/usage.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use bencher_endpoint::{CorsResponse, Endpoint, Get, ResponseOk};
 use bencher_json::{
-    DateTime, OrganizationResourceId,
+    DateTime, OrganizationResourceId, PlanLevel,
     organization::usage::{JsonUsage, UsageKind},
 };
 use bencher_rbac::organization::Permission;
@@ -13,7 +13,10 @@ use bencher_schema::{
     context::{ApiContext, DbConnection},
     error::{forbidden_error, issue_error, payment_required_error, resource_not_found_err},
     model::{
-        organization::{OrganizationId, QueryOrganization, plan::QueryPlan},
+        organization::{
+            OrganizationId, QueryOrganization,
+            plan::{QueryPlan, metered_bills_public_metrics},
+        },
         project::metric::QueryMetric,
         runner::job::QueryJob,
         user::auth::{AuthUser, BearerToken},
@@ -103,6 +106,7 @@ async fn get_inner(
             let (metrics, runner_minutes) = metered_plan_usage(
                 auth_conn!(context),
                 query_organization.id,
+                json_plan.level,
                 start_time,
                 end_time,
             )?;
@@ -215,16 +219,25 @@ fn free_plan_usage(
 
 /// Estimate billable usage for a metered (Bencher Cloud) plan.
 ///
-/// Only Private Project metrics are metered; Public Project metrics are free and
-/// unlimited (see `PlanKind::check_usage`). Bare metal runner minutes are metered
-/// regardless of visibility.
+/// On Pro, only Private Project metrics are metered; Public Project metrics are free
+/// and unlimited. On legacy Team (and metered Enterprise) plans, both Public and
+/// Private Project metrics are metered. This mirrors `PlanKind::check_usage` so the
+/// estimate matches what is actually billed. Bare metal runner minutes are metered
+/// regardless of visibility and plan level.
 fn metered_plan_usage(
     conn: &mut DbConnection,
     organization_id: OrganizationId,
+    level: PlanLevel,
     start_time: DateTime,
     end_time: DateTime,
 ) -> Result<(u32, u32), HttpError> {
-    let metrics = QueryMetric::private_usage(conn, organization_id, start_time, end_time)?;
+    let metrics = if metered_bills_public_metrics(level) {
+        // Team (and metered Enterprise): public metrics are billed, so count all.
+        QueryMetric::usage(conn, organization_id, start_time, end_time)?
+    } else {
+        // Pro: public metrics are free, so count only private metrics.
+        QueryMetric::private_usage(conn, organization_id, start_time, end_time)?
+    };
     let runner_minutes =
         QueryJob::runner_minutes_usage(conn, organization_id, start_time, end_time)?;
     Ok((metrics, runner_minutes))

--- a/lib/bencher_schema/src/model/organization/plan.rs
+++ b/lib/bencher_schema/src/model/organization/plan.rs
@@ -455,11 +455,14 @@ impl PlanKind {
 /// Private Project Metrics are always billed regardless of level, so this only
 /// governs the public case.
 pub fn metered_bills_public_metrics(level: PlanLevel) -> bool {
-    // Free for Pro only; every other level is billed for public metrics.
-    if let PlanLevel::Pro = level {
-        return false;
+    // Public metrics are free on Free and Pro (Pro is the self-serve tier that
+    // includes them); only the legacy Team tier (and metered Enterprise, which the
+    // base-fee heuristic resolves to `Team`) is billed for public metrics.
+    // Matched exhaustively so a new `PlanLevel` variant forces a decision here.
+    match level {
+        PlanLevel::Free | PlanLevel::Pro => false,
+        PlanLevel::Team | PlanLevel::Enterprise => true,
     }
-    true
 }
 
 pub struct LicenseUsage {

--- a/lib/bencher_schema/src/model/organization/plan.rs
+++ b/lib/bencher_schema/src/model/organization/plan.rs
@@ -91,7 +91,7 @@ impl QueryPlan {
         biller: Option<&Biller>,
         api_actor: &ApiActor,
         query_organization: &QueryOrganization,
-    ) -> Result<Option<CustomerId>, HttpError> {
+    ) -> Result<Option<(CustomerId, PlanLevel)>, HttpError> {
         let Some(biller) = biller else {
             return Ok(None);
         };
@@ -106,7 +106,7 @@ impl QueryPlan {
             return Ok(None);
         };
 
-        let (plan_status, customer_id) = biller
+        let (plan_status, customer_id, level) = biller
             .get_metered_plan_status(&metered_plan_id)
             .await
             .map_err(not_found_error)?;
@@ -115,7 +115,7 @@ impl QueryPlan {
         // Free: return `None` so the caller falls through to the public/no-plan
         // logic instead of hard-erroring.
         if plan_status.is_active() {
-            Ok(Some(customer_id))
+            Ok(Some((customer_id, level)))
         } else {
             Ok(None)
         }
@@ -227,7 +227,7 @@ impl InsertPlan {
 }
 
 pub enum PlanKind {
-    Metered(CustomerId),
+    Metered(CustomerId, PlanLevel),
     Licensed(LicenseUsage),
     None,
 }
@@ -260,7 +260,7 @@ impl PlanKind {
         }
         match self {
             Self::None => Priority::Free,
-            Self::Metered(_) => Priority::Plus,
+            Self::Metered(_, _) => Priority::Plus,
             Self::Licensed(license_usage) => match license_usage.level {
                 PlanLevel::Free => Priority::Free,
                 PlanLevel::Pro | PlanLevel::Team | PlanLevel::Enterprise => Priority::Plus,
@@ -276,11 +276,11 @@ impl PlanKind {
         query_organization: &QueryOrganization,
         visibility: Visibility,
     ) -> Result<Self, HttpError> {
-        if let Some(customer_id) =
+        if let Some((customer_id, level)) =
             QueryPlan::get_active_metered_plan(context, biller, api_actor, query_organization)
                 .await?
         {
-            Ok(Self::Metered(customer_id))
+            Ok(Self::Metered(customer_id, level))
         } else if let Some(license_usage) = LicenseUsage::get(
             actor_conn!(context, api_actor),
             licensor,
@@ -396,7 +396,7 @@ impl PlanKind {
         usage: u32,
     ) -> Result<(), HttpError> {
         match self {
-            Self::Metered(customer_id) => {
+            Self::Metered(customer_id, level) => {
                 let Some(biller) = biller else {
                     return Err(issue_error(
                         "No Biller when checking usage",
@@ -404,10 +404,12 @@ impl PlanKind {
                         PlanKindError::NoBiller,
                     ));
                 };
-                // Public Project Metrics are free and unlimited; only Private
-                // Project Metrics are metered. Bare metal runner time is metered
-                // separately (regardless of visibility) via the runner channel.
-                if project.visibility.is_public() {
+                // Private Project Metrics are always metered. Public Project Metrics
+                // are free only on Pro; legacy Team (and metered Enterprise) plans
+                // are billed for public metrics too. Bare metal runner time is
+                // metered separately (regardless of visibility) via the runner
+                // channel.
+                if project.visibility.is_public() && !metered_bills_public_metrics(level) {
                     return Ok(());
                 }
                 if let Err(e) = biller.record_metrics_usage(&customer_id, usage).await {
@@ -443,6 +445,21 @@ impl PlanKind {
 
         Ok(())
     }
+}
+
+/// Whether a metered (Stripe) subscription is billed for *public* project metrics.
+///
+/// Public Project Metrics are free only on Pro (the new self-serve tier, the only
+/// paid tier with a flat base fee). Legacy Team (and metered Enterprise, which the
+/// base-fee heuristic resolves to `Team`) plans are billed for public metrics too.
+/// Private Project Metrics are always billed regardless of level, so this only
+/// governs the public case.
+pub fn metered_bills_public_metrics(level: PlanLevel) -> bool {
+    // Free for Pro only; every other level is billed for public metrics.
+    if let PlanLevel::Pro = level {
+        return false;
+    }
+    true
 }
 
 pub struct LicenseUsage {
@@ -505,5 +522,28 @@ impl LicenseUsage {
                 }
             })
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bencher_json::PlanLevel;
+
+    use super::metered_bills_public_metrics;
+
+    #[test]
+    fn pro_does_not_bill_public_metrics() {
+        // Pro is the only metered tier whose public metrics are free.
+        assert!(!metered_bills_public_metrics(PlanLevel::Pro));
+    }
+
+    #[test]
+    fn non_pro_bills_public_metrics() {
+        // Legacy Team and metered Enterprise are billed for public metrics. Free is
+        // included for completeness even though metered plans only resolve to
+        // Pro/Team via the base-fee heuristic.
+        assert!(metered_bills_public_metrics(PlanLevel::Team));
+        assert!(metered_bills_public_metrics(PlanLevel::Enterprise));
+        assert!(metered_bills_public_metrics(PlanLevel::Free));
     }
 }

--- a/lib/bencher_schema/src/model/organization/plan.rs
+++ b/lib/bencher_schema/src/model/organization/plan.rs
@@ -535,18 +535,18 @@ mod tests {
     use super::metered_bills_public_metrics;
 
     #[test]
-    fn pro_does_not_bill_public_metrics() {
+    fn does_not_bill_public_metrics() {
+        assert!(!metered_bills_public_metrics(PlanLevel::Free));
         // Pro is the only metered tier whose public metrics are free.
         assert!(!metered_bills_public_metrics(PlanLevel::Pro));
     }
 
     #[test]
-    fn non_pro_bills_public_metrics() {
+    fn bills_public_metrics() {
         // Legacy Team and metered Enterprise are billed for public metrics. Free is
         // included for completeness even though metered plans only resolve to
         // Pro/Team via the base-fee heuristic.
         assert!(metered_bills_public_metrics(PlanLevel::Team));
         assert!(metered_bills_public_metrics(PlanLevel::Enterprise));
-        assert!(metered_bills_public_metrics(PlanLevel::Free));
     }
 }

--- a/lib/bencher_schema/src/model/project/metric.rs
+++ b/lib/bencher_schema/src/model/project/metric.rs
@@ -47,11 +47,12 @@ impl QueryMetric {
         Self::usage_inner(conn, organization_id, start_time, end_time, None)
     }
 
-    /// Count the billable metric usage for an organization over a time window.
+    /// Count private-project metric usage for an organization over a time window.
     ///
-    /// Only Private Project Metrics are metered; Public Project Metrics are free
-    /// and unlimited. This mirrors the `visibility.is_public()` skip in
-    /// `PlanKind::check_usage`, so the figure matches what is actually billed.
+    /// This is the billable figure only for plan levels where Public Project Metrics
+    /// are free (see `metered_bills_public_metrics`); levels that bill public metrics
+    /// use `usage` (all visibilities) instead. The selection lives in the metered
+    /// usage estimate and mirrors the skip in `PlanKind::check_usage`.
     #[cfg(feature = "plus")]
     pub fn private_usage(
         conn: &mut DbConnection,

--- a/lib/bencher_schema/src/model/runner/job.rs
+++ b/lib/bencher_schema/src/model/runner/job.rs
@@ -469,7 +469,7 @@ fn resolve_timeout(requested: Option<Timeout>, plan_kind: &PlanKind, is_claimed:
     }
     match plan_kind {
         PlanKind::None => requested.map_or(Timeout::FREE_MAX, |t| t.clamp_max(Timeout::FREE_MAX)),
-        PlanKind::Metered(_) | PlanKind::Licensed(_) => requested.unwrap_or(Timeout::PLUS_DEFAULT),
+        PlanKind::Metered(..) | PlanKind::Licensed(_) => requested.unwrap_or(Timeout::PLUS_DEFAULT),
     }
 }
 
@@ -511,7 +511,7 @@ mod tests {
     };
 
     fn metered_plan() -> PlanKind {
-        PlanKind::Metered("cus_test".into())
+        PlanKind::Metered("cus_test".into(), PlanLevel::Pro)
     }
 
     fn licensed_plan(level: PlanLevel) -> PlanKind {

--- a/lib/bencher_schema/src/model/runner/job.rs
+++ b/lib/bencher_schema/src/model/runner/job.rs
@@ -469,7 +469,9 @@ fn resolve_timeout(requested: Option<Timeout>, plan_kind: &PlanKind, is_claimed:
     }
     match plan_kind {
         PlanKind::None => requested.map_or(Timeout::FREE_MAX, |t| t.clamp_max(Timeout::FREE_MAX)),
-        PlanKind::Metered(..) | PlanKind::Licensed(_) => requested.unwrap_or(Timeout::PLUS_DEFAULT),
+        PlanKind::Metered(_, _) | PlanKind::Licensed(_) => {
+            requested.unwrap_or(Timeout::PLUS_DEFAULT)
+        },
     }
 }
 

--- a/lib/bencher_schema/src/model/server/plus/credit.rs
+++ b/lib/bencher_schema/src/model/server/plus/credit.rs
@@ -94,7 +94,7 @@ pub fn spawn_credit_grants(log: Logger, db_path: PathBuf, busy_timeout: u32, bil
                 };
                 let plan_id = plan.id;
                 match biller.get_metered_plan_status(&metered_plan_id).await {
-                    Ok((status, _)) => match credit_sweep_action(status) {
+                    Ok((status, _, _)) => match credit_sweep_action(status) {
                         // Active (or trialing): ensure this period's included credit.
                         // Idempotent, and a no-op for metered plans without a base fee.
                         CreditSweepAction::EnsureCredit => {

--- a/plus/api_runners/src/channel.rs
+++ b/plus/api_runners/src/channel.rs
@@ -505,7 +505,7 @@ impl BillingState {
                         self.customer = CachedCustomer::None;
                         return Ok(None);
                     };
-                    let (status, customer_id) =
+                    let (status, customer_id, _level) =
                         biller.get_metered_plan_status(&metered_plan_id).await?;
                     if status.is_active() {
                         self.customer = CachedCustomer::Some(customer_id.clone());

--- a/plus/bencher_billing/src/biller.rs
+++ b/plus/bencher_billing/src/biller.rs
@@ -579,6 +579,26 @@ impl Biller {
         self.get_plan(&subscription_id).await
     }
 
+    /// Derive a paid subscription's plan level from its line items. Pro is the only
+    /// paid tier with a flat base fee, so a Pro base-fee item identifies the plan
+    /// level without relying on which Stripe product the metered item sits on.
+    /// Requires the subscription to have its `items` expanded.
+    fn subscription_plan_level(&self, subscription: &Subscription) -> PlanLevel {
+        let pro_base_price_ids: HashSet<&PriceId> = self
+            .products
+            .pro
+            .base
+            .values()
+            .map(|price| &price.id)
+            .collect();
+        let has_base_fee = subscription
+            .items
+            .data
+            .iter()
+            .any(|item| pro_base_price_ids.contains(&item.price.id));
+        plan_level_from_base_fee(has_base_fee)
+    }
+
     async fn get_plan(&self, subscription_id: &SubscriptionId) -> Result<JsonPlan, BillingError> {
         let subscription = self
             .get_subscription_expand(
@@ -598,20 +618,7 @@ impl Biller {
             .parse()
             .map_err(|e| BillingError::BadOrganizationUuid(organization.clone(), e))?;
 
-        // Pro is the only paid tier with a flat base fee, so a Pro base-fee item
-        // identifies the plan level without relying on the metered product.
-        let pro_base_price_ids: HashSet<&PriceId> = self
-            .products
-            .pro
-            .base
-            .values()
-            .map(|price| &price.id)
-            .collect();
-        let has_base_fee = subscription
-            .items
-            .data
-            .iter()
-            .any(|item| pro_base_price_ids.contains(&item.price.id));
+        let level = self.subscription_plan_level(&subscription);
 
         let plan_price_ids = self.products.plan_price_ids();
         let subscription_items = Self::filter_subscription_items(
@@ -653,7 +660,6 @@ impl Biller {
             subscription.default_payment_method.as_ref(),
         )?;
         let unit_amount = Self::get_plan_unit_amount(&subscription_item)?;
-        let level = plan_level_from_base_fee(has_base_fee);
 
         let status = Self::map_status(&subscription.status);
 
@@ -802,12 +808,17 @@ impl Biller {
     pub async fn get_metered_plan_status(
         &self,
         metered_plan_id: &MeteredPlanId,
-    ) -> Result<(PlanStatus, CustomerId), BillingError> {
+    ) -> Result<(PlanStatus, CustomerId, PlanLevel), BillingError> {
         let subscription_id: SubscriptionId = metered_plan_id.as_ref().into();
-        let subscription = self.get_subscription(&subscription_id).await?;
+        // Expand `items` so the plan level (Pro vs Team) can be derived from the
+        // subscription's line items via `subscription_plan_level`.
+        let subscription = self
+            .get_subscription_expand(&subscription_id, vec!["items".into()])
+            .await?;
         Ok((
             Self::map_status(&subscription.status),
             subscription.customer.id().clone(),
+            self.subscription_plan_level(&subscription),
         ))
     }
 
@@ -1323,7 +1334,11 @@ mod tests {
         (customer_id, payment_method_id)
     }
 
-    #[expect(clippy::too_many_arguments, reason = "test helper")]
+    #[expect(
+        clippy::too_many_arguments,
+        clippy::cognitive_complexity,
+        reason = "test helper exercising the full metered subscription lifecycle"
+    )]
     async fn metered_subscription(
         biller: &Biller,
         organization: OrganizationUuid,
@@ -1360,11 +1375,13 @@ mod tests {
         };
         assert_eq!(json_plan.level, expected_level);
 
-        let (plan_status, customer_id) = biller
+        let (plan_status, customer_id, status_level) = biller
             .get_metered_plan_status(metered_plan_id)
             .await
             .unwrap();
         assert_eq!(plan_status, PlanStatus::Active);
+        // The status path derives the same level as the full plan fetch.
+        assert_eq!(status_level, expected_level);
 
         // Only Pro carries a flat base fee, so only Pro grants an included-usage
         // credit; the call is a no-op for Team/Enterprise. Granting twice must be
@@ -1400,7 +1417,7 @@ mod tests {
             .cancel_metered_subscription(&subscription_id.parse().unwrap())
             .await
             .unwrap();
-        let (plan_status, _) = biller
+        let (plan_status, _, _) = biller
             .get_metered_plan_status(metered_plan_id)
             .await
             .unwrap();

--- a/plus/bencher_billing/src/biller.rs
+++ b/plus/bencher_billing/src/biller.rs
@@ -582,7 +582,6 @@ impl Biller {
     /// Derive a paid subscription's plan level from its line items. Pro is the only
     /// paid tier with a flat base fee, so a Pro base-fee item identifies the plan
     /// level without relying on which Stripe product the metered item sits on.
-    /// Requires the subscription to have its `items` expanded.
     fn subscription_plan_level(&self, subscription: &Subscription) -> PlanLevel {
         let pro_base_price_ids: HashSet<&PriceId> = self
             .products
@@ -603,11 +602,7 @@ impl Biller {
         let subscription = self
             .get_subscription_expand(
                 subscription_id,
-                vec![
-                    "customer".into(),
-                    "default_payment_method".into(),
-                    "items".into(),
-                ],
+                vec!["customer".into(), "default_payment_method".into()],
             )
             .await?;
 
@@ -810,11 +805,7 @@ impl Biller {
         metered_plan_id: &MeteredPlanId,
     ) -> Result<(PlanStatus, CustomerId, PlanLevel), BillingError> {
         let subscription_id: SubscriptionId = metered_plan_id.as_ref().into();
-        // Expand `items` so the plan level (Pro vs Team) can be derived from the
-        // subscription's line items via `subscription_plan_level`.
-        let subscription = self
-            .get_subscription_expand(&subscription_id, vec!["items".into()])
-            .await?;
+        let subscription = self.get_subscription(&subscription_id).await?;
         Ok((
             Self::map_status(&subscription.status),
             subscription.customer.id().clone(),

--- a/services/console/src/components/console/billing/BillingPanel.tsx
+++ b/services/console/src/components/console/billing/BillingPanel.tsx
@@ -425,15 +425,11 @@ const CloudMeteredPanel = (props: {
 				<h4>Estimated Credit Remaining: {fmtUsd(creditRemaining())}</h4>
 				<br />
 			</Show>
-			<h4>Cost per Private Metric: {fmtUsd(metricPrice())}</h4>
+			<h4>Cost per Metric: {fmtUsd(metricPrice())}</h4>
 			<h4>
-				Estimated Private Metrics Used:{" "}
-				{props.usage()?.metrics?.toLocaleString() ?? 0}
+				Estimated Metrics Used: {props.usage()?.metrics?.toLocaleString() ?? 0}
 			</h4>
-			<h4>Estimated Private Metrics Cost: {fmtUsd(estMetricsCost())}</h4>
-			<p class="has-text-grey">
-				Public project metrics are free and not billed.
-			</p>
+			<h4>Estimated Metrics Cost: {fmtUsd(estMetricsCost())}</h4>
 			<br />
 			<h4>Cost per Runner Minute: {fmtUsdPrecise(minutePrice())} / min</h4>
 			<h4>


### PR DESCRIPTION
Public Project Metrics were free for every metered plan. Free public
metrics are a Pro benefit (the new self-serve tier), so legacy Team (and
metered Enterprise) subscriptions should still be billed for public
metrics.

Thread the plan level through the metered hot path: get_metered_plan_status
now expands the subscription items and derives the level via the shared
subscription_plan_level helper, and PlanKind::Metered carries the PlanLevel.
PlanKind::check_usage skips public-metric billing only for Pro, and the
usage estimate endpoint mirrors the same rule via metered_bills_public_metrics.