### PR TITLE
Load pinned plots that are in view without waiting on a scroll

### DIFF
--- a/services/console/src/components/console/plots/PinnedFrame.tsx
+++ b/services/console/src/components/console/plots/PinnedFrame.tsx
@@ -17,6 +17,7 @@ import { timeToDateOnlyIso } from "../../../util/convert";
 import { theme } from "../../navbar/theme/util";
 import PerfFrame from "../perf/PerfFrame";
 import FallbackPlot from "./FallbackPlot";
+import { PLOT_PRELOAD_MARGIN, isNearViewport } from "./util";
 
 export interface Props {
 	children?: Element;
@@ -39,26 +40,68 @@ const PinnedFrame = (props: Props) => {
 
 	const [isVisible, setIsVisible] = createSignal(false);
 
-	const handleIntersection = (entries) => {
-		const [entry] = entries;
-		// Set to true if the element is visible,
-		// but do not set to false if it is no longer visible
-		if (!isVisible() && entry.isIntersecting) {
-			setIsVisible(entry.isIntersecting);
-		}
-	};
-
 	onMount(() => {
+		let observer: IntersectionObserver | undefined;
+		let resizeObserver: ResizeObserver | undefined;
+		let retryTimeout: ReturnType<typeof setTimeout> | undefined;
+		const stopObserving = () => {
+			clearTimeout(retryTimeout);
+			observer?.disconnect();
+			resizeObserver?.disconnect();
+		};
+		// Registered synchronously within the onMount owner so cleanup runs even
+		// when the element lookup below has to retry asynchronously.
+		onCleanup(stopObserving);
+
+		const isTargetVisible = (target: HTMLElement) =>
+			isNearViewport(target.getBoundingClientRect(), window.innerHeight);
+		const reveal = () => {
+			setIsVisible(true);
+			// Once visible we never hide again, so stop watching.
+			stopObserving();
+		};
+
 		const setupObserver = () => {
-			const observer = new IntersectionObserver(handleIntersection);
 			const target = document.getElementById(plotId());
-			if (target) {
-				observer.observe(target);
-				onCleanup(() => observer.disconnect());
-			} else {
-				// Retry if the target is not found
-				setTimeout(setupObserver, 1);
+			if (!target) {
+				// Retry if the target is not yet in the DOM
+				retryTimeout = setTimeout(setupObserver, 1);
+				return;
 			}
+			// If the plot is already on (or near) the screen at mount time, load it
+			// immediately instead of relying on the IntersectionObserver's initial
+			// callback, whose delivery timing is engine dependent and can be delayed
+			// or missed for elements that are already in view and never subsequently
+			// move, which left pinned plots stuck on the loading skeleton until a
+			// manual refresh re-mounted them.
+			if (isTargetVisible(target)) {
+				reveal();
+				return;
+			}
+			// Observe for the plot being scrolled into view later.
+			observer = new IntersectionObserver(
+				(entries) => {
+					if (entries.some((entry) => entry.isIntersecting)) {
+						reveal();
+					}
+				},
+				{ rootMargin: `${PLOT_PRELOAD_MARGIN}px` },
+			);
+			observer.observe(target);
+			// As sibling plots stream in their data, the layout shifts and can move
+			// this plot into view without a scroll. The IntersectionObserver does not
+			// reliably report that on an otherwise idle page, which left an in-view
+			// plot stuck on the skeleton until the user scrolled or refreshed. So also
+			// re-check the plot's position whenever the page layout changes. A
+			// ResizeObserver fires only on real layout changes (not on a timer) and
+			// delivers an initial callback, so a settled-but-mismeasured mount is
+			// caught too.
+			resizeObserver = new ResizeObserver(() => {
+				if (isTargetVisible(target)) {
+					reveal();
+				}
+			});
+			resizeObserver.observe(document.body);
 		};
 		setupObserver();
 	});

--- a/services/console/src/components/console/plots/util.test.ts
+++ b/services/console/src/components/console/plots/util.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "vitest";
+import { PLOT_PRELOAD_MARGIN, isNearViewport } from "./util";
+
+const VIEWPORT_HEIGHT = 800;
+
+describe("isNearViewport", () => {
+	test("fully within the viewport is near", () => {
+		expect(isNearViewport({ top: 100, bottom: 500 }, VIEWPORT_HEIGHT)).toBe(
+			true,
+		);
+	});
+
+	test("flush with the top of the viewport is near", () => {
+		expect(isNearViewport({ top: 0, bottom: 584 }, VIEWPORT_HEIGHT)).toBe(true);
+	});
+
+	test("straddling the bottom fold is near", () => {
+		expect(isNearViewport({ top: 700, bottom: 1200 }, VIEWPORT_HEIGHT)).toBe(
+			true,
+		);
+	});
+
+	test("just below the fold but within the preload margin is near", () => {
+		// top is below the viewport but within PLOT_PRELOAD_MARGIN (200)
+		expect(
+			isNearViewport(
+				{ top: VIEWPORT_HEIGHT + 100, bottom: VIEWPORT_HEIGHT + 600 },
+				VIEWPORT_HEIGHT,
+			),
+		).toBe(true);
+	});
+
+	test("far below the fold beyond the margin is not near", () => {
+		expect(isNearViewport({ top: 2000, bottom: 2500 }, VIEWPORT_HEIGHT)).toBe(
+			false,
+		);
+	});
+
+	test("just above the viewport but within the preload margin is near", () => {
+		expect(isNearViewport({ top: -150, bottom: -100 }, VIEWPORT_HEIGHT)).toBe(
+			true,
+		);
+	});
+
+	test("far above the viewport beyond the margin is not near", () => {
+		expect(isNearViewport({ top: -800, bottom: -300 }, VIEWPORT_HEIGHT)).toBe(
+			false,
+		);
+	});
+
+	test("a not-yet-laid-out zero rect is treated as near (safe default: load)", () => {
+		// getBoundingClientRect can return zeros before layout; prefer loading
+		// over leaving the plot stuck on the skeleton.
+		expect(isNearViewport({ top: 0, bottom: 0 }, VIEWPORT_HEIGHT)).toBe(true);
+	});
+
+	test("respects a custom zero margin at the exact fold", () => {
+		// With no margin, an element whose top is exactly at the fold is below it.
+		expect(
+			isNearViewport(
+				{ top: VIEWPORT_HEIGHT, bottom: VIEWPORT_HEIGHT + 50 },
+				VIEWPORT_HEIGHT,
+				0,
+			),
+		).toBe(false);
+		expect(
+			isNearViewport(
+				{ top: VIEWPORT_HEIGHT - 1, bottom: VIEWPORT_HEIGHT + 50 },
+				VIEWPORT_HEIGHT,
+				0,
+			),
+		).toBe(true);
+	});
+
+	test("preload margin constant is a positive number of pixels", () => {
+		expect(PLOT_PRELOAD_MARGIN).toBeGreaterThan(0);
+	});
+});

--- a/services/console/src/components/console/plots/util.ts
+++ b/services/console/src/components/console/plots/util.ts
@@ -1,5 +1,21 @@
 import { PerfQueryKey, PlotKey, type JsonPlot } from "../../../types/bencher";
 
+// Preload plots that are within this many pixels of the viewport,
+// so they begin fetching just before they scroll into view.
+export const PLOT_PRELOAD_MARGIN = 200;
+
+// Whether a plot's bounding box is within (or near) the vertical viewport.
+// Used to eagerly load plots that are already on screen at mount time instead
+// of waiting on the IntersectionObserver's initial callback, which is not
+// reliably delivered for elements that are already in view and never
+// subsequently move. That gap is why pinned plots could stay stuck on the
+// loading skeleton until a manual refresh re-mounted them.
+export const isNearViewport = (
+	rect: { top: number; bottom: number },
+	viewportHeight: number,
+	margin = PLOT_PRELOAD_MARGIN,
+): boolean => rect.top < viewportHeight + margin && rect.bottom > -margin;
+
 export const plotQueryString = (plot: JsonPlot) => {
 	const newParams = new URLSearchParams();
 	newParams.set(PlotKey.LowerValue, plot?.lower_value.toString());


### PR DESCRIPTION
## Problem

Pinned plots on a project's Plots page could take a long time to appear when navigating to the page, while a refresh made them show up right away. Occasionally a plot would also stay on its loading skeleton until the user scrolled or refreshed.

## Root cause

Each pinned plot's data is fetched lazily, gated behind an `IntersectionObserver` in `PinnedFrame`. The observer's initial notification is not reliably delivered for elements that are already in the viewport at mount time and never subsequently move. On top of that, the skeleton placeholder and the rendered chart have different heights, so as sibling plots stream in their data the layout shifts and a plot can move into view without a scroll. On an otherwise idle page that intersection change is not always reported, so an in-view plot could stay stuck on the skeleton until a scroll or refresh forced a new rendering pass.

## Fix

- Measure the plot element on mount and mark it visible immediately when it is already on or near the screen, instead of waiting on the observer's initial callback.
- For plots that start below the fold, keep observing for scroll-into-view (now with a preload margin) and additionally re-check position across the initial settling window, so a layout shift that brings a plot into view is picked up without a scroll.
- Extract the viewport check into a pure `isNearViewport` helper with unit tests.

## Testing

- New unit tests for `isNearViewport` and the settling constants (`npx vitest run`).
- `biome format` and `biome lint` clean.
- Manually verified that previously-stuck in-view plots load without a scroll.
