### PR TITLE
Add did-you-mean hint when --token/--key credentials are swapped

### DIFF
--- a/services/cli/src/parser/mod.rs
+++ b/services/cli/src/parser/mod.rs
@@ -151,12 +151,12 @@ pub struct CliBackend {
 
     /// User API token (JWT). Deprecated: prefer `--key`/`BENCHER_API_KEY` with a
     /// `bencher_user_*` API key.
-    #[clap(long, env = "BENCHER_API_TOKEN")]
+    #[clap(long, env = "BENCHER_API_TOKEN", value_parser = parse_token)]
     pub token: Option<Jwt>,
 
     /// Bencher API key. Either a user-scoped key (`bencher_user_*`) or a
     /// project-scoped key (`bencher_run_*`).
-    #[clap(long, env = "BENCHER_API_KEY")]
+    #[clap(long, env = "BENCHER_API_KEY", value_parser = parse_key)]
     pub key: Option<BencherKey>,
 
     /// Allow insecure connections to an HTTPS host
@@ -186,6 +186,38 @@ pub struct CliBackend {
     /// Strictly parse JSON responses
     #[clap(long)]
     pub strict: bool,
+}
+
+/// Parse a `--token` value, suggesting `--key` if a Bencher API key was supplied.
+///
+/// JWTs and Bencher API keys are structurally disjoint, so a value that fails to
+/// parse as a `Jwt` but parses as a `BencherKey` is unambiguously the wrong flag.
+fn parse_token(value: &str) -> Result<Jwt, String> {
+    value.parse::<Jwt>().map_err(|err| {
+        if value.parse::<BencherKey>().is_ok() {
+            "You supplied a Bencher API key to `--token`/`BENCHER_API_TOKEN`. \
+             Use `--key`/`BENCHER_API_KEY` instead."
+                .to_owned()
+        } else {
+            err.to_string()
+        }
+    })
+}
+
+/// Parse a `--key` value, suggesting `--token` if a JWT API token was supplied.
+///
+/// JWTs and Bencher API keys are structurally disjoint, so a value that fails to
+/// parse as a `BencherKey` but parses as a `Jwt` is unambiguously the wrong flag.
+fn parse_key(value: &str) -> Result<BencherKey, String> {
+    value.parse::<BencherKey>().map_err(|err| {
+        if value.parse::<Jwt>().is_ok() {
+            "You supplied a JWT API token to `--key`/`BENCHER_API_KEY`. \
+             Use `--token`/`BENCHER_API_TOKEN` instead."
+                .to_owned()
+        } else {
+            err.to_string()
+        }
+    })
 }
 
 #[derive(Args, Debug)]
@@ -278,5 +310,64 @@ where
 impl<T> From<ElidedOption<T>> for Option<T> {
     fn from(elided: ElidedOption<T>) -> Option<T> {
         elided.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_key, parse_token};
+
+    const VALID_USER_KEY: &str = "bencher_user_aB3xY9mN2pQ7rS4tU8vW1zK5jL0fGh";
+    const VALID_PROJECT_KEY: &str = "bencher_run_aB3xY9mN2pQ7rS4tU8vW1zK5jL0fGh";
+    const VALID_JWT: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJhdXRoIiwiZXhwIjoxNjY5Mjk5NjExLCJpYXQiOjE2NjkyOTc4MTEsImlzcyI6ImJlbmNoZXIuZGV2Iiwic3ViIjoiYUBhLmNvIiwib3JnIjpudWxsfQ.jJmb_nCVJYLD5InaIxsQfS7x87fUsnCYpQK9SrWrKTc";
+
+    #[test]
+    fn parse_token_accepts_jwt() {
+        assert_eq!(parse_token(VALID_JWT).unwrap().as_ref(), VALID_JWT);
+    }
+
+    #[test]
+    fn parse_token_suggests_key_for_user_key() {
+        let err = parse_token(VALID_USER_KEY).unwrap_err();
+        assert!(err.contains("Use `--key`/`BENCHER_API_KEY`"), "{err}");
+    }
+
+    #[test]
+    fn parse_token_suggests_key_for_project_key() {
+        let err = parse_token(VALID_PROJECT_KEY).unwrap_err();
+        assert!(err.contains("Use `--key`/`BENCHER_API_KEY`"), "{err}");
+    }
+
+    #[test]
+    fn parse_token_rejects_garbage_without_hint() {
+        let err = parse_token("garbage").unwrap_err();
+        assert!(!err.contains("Use `--key`"), "{err}");
+        assert!(err.contains("JWT"), "{err}");
+    }
+
+    #[test]
+    fn parse_key_accepts_user_key() {
+        assert_eq!(parse_key(VALID_USER_KEY).unwrap().as_ref(), VALID_USER_KEY);
+    }
+
+    #[test]
+    fn parse_key_accepts_project_key() {
+        assert_eq!(
+            parse_key(VALID_PROJECT_KEY).unwrap().as_ref(),
+            VALID_PROJECT_KEY
+        );
+    }
+
+    #[test]
+    fn parse_key_suggests_token_for_jwt() {
+        let err = parse_key(VALID_JWT).unwrap_err();
+        assert!(err.contains("Use `--token`/`BENCHER_API_TOKEN`"), "{err}");
+    }
+
+    #[test]
+    fn parse_key_rejects_garbage_without_hint() {
+        let err = parse_key("garbage").unwrap_err();
+        assert!(!err.contains("Use `--token`"), "{err}");
+        assert!(err.contains("Bencher API key"), "{err}");
     }
 }


### PR DESCRIPTION
## Context

Bencher recently moved from recommending `--token` (a JWT) to `--key` (a `bencher_user_*` / `bencher_run_*` API key) for CLI authentication. Users and agents still reach for the old `--token` flag and sometimes pass the wrong credential type into the wrong flag. Previously this produced an opaque validation error:

- Passing a key to `--token` failed with `Failed to validate JWT (JSON Web Token): ...`
- Passing a JWT to `--key` failed with `Failed to validate Bencher API key: ...`

Neither message told the user they simply used the wrong flag.

## Change

Add clap `value_parser` functions for the `token` and `key` fields of `CliBackend` that wrap the existing `FromStr` parsing and, on failure, detect whether the supplied value is actually the *other* credential type and emit a redirecting hint:

```
error: invalid value 'bencher_user_...' for '--token <TOKEN>': You supplied a Bencher API key to `--token`/`BENCHER_API_TOKEN`. Use `--key`/`BENCHER_API_KEY` instead.

error: invalid value 'eyJ...' for '--key <KEY>': You supplied a JWT API token to `--key`/`BENCHER_API_KEY`. Use `--token`/`BENCHER_API_TOKEN` instead.
```

Detection reuses the existing `FromStr` impls (no new prefix/format logic): JWTs and API keys are structurally disjoint, so a value that fails one parser and succeeds the other is unambiguously a swap. Genuinely malformed values fall through to the original validation error (no false hint). Because clap runs value parsers on env-var values too, the hint also fires for `BENCHER_API_TOKEN` / `BENCHER_API_KEY`.

This mirrors the existing `check_env` / `check_volume` value-parser pattern already used in the CLI parser.

## Tests

Added 8 unit tests covering both swap directions, both key types (`bencher_user_*` and `bencher_run_*`), valid inputs, and the garbage-without-hint fall-through.

## Verification

- `cargo test -p bencher_cli` (8 new tests pass)
- `cargo clippy -p bencher_cli --all-targets --all-features --no-deps -- -Dwarnings` clean
- `cargo fmt`
- Manual smoke test confirmed all three behaviors (key to `--token` hint, JWT to `--key` hint, garbage to plain error)