### PR TITLE
Fix failing online lint checks

### DIFF
--- a/.github/workflows/update_sandbox.yml
+++ b/.github/workflows/update_sandbox.yml
@@ -15,7 +15,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked] this job commits and force-pushes the update/sandbox branch, so it needs the persisted GITHUB_TOKEN
         with:
           ref: devel
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
         with:
           mold-version: "2.34.1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "api_auth"
@@ -2388,9 +2388,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -27,6 +27,8 @@ ignore = [
     "RUSTSEC-2025-0134",
     # https://rustsec.org/advisories/RUSTSEC-2026-0173.html
     "RUSTSEC-2026-0173",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0192.html
+    "RUSTSEC-2026-0192",
 ]
 
 [bans]


### PR DESCRIPTION
Fixes the two failing online lint jobs from https://github.com/bencherdev/bencher/actions/runs/28988970210.

## Zizmor Online

`update_sandbox.yml` pinned `dtolnay/rust-toolchain` to an old `stable` branch commit. That branch is force-pushed each Rust release, so the pinned commit became unreachable and tripped zizmor's online impostor commit audit. The pin now points to a `master` SHA with an explicit `toolchain: stable` input; `master` history is append-only, so this cannot recur.

## Cargo Deny Advisories

- **RUSTSEC-2026-0190**: update `anyhow` 1.0.102 -> 1.0.103 (lockfile only)
- **RUSTSEC-2026-0204**: update `crossbeam-epoch` 0.9.18 -> 0.9.20 (lockfile only)
- **RUSTSEC-2026-0192**: `ttf-parser` is unmaintained; it comes in via `plotters` 0.3.7 (used by `bencher_plot` and `criterion`), and no plotters release drops it. Added to the `deny.toml` ignore list, matching the existing exemptions.

## Verification

- `cargo deny --locked check advisories` passes
- `zizmor .` with online audits (v1.25.2, same as CI) reports no findings
- `cargo check` passes after the lockfile bumps