### PR TITLE
Bump Litestream from 0.5.10 to 0.5.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
     with:
       mold-version: "2.34.1"
       wasm-pack-version: "0.12.1"
-      litestream-version: "0.5.10"
+      litestream-version: "0.5.13"
       cargo-chef-version: "0.1.77"
       sccache-version: "0.16.0"
       is-fork: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
@@ -175,7 +175,7 @@ jobs:
     uses: ./.github/workflows/docker.yml
     with:
       mold-version: "2.34.1"
-      litestream-version: "0.5.10"
+      litestream-version: "0.5.13"
       cargo-chef-version: "0.1.77"
       sccache-version: "0.16.0"
       is-fork: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: ./services/api/Dockerfile
       args:
         MOLD_VERSION: 2.34.1
-        LITESTREAM_VERSION: 0.5.10
+        LITESTREAM_VERSION: 0.5.13
         CARGO_CHEF_VERSION: 0.1.77
         SCCACHE_VERSION: 0.16.0
     image: bencher-api


### PR DESCRIPTION
## Why

The Bencher Cloud data volume grew starting 2026-06-25, the same moment the Litestream replica datastore moved from AWS S3 to Cloudflare R2.

Root cause: R2 `DeleteObjects` calls can return HTTP 200 while silently leaving the objects in place ([Litestream troubleshooting](https://litestream.io/docs/troubleshooting/), [litestream#976](https://github.com/benbjohnson/litestream/issues/976)). Litestream retention enforcement is what prunes the local `.bencher.db-litestream/ltx/` directory, so when the R2 deletes fail, local LTX files accumulate and fill the volume. The database itself is healthy.

## What

- Bump `litestream-version` in CI from 0.5.10 to 0.5.13 (API server Docker image and docker-compose). v0.5.12 fixed compactor pipe closure on upload failures and started honoring database snapshot settings from the config file; v0.5.13 is the latest release.