### PR TITLE
Speed up API Docker build with cargo-chef and sccache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,15 @@ on:
       litestream-version:
         type: string
         required: true
+      cargo-chef-version:
+        type: string
+        required: true
+      sccache-version:
+        type: string
+        required: true
+      is-fork:
+        type: boolean
+        required: true
       build-action:
         type: boolean
         required: true
@@ -21,6 +30,11 @@ on:
       deploy-only:
         type: boolean
         required: true
+    secrets:
+      R2_ACCESS_KEY_ID:
+        required: false
+      R2_SECRET_ACCESS_KEY:
+        required: false
     outputs:
       wasm-artifact-name:
         description: "WASM artifact name"
@@ -143,6 +157,10 @@ jobs:
   build_api_docker:
     name: Build API Docker
     runs-on: ubuntu-22.04
+    # `Cloudflare` environment provides the sccache cache vars (SCCACHE_BUCKET/ENDPOINT).
+    # The S3 credentials arrive as repo secrets via `secrets:` below; reusable workflows
+    # receive environment variables but NOT environment secrets.
+    environment: Cloudflare
     if: ${{ inputs.build-docker }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -156,9 +174,31 @@ jobs:
           registry: ${{ env.GITHUB_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set cache name
-        id: cache-name
-        run: echo "value=${GITHUB_REF_NAME//\//-}" >> $GITHUB_OUTPUT
+      # Trusted builds (not a fork PR) use the shared registry cache + sccache; fork builds
+      # get neither (cold but correct) so untrusted code can never poison the shared cache.
+      - name: Set cache config
+        id: cache
+        env:
+          IS_FORK: ${{ inputs.is-fork }}
+          IMAGE_REF: ${{ env.GITHUB_REGISTRY }}/${{ github.repository_owner }}/${{ env.API_DOCKER_IMAGE }}
+        run: |
+          if [ "${IS_FORK}" = "true" ]; then
+            {
+              echo "wrapper="
+              echo "cache_from="
+              echo "cache_to="
+            } >> "$GITHUB_OUTPUT"
+          else
+            CACHE_NAME="${GITHUB_REF_NAME//\//-}"
+            {
+              echo "wrapper=sccache"
+              echo "cache_from<<EOF"
+              echo "type=registry,ref=${IMAGE_REF}:cache-${CACHE_NAME}-amd64"
+              echo "type=registry,ref=${IMAGE_REF}:cache-devel-amd64"
+              echo "EOF"
+              echo "cache_to=type=registry,ref=${IMAGE_REF}:cache-${CACHE_NAME}-amd64,mode=max"
+            } >> "$GITHUB_OUTPUT"
+          fi
       - name: Build & Push API Docker Image (amd64)
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
@@ -169,8 +209,14 @@ jobs:
           build-args: |
             MOLD_VERSION=${{ inputs.mold-version }}
             LITESTREAM_VERSION=${{ inputs.litestream-version }}
-          cache-from: |
-            type=registry,ref=${{ env.GITHUB_REGISTRY }}/${{ github.repository_owner }}/${{ env.API_DOCKER_IMAGE }}:cache-${{ steps.cache-name.outputs.value }}-amd64
-            type=registry,ref=${{ env.GITHUB_REGISTRY }}/${{ github.repository_owner }}/${{ env.API_DOCKER_IMAGE }}:cache-devel-amd64
-          cache-to: type=registry,ref=${{ env.GITHUB_REGISTRY }}/${{ github.repository_owner }}/${{ env.API_DOCKER_IMAGE }}:cache-${{ steps.cache-name.outputs.value }}-amd64,mode=max
-          push: true
+            CARGO_CHEF_VERSION=${{ inputs.cargo-chef-version }}
+            SCCACHE_VERSION=${{ inputs.sccache-version }}
+            SCCACHE_BUCKET=${{ vars.SCCACHE_BUCKET }}
+            SCCACHE_ENDPOINT=${{ vars.SCCACHE_ENDPOINT }}
+            RUSTC_WRAPPER=${{ steps.cache.outputs.wrapper }}
+          cache-from: ${{ steps.cache.outputs.cache_from }}
+          cache-to: ${{ steps.cache.outputs.cache_to }}
+          secrets: |
+            s3_access_key_id=${{ secrets.R2_ACCESS_KEY_ID }}
+            s3_secret_access_key=${{ secrets.R2_SECRET_ACCESS_KEY }}
+          push: ${{ !inputs.is-fork }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,9 +156,15 @@ jobs:
       mold-version: "2.34.1"
       wasm-pack-version: "0.12.1"
       litestream-version: "0.5.10"
+      cargo-chef-version: "0.1.77"
+      sccache-version: "0.16.0"
+      is-fork: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
       build-action: ${{ needs.changes.outputs.action == 'true' || github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/cloud' || startsWith(github.ref, 'refs/tags/') }}
       build-docker: ${{ !startsWith(github.ref, 'refs/tags/') && (needs.changes.outputs.docker == 'true' || github.ref == 'refs/heads/devel' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy'))) }}
       deploy-only: ${{ github.ref == 'refs/heads/cloud' }}
+    secrets:
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
 
   docker:
     name: Docker
@@ -170,6 +176,12 @@ jobs:
     with:
       mold-version: "2.34.1"
       litestream-version: "0.5.10"
+      cargo-chef-version: "0.1.77"
+      sccache-version: "0.16.0"
+      is-fork: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+    secrets:
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
 
   nix:
     name: Nix

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,20 @@ on:
       litestream-version:
         type: string
         required: true
+      cargo-chef-version:
+        type: string
+        required: true
+      sccache-version:
+        type: string
+        required: true
+      is-fork:
+        type: boolean
+        required: true
+    secrets:
+      R2_ACCESS_KEY_ID:
+        required: false
+      R2_SECRET_ACCESS_KEY:
+        required: false
 
 env:
   GITHUB_REGISTRY: ghcr.io
@@ -19,6 +33,10 @@ env:
 jobs:
   build_api_docker:
     name: Build API Docker (${{ matrix.suffix }})
+    # `Cloudflare` environment provides the sccache cache vars (SCCACHE_BUCKET/ENDPOINT).
+    # The S3 credentials arrive as repo secrets via `secrets:` below; reusable workflows
+    # receive environment variables but NOT environment secrets.
+    environment: Cloudflare
     strategy:
       fail-fast: false
       matrix:
@@ -42,9 +60,32 @@ jobs:
           registry: ${{ env.GITHUB_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set cache name
-        id: cache-name
-        run: echo "value=${GITHUB_REF_NAME//\//-}" >> $GITHUB_OUTPUT
+      # Trusted builds (not a fork PR) use the shared registry cache + sccache; fork builds
+      # get neither (cold but correct) so untrusted code can never poison the shared cache.
+      - name: Set cache config
+        id: cache
+        env:
+          IS_FORK: ${{ inputs.is-fork }}
+          IMAGE_REF: ${{ env.GITHUB_REGISTRY }}/${{ github.repository_owner }}/${{ env.API_DOCKER_IMAGE }}
+          SUFFIX: ${{ matrix.suffix }}
+        run: |
+          if [ "${IS_FORK}" = "true" ]; then
+            {
+              echo "wrapper="
+              echo "cache_from="
+              echo "cache_to="
+            } >> "$GITHUB_OUTPUT"
+          else
+            CACHE_NAME="${GITHUB_REF_NAME//\//-}"
+            {
+              echo "wrapper=sccache"
+              echo "cache_from<<EOF"
+              echo "type=registry,ref=${IMAGE_REF}:cache-${CACHE_NAME}-${SUFFIX}"
+              echo "type=registry,ref=${IMAGE_REF}:cache-devel-${SUFFIX}"
+              echo "EOF"
+              echo "cache_to=type=registry,ref=${IMAGE_REF}:cache-${CACHE_NAME}-${SUFFIX},mode=max"
+            } >> "$GITHUB_OUTPUT"
+          fi
       - name: Build & Push API Docker Image (${{ matrix.suffix }})
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
@@ -55,15 +96,23 @@ jobs:
           build-args: |
             MOLD_VERSION=${{ inputs.mold-version }}
             LITESTREAM_VERSION=${{ inputs.litestream-version }}
-          cache-from: |
-            type=registry,ref=${{ env.GITHUB_REGISTRY }}/${{ github.repository_owner }}/${{ env.API_DOCKER_IMAGE }}:cache-${{ steps.cache-name.outputs.value }}-${{ matrix.suffix }}
-            type=registry,ref=${{ env.GITHUB_REGISTRY }}/${{ github.repository_owner }}/${{ env.API_DOCKER_IMAGE }}:cache-devel-${{ matrix.suffix }}
-          cache-to: type=registry,ref=${{ env.GITHUB_REGISTRY }}/${{ github.repository_owner }}/${{ env.API_DOCKER_IMAGE }}:cache-${{ steps.cache-name.outputs.value }}-${{ matrix.suffix }},mode=max
-          push: true
+            CARGO_CHEF_VERSION=${{ inputs.cargo-chef-version }}
+            SCCACHE_VERSION=${{ inputs.sccache-version }}
+            SCCACHE_BUCKET=${{ vars.SCCACHE_BUCKET }}
+            SCCACHE_ENDPOINT=${{ vars.SCCACHE_ENDPOINT }}
+            RUSTC_WRAPPER=${{ steps.cache.outputs.wrapper }}
+          cache-from: ${{ steps.cache.outputs.cache_from }}
+          cache-to: ${{ steps.cache.outputs.cache_to }}
+          secrets: |
+            s3_access_key_id=${{ secrets.R2_ACCESS_KEY_ID }}
+            s3_secret_access_key=${{ secrets.R2_SECRET_ACCESS_KEY }}
+          push: ${{ !inputs.is-fork }}
 
   create_api_docker_manifest:
     name: Create API Docker Manifest
     needs: build_api_docker
+    # Fork builds do not push per-arch images, so there is nothing to assemble.
+    if: ${{ !inputs.is-fork }}
     runs-on: ubuntu-22.04
     steps:
       - name: Setup Docker buildx
@@ -106,9 +155,30 @@ jobs:
           registry: ${{ env.GITHUB_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set cache name
-        id: cache-name
-        run: echo "value=${GITHUB_REF_NAME//\//-}" >> $GITHUB_OUTPUT
+      # Trusted builds (not a fork PR) use the shared registry cache; fork builds get neither
+      # (a read-only token cannot export cache or push), so they build cold and push nothing.
+      - name: Set cache config
+        id: cache
+        env:
+          IS_FORK: ${{ inputs.is-fork }}
+          IMAGE_REF: ${{ env.GITHUB_REGISTRY }}/${{ github.repository_owner }}/${{ env.CONSOLE_DOCKER_IMAGE }}
+          SUFFIX: ${{ matrix.suffix }}
+        run: |
+          if [ "${IS_FORK}" = "true" ]; then
+            {
+              echo "cache_from="
+              echo "cache_to="
+            } >> "$GITHUB_OUTPUT"
+          else
+            CACHE_NAME="${GITHUB_REF_NAME//\//-}"
+            {
+              echo "cache_from<<EOF"
+              echo "type=registry,ref=${IMAGE_REF}:cache-${CACHE_NAME}-${SUFFIX}"
+              echo "type=registry,ref=${IMAGE_REF}:cache-devel-${SUFFIX}"
+              echo "EOF"
+              echo "cache_to=type=registry,ref=${IMAGE_REF}:cache-${CACHE_NAME}-${SUFFIX},mode=max"
+            } >> "$GITHUB_OUTPUT"
+          fi
       - name: Build & Push Console Docker Image (${{ matrix.suffix }})
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
@@ -116,15 +186,15 @@ jobs:
           file: ./services/console/Dockerfile
           platforms: ${{ matrix.platform }}
           tags: ${{ env.GITHUB_REGISTRY }}/${{ github.repository_owner }}/${{ env.CONSOLE_DOCKER_IMAGE }}:${{ github.sha }}-${{ matrix.suffix }}
-          cache-from: |
-            type=registry,ref=${{ env.GITHUB_REGISTRY }}/${{ github.repository_owner }}/${{ env.CONSOLE_DOCKER_IMAGE }}:cache-${{ steps.cache-name.outputs.value }}-${{ matrix.suffix }}
-            type=registry,ref=${{ env.GITHUB_REGISTRY }}/${{ github.repository_owner }}/${{ env.CONSOLE_DOCKER_IMAGE }}:cache-devel-${{ matrix.suffix }}
-          cache-to: type=registry,ref=${{ env.GITHUB_REGISTRY }}/${{ github.repository_owner }}/${{ env.CONSOLE_DOCKER_IMAGE }}:cache-${{ steps.cache-name.outputs.value }}-${{ matrix.suffix }},mode=max
-          push: true
+          cache-from: ${{ steps.cache.outputs.cache_from }}
+          cache-to: ${{ steps.cache.outputs.cache_to }}
+          push: ${{ !inputs.is-fork }}
 
   create_console_docker_manifest:
     name: Create Console Docker Manifest
     needs: build_console_docker
+    # Fork builds do not push per-arch images, so there is nothing to assemble.
+    if: ${{ !inputs.is-fork }}
     runs-on: ubuntu-22.04
     steps:
       - name: Setup Docker buildx
@@ -167,9 +237,30 @@ jobs:
           registry: ${{ env.GITHUB_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set cache name
-        id: cache-name
-        run: echo "value=${GITHUB_REF_NAME//\//-}" >> $GITHUB_OUTPUT
+      # Trusted builds (not a fork PR) use the shared registry cache; fork builds get neither
+      # (a read-only token cannot export cache or push), so they build cold and push nothing.
+      - name: Set cache config
+        id: cache
+        env:
+          IS_FORK: ${{ inputs.is-fork }}
+          IMAGE_REF: ${{ env.GITHUB_REGISTRY }}/${{ github.repository_owner }}/${{ env.CLI_DOCKER_IMAGE }}
+          SUFFIX: ${{ matrix.suffix }}
+        run: |
+          if [ "${IS_FORK}" = "true" ]; then
+            {
+              echo "cache_from="
+              echo "cache_to="
+            } >> "$GITHUB_OUTPUT"
+          else
+            CACHE_NAME="${GITHUB_REF_NAME//\//-}"
+            {
+              echo "cache_from<<EOF"
+              echo "type=registry,ref=${IMAGE_REF}:cache-${CACHE_NAME}-${SUFFIX}"
+              echo "type=registry,ref=${IMAGE_REF}:cache-devel-${SUFFIX}"
+              echo "EOF"
+              echo "cache_to=type=registry,ref=${IMAGE_REF}:cache-${CACHE_NAME}-${SUFFIX},mode=max"
+            } >> "$GITHUB_OUTPUT"
+          fi
       - name: Build & Push CLI Docker Image (${{ matrix.suffix }})
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
@@ -179,15 +270,15 @@ jobs:
           tags: ${{ env.GITHUB_REGISTRY }}/${{ github.repository_owner }}/${{ env.CLI_DOCKER_IMAGE }}:${{ github.sha }}-${{ matrix.suffix }}
           build-args: |
             MOLD_VERSION=${{ inputs.mold-version }}
-          cache-from: |
-            type=registry,ref=${{ env.GITHUB_REGISTRY }}/${{ github.repository_owner }}/${{ env.CLI_DOCKER_IMAGE }}:cache-${{ steps.cache-name.outputs.value }}-${{ matrix.suffix }}
-            type=registry,ref=${{ env.GITHUB_REGISTRY }}/${{ github.repository_owner }}/${{ env.CLI_DOCKER_IMAGE }}:cache-devel-${{ matrix.suffix }}
-          cache-to: type=registry,ref=${{ env.GITHUB_REGISTRY }}/${{ github.repository_owner }}/${{ env.CLI_DOCKER_IMAGE }}:cache-${{ steps.cache-name.outputs.value }}-${{ matrix.suffix }},mode=max
-          push: true
+          cache-from: ${{ steps.cache.outputs.cache_from }}
+          cache-to: ${{ steps.cache.outputs.cache_to }}
+          push: ${{ !inputs.is-fork }}
 
   create_cli_docker_manifest:
     name: Create CLI Docker Manifest
     needs: build_cli_docker
+    # Fork builds do not push per-arch images, so there is nothing to assemble.
+    if: ${{ !inputs.is-fork }}
     runs-on: ubuntu-22.04
     steps:
       - name: Setup Docker buildx

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       args:
         MOLD_VERSION: 2.34.1
         LITESTREAM_VERSION: 0.5.10
+        CARGO_CHEF_VERSION: 0.1.77
+        SCCACHE_VERSION: 0.16.0
     image: bencher-api
     container_name: bencher_api
     ports:

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -1,5 +1,8 @@
+# syntax=docker/dockerfile:1
 # https://hub.docker.com/_/rust
-FROM rust:1.95.0-bookworm@sha256:503651ea31e66ecb74623beabde781059a5978df1595a9e8ed03974d5fec1bf0 AS builder
+FROM rust:1.95.0-bookworm@sha256:503651ea31e66ecb74623beabde781059a5978df1595a9e8ed03974d5fec1bf0 AS base
+
+FROM base AS chef
 
 RUN apt-get update \
     && apt-get install -y \
@@ -7,9 +10,31 @@ RUN apt-get update \
     clang \
     # Plot
     pkg-config libfreetype6-dev libfontconfig1-dev \
-    # Stipe
+    # Stripe
     ca-certificates
 
+WORKDIR /tmp/mold
+ARG MOLD_VERSION
+RUN curl -L --retry 10 --silent --show-error https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-$(uname -m)-linux.tar.gz | tar -C /usr/local --strip-components=1 -xzf -
+RUN "$(realpath /usr/bin/ld)" != /usr/local/bin/mold && sudo ln -sf /usr/local/bin/mold "$(realpath /usr/bin/ld)"; true
+
+# cargo-chef caches the dependency build as its own layer; sccache caches each crate's
+# compilation in S3-compatible object storage so only changed first-party crates are rebuilt.
+ARG CARGO_CHEF_VERSION
+ARG SCCACHE_VERSION
+RUN cargo install cargo-chef --locked --version ${CARGO_CHEF_VERSION} \
+    && cargo install sccache --locked --version ${SCCACHE_VERSION}
+
+WORKDIR /usr/src/bencher
+
+# Compute the dependency recipe from the workspace manifests + lockfile.
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# Litestream is a runtime-only binary; keep it in its own stage so its version is decoupled
+# from the build layers (a Litestream bump never invalidates the dependency cache).
+FROM base AS litestream
 WORKDIR /tmp/litestream
 ARG LITESTREAM_VERSION
 ARG TARGETARCH
@@ -18,89 +43,46 @@ RUN LITESTREAM_ARCH=$(case "${TARGETARCH}" in amd64) echo "x86_64" ;; arm64) ech
     wget "https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/${LITESTREAM_BIN}.tar.gz" && \
     tar -xzf "${LITESTREAM_BIN}.tar.gz"
 
-WORKDIR /tmp/mold
-ARG MOLD_VERSION
-RUN curl -L --retry 10 --silent --show-error https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-$(uname -m)-linux.tar.gz | tar -C /usr/local --strip-components=1 -xzf -
-RUN "$(realpath /usr/bin/ld)" != /usr/local/bin/mold && sudo ln -sf /usr/local/bin/mold "$(realpath /usr/bin/ld)"; true
+FROM chef AS builder
+# "sccache" for trusted builds; empty for untrusted (fork) builds, which disables sccache
+# entirely so the absent S3 credentials are never needed (a cold but correct build).
+ARG RUSTC_WRAPPER=""
+ENV RUSTC_WRAPPER=${RUSTC_WRAPPER}
+ENV CARGO_INCREMENTAL=0
+# sccache S3-compatible object storage backend.
+ARG SCCACHE_BUCKET
+ARG SCCACHE_ENDPOINT
+ENV SCCACHE_BUCKET=${SCCACHE_BUCKET}
+ENV SCCACHE_ENDPOINT=${SCCACHE_ENDPOINT}
+ENV SCCACHE_REGION=auto
 
+# `.cargo/config.toml` (mold linker + v0 symbol mangling) must be identical during `cook`
+# and the final build, or cargo treats the cooked artifacts as stale and rebuilds them.
 WORKDIR /usr/src/bencher/.cargo
 COPY .cargo/config.toml config.toml
-
-WORKDIR /usr/src/bencher/lib
-RUN cargo init --lib bencher_api_tests
-RUN cargo init --lib bencher_client
-RUN cargo init --lib bencher_comment
-RUN cargo init --lib bencher_parser
-COPY lib/api_auth api_auth
-COPY lib/api_checkout api_checkout
-COPY lib/api_organizations api_organizations
-COPY lib/api_projects api_projects
-COPY lib/api_run api_run
-COPY lib/api_server api_server
-COPY lib/api_users api_users
-COPY lib/bencher_adapter bencher_adapter
-COPY lib/bencher_boundary bencher_boundary
-COPY lib/bencher_config bencher_config
-COPY lib/bencher_context bencher_context
-COPY lib/bencher_endpoint bencher_endpoint
-COPY lib/bencher_json bencher_json
-COPY lib/bencher_logger bencher_logger
-COPY lib/bencher_noise bencher_noise
-COPY lib/bencher_plot bencher_plot
-COPY lib/bencher_rank bencher_rank
-COPY lib/bencher_rbac bencher_rbac
-COPY lib/bencher_schema bencher_schema
-COPY lib/bencher_token bencher_token
-COPY lib/bencher_valid bencher_valid
-
-WORKDIR /usr/src/bencher/plus
-RUN cargo init --lib bencher_init
-RUN cargo init --lib bencher_oci
-RUN cargo init --lib bencher_output_protocol
-RUN cargo init --lib bencher_rootfs
-RUN cargo init --lib bencher_runner
-COPY plus/api_oci api_oci
-COPY plus/api_runners api_runners
-COPY plus/api_specs api_specs
-COPY plus/bencher_billing bencher_billing
-COPY plus/bencher_bing_index bencher_bing_index
-COPY plus/bencher_github_client bencher_github_client
-COPY plus/bencher_google_client bencher_google_client
-COPY plus/bencher_google_index bencher_google_index
-COPY plus/bencher_license bencher_license
-COPY plus/bencher_oci_storage bencher_oci_storage
-COPY plus/bencher_otel bencher_otel
-COPY plus/bencher_otel_provider bencher_otel_provider
-COPY plus/bencher_rate_limiter bencher_rate_limiter
-COPY plus/bencher_recaptcha bencher_recaptcha
-
-WORKDIR /usr/src/bencher/tasks
-RUN cargo init --bin bin_version
-RUN cargo init --bin gen_installer
-RUN cargo init --bin gen_pkg
-RUN cargo init --bin gen_notes
-RUN cargo init --bin gen_types
-RUN cargo init --bin test_api
-RUN cargo init --bin test_netlify
-RUN cargo init --bin test_runner
-RUN cargo init --bin runner_ops
-RUN cargo init --bin update_sandbox
-
 WORKDIR /usr/src/bencher
-COPY Cargo.toml Cargo.toml
-COPY Cargo.lock Cargo.lock
-RUN cargo init xtask
 
-WORKDIR /usr/src/bencher/services
-RUN cargo init cli
-RUN cargo init runner
+# Cook only the `api` binary's dependency graph. This layer is keyed on `recipe.json`
+# (derived from `Cargo.lock` + the manifests), so it is reused whenever dependencies are
+# unchanged. The S3 credential mounts are `required=false`: absent for untrusted builds,
+# where `RUSTC_WRAPPER` is empty so sccache (and thus object storage) is never invoked.
+COPY --from=planner /usr/src/bencher/recipe.json recipe.json
+RUN --mount=type=secret,id=s3_access_key_id,required=false \
+    --mount=type=secret,id=s3_secret_access_key,required=false \
+    AWS_ACCESS_KEY_ID="$(cat /run/secrets/s3_access_key_id 2>/dev/null || true)" \
+    AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/s3_secret_access_key 2>/dev/null || true)" \
+    cargo chef cook --release --bin api --recipe-path recipe.json \
+    && (sccache --show-stats || true)
 
-WORKDIR /usr/src/bencher/services/api
-COPY services/api/src src
-COPY services/api/Cargo.toml Cargo.toml
-COPY services/api/openapi.json openapi.json
-
-RUN cargo build --release
+# Build the first-party code. Dependencies are already compiled above; sccache restores any
+# unchanged first-party crates so only what actually changed is recompiled.
+COPY . .
+RUN --mount=type=secret,id=s3_access_key_id,required=false \
+    --mount=type=secret,id=s3_secret_access_key,required=false \
+    AWS_ACCESS_KEY_ID="$(cat /run/secrets/s3_access_key_id 2>/dev/null || true)" \
+    AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/s3_secret_access_key 2>/dev/null || true)" \
+    cargo build --release --bin api \
+    && (sccache --show-stats || true)
 
 WORKDIR /usr/local/bencher-deps
 RUN cp /usr/lib/$(uname -m)-linux-gnu/libexpat.so.1 libexpat.so.1
@@ -117,7 +99,7 @@ WORKDIR /var/lib/bencher/data
 
 # https://github.com/GoogleContainerTools/distroless/blob/main/cc/README.md
 FROM gcr.io/distroless/cc-debian12@sha256:0c8eac8ea42a167255d03c3ba6dfad2989c15427ed93d16c53ef9706ea4691df
-COPY --from=builder /tmp/litestream/litestream /usr/bin/litestream
+COPY --from=litestream /tmp/litestream/litestream /usr/bin/litestream
 
 COPY --from=builder /etc/fonts /etc/fonts
 COPY --from=builder /usr/include/fontconfig /usr/include/fontconfig

--- a/services/api/Dockerfile.dockerignore
+++ b/services/api/Dockerfile.dockerignore
@@ -1,14 +1,19 @@
 # Ignore all
 *
 
-# Except
+# Except the Rust workspace: every member's manifest + source must be present so that
+# `cargo chef prepare` can resolve the full workspace.
 !.cargo/
 !Cargo.toml
 !Cargo.lock
 !lib/
 !plus/
-!services/api/migrations/
-!services/api/src/
-!services/api/Cargo.toml
-!services/api/diesel.toml
-!services/api/openapi.json
+!services/api/
+!services/cli/
+!services/runner/
+!tasks/
+!xtask/
+
+# Re-exclude build artifacts and the local database (never needed to build the API).
+services/api/data/
+**/target/


### PR DESCRIPTION
## Problem

The API server Docker build took ~15 minutes on nearly every run. Root cause (from a recent build log): the entire Rust workspace compiled in a single monolithic `RUN cargo build --release` layer whose registry cache rarely restored. A console-only PR with zero Rust changes still triggered a full `12m49s` recompile of the whole dependency graph.

## Changes

- **cargo-chef**: restructure `services/api/Dockerfile` into `base` -> `planner` -> `builder` stages. Third-party dependencies cook in a layer keyed only on `recipe.json` (`Cargo.lock` + manifests), so they are reused whenever dependencies are unchanged.
- **sccache** (S3-compatible object storage backend): caches each crate's compilation, so a change to a single first-party crate only recompiles that crate and its dependents instead of the whole first-party graph (which Docker's `COPY` mtime reset otherwise forces).
- **Supply-chain gate**: the shared cache is restricted to trusted builds. Fork PRs run with `RUSTC_WRAPPER` empty (sccache off) and no registry `cache-from`/`cache-to` via the `is-fork` input, so untrusted code can never write or poison the cache. The S3 credentials live in a GitHub environment that withholds secrets from fork PRs.
- Scope cook and the real build to the `api` binary (`cargo build --bin api`), which also dodges the two `build.rs` crates that are not API dependencies.
- Decouple Litestream into its own stage so a Litestream bump never invalidates the dependency cache.
- Expand `services/api/Dockerfile.dockerignore` so `cargo chef prepare` can resolve every workspace member.
- Thread `cargo-chef-version` / `sccache-version` through `ci.yml`, `build.yml`, `docker.yml`, and add the matching build args to `docker-compose.yml`.

## Expected impact

- A change to a single backend crate: ~13 min -> ~2-4 min (deps layer cached, sccache rebuilds only the touched crate).
- A `Cargo.lock` bump: deps re-cook, but sccache restores most unchanged crates from the backend.

## Testing

- Local cold build of `services/api/Dockerfile` succeeded end to end: `cargo chef prepare`, `cargo chef cook --release --bin api` (4m05s), `cargo build --release --bin api` (3m18s), distroless assembly (292 MB image).
- The cold / fork path (no credentials, `RUSTC_WRAPPER` empty, `required=false` secret mounts) builds correctly.
- sccache to object storage caching and multi-arch are exercised by CI on the first run (cold, then warm).
