### PR TITLE
Persist rate limiting snapshot across graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,6 +1636,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "url",
  "uuid",
 ]

--- a/lib/bencher_api_tests/src/context.rs
+++ b/lib/bencher_api_tests/src/context.rs
@@ -147,6 +147,7 @@ impl TestServer {
             heartbeat_timeout: std::time::Duration::from_secs(5),
             job_timeout_grace_period: std::time::Duration::from_mins(1),
             heartbeat_tasks: bencher_schema::context::HeartbeatTasks::new(),
+            shutdown: bencher_schema::context::CancellationToken::new(),
         };
 
         Self::start_server(context, &log, token_key, db_path, db_file)

--- a/lib/bencher_config/src/config_tx.rs
+++ b/lib/bencher_config/src/config_tx.rs
@@ -368,6 +368,8 @@ async fn into_context(
         job_timeout_grace_period,
         #[cfg(feature = "plus")]
         heartbeat_tasks: bencher_schema::context::HeartbeatTasks::new(),
+        #[cfg(feature = "plus")]
+        shutdown: bencher_schema::context::CancellationToken::new(),
     })
 }
 

--- a/lib/bencher_schema/Cargo.toml
+++ b/lib/bencher_schema/Cargo.toml
@@ -19,6 +19,7 @@ plus = [
     "dep:reqwest",
     "dep:serde",
     "dep:serde_json",
+    "dep:tokio-util",
     "bencher_adapter/plus",
     "bencher_billing/plus",
     "bencher_json/plus",
@@ -73,6 +74,7 @@ slog.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs", "rt-multi-thread", "time"] }
 tokio-rustls.workspace = true
+tokio-util = { workspace = true, optional = true }
 url.workspace = true
 uuid = { workspace = true, features = ["v4", "serde"] }
 

--- a/lib/bencher_schema/src/context/mod.rs
+++ b/lib/bencher_schema/src/context/mod.rs
@@ -45,6 +45,8 @@ pub use rate_limiting::{HeaderMap, RateLimiting, RateLimitingError};
 pub use rbac::{Rbac, RbacError};
 #[cfg(feature = "plus")]
 pub use stats::StatsSettings;
+#[cfg(feature = "plus")]
+pub use tokio_util::sync::CancellationToken;
 
 pub struct ApiContext {
     pub console_url: Url,
@@ -82,6 +84,10 @@ pub struct ApiContext {
     pub job_timeout_grace_period: std::time::Duration,
     #[cfg(feature = "plus")]
     pub heartbeat_tasks: HeartbeatTasks,
+    /// Cancellation signal tripped on graceful shutdown so long-lived handlers (the runner WebSocket
+    /// channel) can wind down and let `server.close()` complete.
+    #[cfg(feature = "plus")]
+    pub shutdown: CancellationToken,
 }
 
 #[macro_export]

--- a/lib/bencher_schema/src/context/rate_limiting/mod.rs
+++ b/lib/bencher_schema/src/context/rate_limiting/mod.rs
@@ -1,4 +1,4 @@
-use std::{net::IpAddr, path::Path, time::Duration};
+use std::{io::Write as _, net::IpAddr, path::Path, time::Duration};
 
 use camino::{Utf8Path, Utf8PathBuf};
 
@@ -385,11 +385,28 @@ impl RateLimiting {
         let snapshot_path = Self::snapshot_path(db_path)?;
         let partial_path = snapshot_path.with_extension("json.partial");
         let json = serde_json::to_string(&snapshot).map_err(RateLimitingPersistError::Serialize)?;
-        std::fs::write(&partial_path, json)
+        // Write to a temp file and fsync it before the atomic rename, so a saved snapshot is durable
+        // across an abrupt VM stop rather than lingering in the page cache.
+        let mut file = std::fs::File::create(&partial_path)
             .map_err(|e| RateLimitingPersistError::Write(e, partial_path.clone()))?;
+        file.write_all(json.as_bytes())
+            .map_err(|e| RateLimitingPersistError::Write(e, partial_path.clone()))?;
+        file.sync_all()
+            .map_err(|e| RateLimitingPersistError::Write(e, partial_path.clone()))?;
+        drop(file);
         std::fs::rename(&partial_path, &snapshot_path).map_err(|e| {
             RateLimitingPersistError::Rename(e, partial_path, snapshot_path.clone())
         })?;
+        // Best-effort fsync of the parent directory so the rename itself is durable. The data file is
+        // already fsynced and the rename is atomic, so a directory-sync failure must not fail the save.
+        if let Some(parent) = snapshot_path.parent()
+            && let Err(e) = std::fs::File::open(parent).and_then(|dir| dir.sync_all())
+        {
+            slog::debug!(
+                log,
+                "Non-fatal: failed to fsync snapshot directory {parent}: {e}"
+            );
+        }
         slog::info!(log, "Saved rate limiting snapshot to {snapshot_path}");
         Ok(())
     }
@@ -401,8 +418,21 @@ impl RateLimiting {
         }
         let json = std::fs::read_to_string(&snapshot_path)
             .map_err(|e| RateLimitingPersistError::Read(e, snapshot_path.clone()))?;
-        let snapshot: RateLimitingSnapshot =
-            serde_json::from_str(&json).map_err(RateLimitingPersistError::Deserialize)?;
+        let snapshot: RateLimitingSnapshot = match serde_json::from_str(&json) {
+            Ok(snapshot) => snapshot,
+            Err(e) => {
+                // Log the full raw content so an incompatible/old on-disk format can be diagnosed
+                // from the logs (the file is left in place for the next save to overwrite).
+                slog::error!(
+                    log,
+                    "Failed to deserialize rate limiting snapshot from {snapshot_path} ({} bytes)",
+                    json.len();
+                    "error" => %e,
+                    "content" => json.as_str(),
+                );
+                return Err(RateLimitingPersistError::Deserialize(e));
+            },
+        };
         let RateLimitingSnapshot {
             public,
             user,

--- a/lib/bencher_schema/src/context/rate_limiting/snapshot.rs
+++ b/lib/bencher_schema/src/context/rate_limiting/snapshot.rs
@@ -299,4 +299,31 @@ mod tests {
             .expect("org_uuid present");
         assert_eq!(entries.len(), 1);
     }
+
+    #[test]
+    fn load_legacy_format_errs() {
+        use crate::context::RateLimiting;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("bencher.db");
+        let snapshot_path = dir.path().join("rate_limiting.json");
+
+        // Regression for the production failure: a snapshot written by the pre-bucketing format stored
+        // raw second timestamps in a flat array, but the current code expects `Vec<(EpochBucket, u32)>`
+        // (arrays of `[bucket, count]`). Deserializing `[1778809249, 1]` as a list of tuples yields:
+        // "invalid type: integer `1778809249`, expected a tuple of size 2".
+        let legacy = r#"{"public":{"requests":{"minute":{"events":{"1.2.3.4":[1778809249,1]}}}}}"#;
+        std::fs::write(&snapshot_path, legacy).unwrap();
+
+        let log = slog::Logger::root(slog::Discard, slog::o!());
+        let limiter = RateLimiting::default();
+        let err = limiter.load(&db_path, &log).unwrap_err();
+
+        assert!(matches!(
+            err,
+            super::super::RateLimitingPersistError::Deserialize(_)
+        ));
+        // The bad file is left in place; the next successful save overwrites it.
+        assert!(snapshot_path.exists());
+    }
 }

--- a/plus/api_runners/src/channel.rs
+++ b/plus/api_runners/src/channel.rs
@@ -14,7 +14,7 @@ use bencher_json::{
 use bencher_oci_storage::OciStorageError;
 use bencher_schema::{
     auth_conn,
-    context::ApiContext,
+    context::{ApiContext, CancellationToken},
     error::{resource_conflict_err, resource_not_found_err},
     model::{
         organization::OrganizationId,
@@ -997,6 +997,34 @@ enum ExecuteResult {
     JobDone,
     /// Runner disconnected or heartbeat timed out.
     Disconnected,
+    /// The server is shutting down; close the channel so `server.close()` can complete.
+    ShuttingDown,
+}
+
+/// Spawn a heartbeat timeout for a job whose channel ended (client disconnect, execute error, or
+/// server shutdown) before the job finished, so the in-flight job is not orphaned: the runner can
+/// reconnect to another instance and resume within the grace period. `reason` is logged for context.
+async fn spawn_inflight_heartbeat_timeout(
+    log: &slog::Logger,
+    context: &ApiContext,
+    heartbeat_timeout: Duration,
+    job_id: JobId,
+    reason: &str,
+) -> Result<(), ChannelError> {
+    let job = QueryJob::get(auth_conn!(context), job_id)?;
+    if !job.status.has_run() {
+        slog::info!(log, "Channel ended ({reason}) for in-flight job, spawning heartbeat timeout"; "job_id" => ?job.id);
+        spawn_heartbeat_timeout(
+            log.clone(),
+            heartbeat_timeout,
+            context.database.connection.clone(),
+            job.id,
+            &context.heartbeat_tasks,
+            context.job_timeout_grace_period,
+            context.clock.clone(),
+        );
+    }
+    Ok(())
 }
 
 /// Path parameters for the runner channel endpoint.
@@ -1053,9 +1081,13 @@ pub async fn runner_channel(
 
     let (mut tx, mut rx) = ws_stream.split();
     let heartbeat_timeout = context.heartbeat_timeout;
+    let shutdown = &context.shutdown;
 
     #[cfg(feature = "otel")]
     let mut state_guard = RunnerStateGuard::new(bencher_otel::RunnerStateKind::Idle);
+
+    // Set when graceful shutdown is signalled so we send a Close frame after leaving the loop.
+    let mut shutting_down = false;
 
     // State machine: Idle -> Executing -> Idle -> ...
     loop {
@@ -1068,6 +1100,7 @@ pub async fn runner_channel(
             &mut tx,
             &mut rx,
             heartbeat_timeout,
+            shutdown,
         )
         .await
         {
@@ -1075,6 +1108,10 @@ pub async fn runner_channel(
             Ok(ReadyOutcome::UpdateSent) => {
                 #[cfg(feature = "otel")]
                 state_guard.transition(bencher_otel::RunnerStateKind::Updating);
+                break;
+            },
+            Ok(ReadyOutcome::ShuttingDown) => {
+                shutting_down = true;
                 break;
             },
             Err(_) => {
@@ -1087,11 +1124,20 @@ pub async fn runner_channel(
         let deadline = tokio::time::Instant::now() + Duration::from_secs(u64::from(poll_timeout));
 
         // Poll for a job, checking for WS disconnect between polls
-        let claimed_job =
-            poll_for_job(&log, context, &runner_key, deadline, &mut tx, &mut rx).await;
+        let claimed_job = poll_for_job(
+            &log,
+            context,
+            &runner_key,
+            deadline,
+            &mut tx,
+            &mut rx,
+            shutdown,
+        )
+        .await;
 
         match claimed_job {
-            Ok(Some((query_job, claimed_job))) => {
+            Ok(PollOutcome::Claimed(claimed)) => {
+                let (query_job, claimed_job) = *claimed;
                 // Send Job to runner
                 let job_msg = ServerMessage::Job(Box::new(claimed_job));
                 let text = serde_json::to_string(&job_msg)
@@ -1113,6 +1159,7 @@ pub async fn runner_channel(
                     &mut tx,
                     &mut rx,
                     heartbeat_timeout,
+                    shutdown,
                 )
                 .await
                 {
@@ -1125,20 +1172,24 @@ pub async fn runner_channel(
                         bencher_otel::ApiMeter::increment(
                             bencher_otel::ApiCounter::RunnerDisconnect,
                         );
-                        // Spawn heartbeat timeout for in-flight jobs
-                        let job = QueryJob::get(auth_conn!(context), query_job.id)?;
-                        if !job.status.has_run() {
-                            slog::info!(log, "Channel disconnected for in-flight job, spawning heartbeat timeout"; "job_id" => ?job.id);
-                            spawn_heartbeat_timeout(
-                                log,
-                                heartbeat_timeout,
-                                context.database.connection.clone(),
-                                job.id,
-                                &context.heartbeat_tasks,
-                                context.job_timeout_grace_period,
-                                context.clock.clone(),
-                            );
-                        }
+                        spawn_inflight_heartbeat_timeout(
+                            &log,
+                            context,
+                            heartbeat_timeout,
+                            query_job.id,
+                            "client disconnect",
+                        )
+                        .await?;
+                        break;
+                    },
+                    Ok(ExecuteResult::ShuttingDown) => {
+                        // Server shutting down mid-job: leave the job Running and close the channel.
+                        // Unlike the disconnect branch we do NOT spawn a heartbeat timeout here: the
+                        // process is exiting, so the runtime would abort that task before it could
+                        // fire. Recovery is resume-on-another-instance: the runner reconnects and
+                        // re-sends its terminal result (`wait_for_ready` handles the retry), with
+                        // billing continuing from the persisted `last_billed_minute` watermark.
+                        shutting_down = true;
                         break;
                     },
                     Err(e) => {
@@ -1147,25 +1198,19 @@ pub async fn runner_channel(
                             bencher_otel::ApiCounter::RunnerDisconnect,
                         );
                         slog::error!(log, "Execute loop error"; "error" => %e, "job_id" => ?query_job.id);
-                        // Spawn heartbeat timeout for in-flight jobs
-                        let job = QueryJob::get(auth_conn!(context), query_job.id)?;
-                        if !job.status.has_run() {
-                            slog::info!(log, "Channel error for in-flight job, spawning heartbeat timeout"; "job_id" => ?job.id);
-                            spawn_heartbeat_timeout(
-                                log,
-                                heartbeat_timeout,
-                                context.database.connection.clone(),
-                                job.id,
-                                &context.heartbeat_tasks,
-                                context.job_timeout_grace_period,
-                                context.clock.clone(),
-                            );
-                        }
+                        spawn_inflight_heartbeat_timeout(
+                            &log,
+                            context,
+                            heartbeat_timeout,
+                            query_job.id,
+                            "execute error",
+                        )
+                        .await?;
                         break;
                     },
                 }
             },
-            Ok(None) => {
+            Ok(PollOutcome::Deadline) => {
                 // No job available, send NoJob and stay in Idle
                 let text = serde_json::to_string(&ServerMessage::NoJob)
                     .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
@@ -1175,12 +1220,27 @@ pub async fn runner_channel(
                     break;
                 }
             },
+            Ok(PollOutcome::ShuttingDown) => {
+                shutting_down = true;
+                break;
+            },
             Err(_) => {
                 #[cfg(feature = "otel")]
                 bencher_otel::ApiMeter::increment(bencher_otel::ApiCounter::RunnerDisconnect);
                 break;
             },
         }
+    }
+
+    // Tell the runner we're going away so it reconnects to the next instance, then return so
+    // `server.close()` can complete instead of hanging on this persistent connection.
+    if shutting_down {
+        slog::info!(log, "Closing runner channel for server shutdown");
+        let close_frame = CloseFrame {
+            code: CloseCode::Away,
+            reason: "server shutting down".into(),
+        };
+        drop(tx.send(Message::Close(Some(close_frame))).await);
     }
 
     Ok(())
@@ -1192,6 +1252,8 @@ enum ReadyOutcome {
     Ready(u32),
     /// Runner version is outdated; `Update` message was sent.
     UpdateSent,
+    /// The server is shutting down; close the channel so `server.close()` can complete.
+    ShuttingDown,
 }
 
 #[cfg(feature = "otel")]
@@ -1287,20 +1349,25 @@ async fn wait_for_ready<S, R>(
     tx: &mut S,
     rx: &mut R,
     idle_timeout: Duration,
+    shutdown: &CancellationToken,
 ) -> Result<ReadyOutcome, ChannelError>
 where
     S: futures::Sink<Message, Error = tokio_tungstenite::tungstenite::Error> + Unpin,
     R: futures::Stream<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
 {
     loop {
-        let msg = match tokio::time::timeout(idle_timeout, rx.next()).await {
-            Ok(Some(msg)) => msg,
-            Ok(None) => {
+        let msg = match shutdown
+            .run_until_cancelled(tokio::time::timeout(idle_timeout, rx.next()))
+            .await
+        {
+            None => return Ok(ReadyOutcome::ShuttingDown),
+            Some(Ok(Some(msg))) => msg,
+            Some(Ok(None)) => {
                 return Err(ChannelError::WebSocket(
                     tokio_tungstenite::tungstenite::Error::ConnectionClosed,
                 ));
             },
-            Err(_elapsed) => {
+            Some(Err(_elapsed)) => {
                 slog::warn!(log, "Idle timeout waiting for Ready message");
                 return Err(ChannelError::WebSocket(
                     tokio_tungstenite::tungstenite::Error::ConnectionClosed,
@@ -1454,10 +1521,20 @@ async fn lookup_runner_job(
     Ok(Some(job))
 }
 
+/// Outcome of polling for a job during the idle state.
+enum PollOutcome {
+    /// A job was claimed for this runner.
+    Claimed(Box<(QueryJob, JsonClaimedJob)>),
+    /// The poll deadline elapsed without claiming a job.
+    Deadline,
+    /// The server is shutting down; close the channel so `server.close()` can complete.
+    ShuttingDown,
+}
+
 /// Poll for a job, checking for WS disconnect between polls.
 ///
-/// Returns `Ok(Some(job))` if claimed, `Ok(None)` if deadline expired,
-/// or `Err` on WS disconnect.
+/// Returns `Ok(PollOutcome::Claimed)` if claimed, `Ok(PollOutcome::Deadline)` if the deadline
+/// expired, `Ok(PollOutcome::ShuttingDown)` if the server is shutting down, or `Err` on WS disconnect.
 async fn poll_for_job<S, R>(
     log: &slog::Logger,
     context: &ApiContext,
@@ -1465,14 +1542,17 @@ async fn poll_for_job<S, R>(
     deadline: tokio::time::Instant,
     tx: &mut S,
     rx: &mut R,
-) -> Result<Option<(QueryJob, JsonClaimedJob)>, ChannelError>
+    shutdown: &CancellationToken,
+) -> Result<PollOutcome, ChannelError>
 where
     S: futures::Sink<Message> + Unpin,
     R: futures::Stream<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
 {
     loop {
         match try_claim_job(context, runner_key).await {
-            Ok(Some(job)) => return Ok(Some(job)),
+            Ok(Some((query_job, claimed_job))) => {
+                return Ok(PollOutcome::Claimed(Box::new((query_job, claimed_job))));
+            },
             Ok(None) => {},
             Err(e) => {
                 slog::error!(log, "Error claiming job"; "error" => %e);
@@ -1481,29 +1561,33 @@ where
         }
 
         if tokio::time::Instant::now() >= deadline {
-            return Ok(None);
+            return Ok(PollOutcome::Deadline);
         }
 
-        // Wait POLL_INTERVAL, but check WS for disconnect
-        match tokio::time::timeout(POLL_INTERVAL, rx.next()).await {
-            Ok(Some(Ok(Message::Close(_))) | None) => {
+        // Wait POLL_INTERVAL, but check the WS for disconnect and the server for shutdown
+        match shutdown
+            .run_until_cancelled(tokio::time::timeout(POLL_INTERVAL, rx.next()))
+            .await
+        {
+            None => return Ok(PollOutcome::ShuttingDown),
+            Some(Ok(Some(Ok(Message::Close(_))) | None)) => {
                 return Err(ChannelError::WebSocket(
                     tokio_tungstenite::tungstenite::Error::ConnectionClosed,
                 ));
             },
-            Ok(Some(Ok(Message::Ping(data)))) => {
+            Some(Ok(Some(Ok(Message::Ping(data))))) => {
                 if tx.send(Message::Pong(data)).await.is_err() {
                     slog::warn!(log, "Failed to send pong during polling");
                 }
             },
-            Ok(Some(Err(e))) => return Err(ChannelError::WebSocket(e)),
-            Ok(Some(Ok(Message::Text(text)))) => {
+            Some(Ok(Some(Err(e)))) => return Err(ChannelError::WebSocket(e)),
+            Some(Ok(Some(Ok(Message::Text(text))))) => {
                 slog::warn!(log, "Unexpected text message during polling"; "text" => %text);
             },
-            Ok(Some(Ok(Message::Binary(data)))) => {
+            Some(Ok(Some(Ok(Message::Binary(data))))) => {
                 slog::warn!(log, "Unexpected binary message during polling"; "len" => data.len());
             },
-            Ok(Some(Ok(Message::Pong(_) | Message::Frame(_)))) | Err(_) => {},
+            Some(Ok(Some(Ok(Message::Pong(_) | Message::Frame(_)))) | Err(_)) => {},
         }
     }
 }
@@ -1519,6 +1603,7 @@ async fn execute_loop<S, R>(
     tx: &mut S,
     rx: &mut R,
     heartbeat_timeout: Duration,
+    shutdown: &CancellationToken,
 ) -> Result<ExecuteResult, ChannelError>
 where
     S: futures::Sink<Message, Error = tokio_tungstenite::tungstenite::Error> + Unpin,
@@ -1532,14 +1617,26 @@ where
             .checked_sub(last_heartbeat.elapsed())
             .unwrap_or(Duration::ZERO);
 
-        let msg_result = match tokio::time::timeout(remaining, rx.next()).await {
-            Ok(Some(msg_result)) => msg_result,
-            Ok(None) => {
+        let msg_result = match shutdown
+            .run_until_cancelled(tokio::time::timeout(remaining, rx.next()))
+            .await
+        {
+            None => {
+                // Server shutting down: return promptly. Unlike the disconnect and timeout branches,
+                // we deliberately do NOT call `bill_final_minutes` here: it awaits a Stripe call, and
+                // the whole point of this cancellation path is to drain `server.close()` fast (a slow
+                // Stripe round-trip would risk the SIGKILL-before-save hang this fix prevents). The job
+                // resumes on another instance, which re-bills the elapsed minutes from the persisted
+                // `last_billed_minute` watermark (`BillingDelta` is job-age-based).
+                return Ok(ExecuteResult::ShuttingDown);
+            },
+            Some(Ok(Some(msg_result))) => msg_result,
+            Some(Ok(None)) => {
                 // Stream ended (client disconnected) — best-effort bill any remaining partial minute
                 bill_final_minutes(log, context, job.id, &mut billing_state).await;
                 return Ok(ExecuteResult::Disconnected);
             },
-            Err(_elapsed) => {
+            Some(Err(_elapsed)) => {
                 // Heartbeat timeout — best-effort bill any remaining partial minute before marking job
                 bill_final_minutes(log, context, job.id, &mut billing_state).await;
                 let reason = handle_timeout(log, context, job.id).await?;

--- a/plus/api_runners/tests/jobs/websocket.rs
+++ b/plus/api_runners/tests/jobs/websocket.rs
@@ -15,7 +15,9 @@ use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 use futures::{SinkExt as _, StreamExt as _};
 use http::StatusCode;
 use tokio_tungstenite::tungstenite::{
-    Message, client::IntoClientRequest as _, protocol::WebSocketConfig,
+    Message,
+    client::IntoClientRequest as _,
+    protocol::{WebSocketConfig, frame::coding::CloseCode},
 };
 
 /// Full setup: create user, org, project, runner, job, then connect channel,
@@ -77,6 +79,72 @@ fn get_job_status(server: &TestServer, job_uuid: JobUuid) -> JobStatus {
         .select(schema::job::status)
         .first(&mut conn)
         .expect("Failed to get job status")
+}
+
+// =============================================================================
+// Graceful Shutdown Tests
+// =============================================================================
+
+/// When the server begins graceful shutdown, the persistent runner channel must wind down: the
+/// handler sends a Close frame and returns so `server.close()` can complete instead of hanging on
+/// this long-lived connection.
+#[tokio::test]
+async fn channel_closes_on_server_shutdown() {
+    let server = TestServer::new().await;
+    let admin = server.signup("Admin", "ws-shutdown@example.com").await;
+    let runner = create_runner(&server, &admin.token, "Runner shutdown").await;
+    let runner_key = runner.key.to_string();
+
+    // Connect the channel; the handler is now idle, waiting for a Ready message.
+    let mut ws = connect_channel(&server, runner.uuid, &runner_key).await;
+
+    // Signal graceful shutdown.
+    server.context().shutdown.cancel();
+
+    // The idle handler should send a Close(Away) frame and return.
+    let next = tokio::time::timeout(std::time::Duration::from_secs(5), ws.next())
+        .await
+        .expect("runner channel did not close after shutdown was signalled");
+    assert!(
+        matches!(
+            &next,
+            Some(Ok(Message::Close(Some(frame)))) if frame.code == CloseCode::Away
+        ),
+        "expected a Close(Away) frame on shutdown, got: {next:?}"
+    );
+}
+
+/// Graceful shutdown mid-execution closes the channel gracefully and leaves the in-flight job Running
+/// so it can resume on another instance (the runner reconnects and re-sends its result). No local
+/// heartbeat timeout is spawned, since the process is exiting.
+#[tokio::test]
+async fn channel_shutdown_midjob_preserves_job() {
+    let server = TestServer::new().await;
+    let (mut ws, _runner_uuid, _runner_key, job_uuid) =
+        setup_claimed_job(&server, "shutdown-midjob").await;
+
+    // Drive the job into the executing state.
+    send_msg(&mut ws, &RunnerMessage::Running).await;
+    assert!(matches!(recv_msg(&mut ws).await, ServerMessage::Ack { .. }));
+    assert_eq!(get_job_status(&server, job_uuid), JobStatus::Running);
+
+    // Signal graceful shutdown while the job is in flight.
+    server.context().shutdown.cancel();
+
+    // The handler sends a Close(Away) frame and returns.
+    let next = tokio::time::timeout(std::time::Duration::from_secs(5), ws.next())
+        .await
+        .expect("runner channel did not close after shutdown was signalled");
+    assert!(
+        matches!(
+            &next,
+            Some(Ok(Message::Close(Some(frame)))) if frame.code == CloseCode::Away
+        ),
+        "expected a Close(Away) frame on shutdown, got: {next:?}"
+    );
+
+    // The in-flight job is left Running (not failed or dropped) so it can resume on another instance.
+    assert_eq!(get_job_status(&server, job_uuid), JobStatus::Running);
 }
 
 // =============================================================================

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -146,6 +146,10 @@ async fn shutdown(log: &Logger, server: HttpServer<ApiContext>) {
     #[cfg(feature = "plus")]
     let save_rate_limiting = {
         let ctx = server.app_private();
+        // Signal long-lived handlers (the runner WebSocket channel) to wind down so the in-flight
+        // connection drain in `server.close()` can complete instead of hanging until the platform
+        // escalates to SIGKILL (which would skip the rate limiting save below entirely).
+        ctx.shutdown.cancel();
         let rate_limiting = ctx.rate_limiting.clone();
         let database_path = ctx.database.path.clone();
         rate_limiting.prune();


### PR DESCRIPTION
## Problem

The API server saves its in-memory rate limiting state to `rate_limiting.json` on shutdown and restores it on startup. In production the on-disk snapshot had not been overwritten in weeks, and every boot logged:

> Failed to restore rate limiting state: Failed to deserialize rate limiting snapshot: invalid type: integer `1778809249`, expected a tuple of size 2

There are two separate problems:

1. The deserialize failure is a stale, incompatible on-disk format, not a truncated write. `1778809249` is a raw Unix-seconds timestamp from a pre-bucketing version; the current format stores `Vec<(EpochBucket, u32)>` where buckets are `secs / 60|3600|86400`, so the current code never produces a raw-seconds value.
2. The snapshot was never re-saved because graceful shutdown never completed. `server.close()` waits for in-flight handlers, but the persistent runner WebSocket (`runner_channel`) loops forever, so the platform escalated SIGINT to SIGTERM and killed the process before the save ran.

## Changes

- **Graceful shutdown of the runner channel.** Add a `CancellationToken` to `ApiContext`, tripped before `server.close()`. The `runner_channel` helpers now run their reads under `run_until_cancelled`, so on shutdown the handler sends a `Close(Away)` frame and returns, letting `close()` complete and the save run. In-flight jobs reuse the existing heartbeat-timeout path so they are not orphaned.
- **Log the snapshot on deserialize failure.** `load()` logs the full raw content (plus path and byte length) so an incompatible format is diagnosable from the logs. The bad file is left in place for the next save to overwrite.
- **Durable saves.** `save()` writes to a temp file, `fsync`s it, atomically renames, then `fsync`s the parent directory.

## Tests

- `channel_closes_on_server_shutdown`: an idle runner channel receives a `Close(Away)` frame after the shutdown token is cancelled.
- `load_legacy_format_errs`: the raw-seconds legacy snapshot reproduces the production `Deserialize` error, and the file is left in place.

## Notes

On the first boot of this build, the existing stale snapshot will still fail to deserialize (now logging its full content), and that boot's graceful shutdown will write a fresh, current-format snapshot. Subsequent boots restore cleanly.

## Verification

- `cargo clippy --no-deps --all-targets --all-features -- -Dwarnings`
- `cargo nextest run` for `api_runners` (161) and `bencher_schema` (150)
- `cargo test --doc`
- `cargo check --no-default-features`
- `cargo deny check`
