### PR TITLE
Support updating a pinned plot in place

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,8 @@ The clippy script will install the target automatically and warn if no cross-com
 
 ## Code Quality
 
+**Core Axiom: Less is more. Err on the side of simplicity. KISS.**
+
 - Always run `cargo fmt` and `cargo clippy` when testing or before committing
 - Run `cargo fmt` one final time after all changes are complete (including any generated code or lint fixes), since clippy fixes and other automated changes can introduce formatting drift
 - Use `#[expect(...)]` instead of `#[allow(...)]` for lint suppression

--- a/lib/api_projects/src/plots.rs
+++ b/lib/api_projects/src/plots.rs
@@ -14,7 +14,7 @@ use bencher_schema::{
     model::{
         project::{
             QueryProject,
-            plot::{InsertPlot, QueryPlot, UpdatePlot},
+            plot::{InsertPlot, QueryPlot},
         },
         user::{
             actor::{ApiActor, PubProjectBearerToken},
@@ -367,12 +367,9 @@ async fn patch_inner(
     let query_plot =
         QueryPlot::get_with_uuid(auth_conn!(context), &query_project, path_params.plot)?;
 
-    let update_plot =
-        UpdatePlot::from_json(context, &query_project, &query_plot, json_plot.clone()).await?;
-    diesel::update(schema::plot::table.filter(schema::plot::id.eq(query_plot.id)))
-        .set(&update_plot)
-        .execute(write_conn!(context))
-        .map_err(resource_conflict_err!(Plot, (&query_plot, &json_plot)))?;
+    query_plot
+        .update(context, &query_project, json_plot)
+        .await?;
 
     auth_conn!(context, |conn| {
         QueryPlot::get_with_uuid(conn, &query_project, path_params.plot)

--- a/lib/api_projects/tests/projects.rs
+++ b/lib/api_projects/tests/projects.rs
@@ -698,3 +698,234 @@ async fn projects_soft_delete_endpoints_inaccessible() {
         );
     }
 }
+
+// Plot dimensions seeded directly in the DB for the plot PATCH test.
+struct PlotDimensions {
+    branch1: bencher_json::BranchUuid,
+    branch2: bencher_json::BranchUuid,
+    testbed: bencher_json::TestbedUuid,
+    benchmark: bencher_json::BenchmarkUuid,
+    measure: bencher_json::MeasureUuid,
+}
+
+#[expect(clippy::expect_used, reason = "test helper seeding plot dimensions")]
+fn seed_plot_dimensions(server: &TestServer, project_id: i32) -> PlotDimensions {
+    use bencher_api_tests::helpers::base_timestamp;
+    use bencher_json::{BenchmarkUuid, BranchUuid, MeasureUuid, TestbedUuid};
+    use bencher_schema::schema;
+    use diesel::{ExpressionMethods as _, RunQueryDsl as _};
+
+    let now = base_timestamp();
+    let branch1 = BranchUuid::new();
+    let branch2 = BranchUuid::new();
+    let testbed = TestbedUuid::new();
+    let benchmark = BenchmarkUuid::new();
+    let measure = MeasureUuid::new();
+
+    let mut conn = server.db_conn();
+    for (uuid, name) in [(&branch1, "branch-one"), (&branch2, "branch-two")] {
+        diesel::insert_into(schema::branch::table)
+            .values((
+                schema::branch::uuid.eq(uuid),
+                schema::branch::project_id.eq(project_id),
+                schema::branch::name.eq(name),
+                schema::branch::slug.eq(&format!("{name}-{uuid}")),
+                schema::branch::created.eq(&now),
+                schema::branch::modified.eq(&now),
+            ))
+            .execute(&mut conn)
+            .expect("Failed to insert branch");
+    }
+    diesel::insert_into(schema::testbed::table)
+        .values((
+            schema::testbed::uuid.eq(&testbed),
+            schema::testbed::project_id.eq(project_id),
+            schema::testbed::name.eq("testbed-one"),
+            schema::testbed::slug.eq(&format!("testbed-one-{testbed}")),
+            schema::testbed::created.eq(&now),
+            schema::testbed::modified.eq(&now),
+        ))
+        .execute(&mut conn)
+        .expect("Failed to insert testbed");
+    diesel::insert_into(schema::benchmark::table)
+        .values((
+            schema::benchmark::uuid.eq(&benchmark),
+            schema::benchmark::project_id.eq(project_id),
+            schema::benchmark::name.eq("benchmark-one"),
+            schema::benchmark::slug.eq(&format!("benchmark-one-{benchmark}")),
+            schema::benchmark::created.eq(&now),
+            schema::benchmark::modified.eq(&now),
+        ))
+        .execute(&mut conn)
+        .expect("Failed to insert benchmark");
+    diesel::insert_into(schema::measure::table)
+        .values((
+            schema::measure::uuid.eq(&measure),
+            schema::measure::project_id.eq(project_id),
+            schema::measure::name.eq("latency"),
+            schema::measure::slug.eq(&format!("latency-{measure}")),
+            schema::measure::units.eq("nanoseconds"),
+            schema::measure::created.eq(&now),
+            schema::measure::modified.eq(&now),
+        ))
+        .execute(&mut conn)
+        .expect("Failed to insert measure");
+
+    PlotDimensions {
+        branch1,
+        branch2,
+        testbed,
+        benchmark,
+        measure,
+    }
+}
+
+// PATCH /v0/projects/{project}/plots/{plot} - full update (flags, x-axis, components)
+#[tokio::test]
+async fn plot_patch_updates_full_config() {
+    use bencher_api_tests::helpers::get_project_id;
+    use bencher_json::{JsonPlot, project::plot::XAxis};
+
+    let server = TestServer::new().await;
+    let user = server.signup("Plot User", "plotpatch@example.com").await;
+    let org = server.create_org(&user, "Plot Org").await;
+    let project = server.create_project(&user, &org, "Plot Project").await;
+    let project_slug: &str = project.slug.as_ref();
+    let project_id = get_project_id(&server, project_slug);
+
+    let PlotDimensions {
+        branch1,
+        branch2,
+        testbed,
+        benchmark,
+        measure,
+    } = seed_plot_dimensions(&server, project_id);
+
+    // Create the plot via the API.
+    let new_plot = serde_json::json!({
+        "lower_value": true,
+        "upper_value": true,
+        "lower_boundary": false,
+        "upper_boundary": false,
+        "x_axis": "date_time",
+        "window": 2_592_000,
+        "branches": [branch1.to_string()],
+        "testbeds": [testbed.to_string()],
+        "benchmarks": [benchmark.to_string()],
+        "measures": [measure.to_string()],
+    });
+    let created: JsonPlot = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{project_slug}/plots")))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(&new_plot)
+        .send()
+        .await
+        .expect("Request failed")
+        .json()
+        .await
+        .expect("Failed to parse created plot");
+    assert_eq!(created.branches, vec![branch1]);
+    assert!(created.lower_value);
+    assert!(matches!(created.x_axis, XAxis::DateTime));
+
+    // PATCH: flip a flag, switch the x-axis, and replace the branches.
+    let patch = serde_json::json!({
+        "lower_value": false,
+        "x_axis": "version",
+        "branches": [branch1.to_string(), branch2.to_string()],
+    });
+    let resp = server
+        .client
+        .patch(server.api_url(&format!(
+            "/v0/projects/{project_slug}/plots/{}",
+            created.uuid
+        )))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(&patch)
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let updated: JsonPlot = resp.json().await.expect("Failed to parse updated plot");
+
+    // Provided fields changed.
+    assert!(!updated.lower_value);
+    assert!(matches!(updated.x_axis, XAxis::Version));
+    assert_eq!(updated.branches, vec![branch1, branch2]);
+    // Omitted fields left unchanged.
+    assert!(updated.upper_value);
+    assert_eq!(updated.testbeds, vec![testbed]);
+    assert_eq!(updated.benchmarks, vec![benchmark]);
+    assert_eq!(updated.measures, vec![measure]);
+}
+
+// PATCH referencing a component that does not belong to the project is rejected.
+#[tokio::test]
+async fn plot_patch_rejects_unknown_component() {
+    use bencher_api_tests::helpers::get_project_id;
+    use bencher_json::{BranchUuid, JsonPlot};
+
+    let server = TestServer::new().await;
+    let user = server
+        .signup("Plot User 404", "plotpatch404@example.com")
+        .await;
+    let org = server.create_org(&user, "Plot Org 404").await;
+    let project = server.create_project(&user, &org, "Plot Project 404").await;
+    let project_slug: &str = project.slug.as_ref();
+    let project_id = get_project_id(&server, project_slug);
+
+    let dims = seed_plot_dimensions(&server, project_id);
+    let new_plot = serde_json::json!({
+        "lower_value": true,
+        "upper_value": true,
+        "lower_boundary": false,
+        "upper_boundary": false,
+        "x_axis": "date_time",
+        "window": 2_592_000,
+        "branches": [dims.branch1.to_string()],
+        "testbeds": [dims.testbed.to_string()],
+        "benchmarks": [dims.benchmark.to_string()],
+        "measures": [dims.measure.to_string()],
+    });
+    let created: JsonPlot = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{project_slug}/plots")))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(&new_plot)
+        .send()
+        .await
+        .expect("Request failed")
+        .json()
+        .await
+        .expect("Failed to parse created plot");
+
+    // A branch UUID that was never created in this project must be rejected
+    // rather than silently referenced or returning a 500.
+    let unknown = BranchUuid::new();
+    let patch = serde_json::json!({ "branches": [unknown.to_string()] });
+    let resp = server
+        .client
+        .patch(server.api_url(&format!(
+            "/v0/projects/{project_slug}/plots/{}",
+            created.uuid
+        )))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(&patch)
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}

--- a/lib/api_projects/tests/projects.rs
+++ b/lib/api_projects/tests/projects.rs
@@ -929,3 +929,292 @@ async fn plot_patch_rejects_unknown_component() {
         .expect("Request failed");
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
+
+// POST a plot via the API and parse the response.
+#[expect(clippy::expect_used, reason = "test helper creating a plot")]
+async fn post_plot(
+    server: &TestServer,
+    user: &bencher_api_tests::TestUser,
+    project_slug: &str,
+    new_plot: &serde_json::Value,
+) -> bencher_json::JsonPlot {
+    server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{project_slug}/plots")))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(new_plot)
+        .send()
+        .await
+        .expect("Request failed")
+        .json()
+        .await
+        .expect("Failed to parse created plot")
+}
+
+// PATCH a plot via the API, assert success, and parse the response.
+#[expect(clippy::expect_used, reason = "test helper patching a plot")]
+async fn patch_plot(
+    server: &TestServer,
+    user: &bencher_api_tests::TestUser,
+    project_slug: &str,
+    plot: bencher_json::PlotUuid,
+    patch: &serde_json::Value,
+) -> bencher_json::JsonPlot {
+    let resp = server
+        .client
+        .patch(server.api_url(&format!("/v0/projects/{project_slug}/plots/{plot}")))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(patch)
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(resp.status(), StatusCode::OK, "Failed to update plot");
+    resp.json().await.expect("Failed to parse updated plot")
+}
+
+// PATCH with `"title": null` (the `Null` variant) clears the title while
+// still applying the other provided fields.
+#[tokio::test]
+async fn plot_patch_null_title_clears_it() {
+    use bencher_api_tests::helpers::get_project_id;
+
+    let server = TestServer::new().await;
+    let user = server
+        .signup("Plot User Null", "plotpatchnull@example.com")
+        .await;
+    let org = server.create_org(&user, "Plot Org Null").await;
+    let project = server
+        .create_project(&user, &org, "Plot Project Null")
+        .await;
+    let project_slug: &str = project.slug.as_ref();
+    let project_id = get_project_id(&server, project_slug);
+
+    let dims = seed_plot_dimensions(&server, project_id);
+    let created = post_plot(
+        &server,
+        &user,
+        project_slug,
+        &serde_json::json!({
+            "title": "My Titled Plot",
+            "lower_value": true,
+            "upper_value": true,
+            "lower_boundary": false,
+            "upper_boundary": false,
+            "x_axis": "date_time",
+            "window": 2_592_000,
+            "branches": [dims.branch1.to_string()],
+            "testbeds": [dims.testbed.to_string()],
+            "benchmarks": [dims.benchmark.to_string()],
+            "measures": [dims.measure.to_string()],
+        }),
+    )
+    .await;
+    assert!(created.title.is_some());
+
+    // Clear the title and flip a flag in the same PATCH.
+    let patch = serde_json::json!({ "title": null, "upper_boundary": true });
+    let updated = patch_plot(&server, &user, project_slug, created.uuid, &patch).await;
+
+    assert!(updated.title.is_none());
+    assert!(updated.upper_boundary);
+    // Everything else is unchanged.
+    assert!(updated.lower_value);
+    assert_eq!(updated.branches, vec![dims.branch1]);
+}
+
+// PATCH with both `index` (rank move) and a component list applies both.
+#[tokio::test]
+async fn plot_patch_index_and_components() {
+    use bencher_api_tests::helpers::get_project_id;
+    use bencher_json::JsonPlots;
+
+    let server = TestServer::new().await;
+    let user = server
+        .signup("Plot User Index", "plotpatchindex@example.com")
+        .await;
+    let org = server.create_org(&user, "Plot Org Index").await;
+    let project = server
+        .create_project(&user, &org, "Plot Project Index")
+        .await;
+    let project_slug: &str = project.slug.as_ref();
+    let project_id = get_project_id(&server, project_slug);
+
+    let dims = seed_plot_dimensions(&server, project_id);
+    let base_plot = |index: u8| {
+        serde_json::json!({
+            "index": index,
+            "lower_value": true,
+            "upper_value": true,
+            "lower_boundary": false,
+            "upper_boundary": false,
+            "x_axis": "date_time",
+            "window": 2_592_000,
+            "branches": [dims.branch1.to_string()],
+            "testbeds": [dims.testbed.to_string()],
+            "benchmarks": [dims.benchmark.to_string()],
+            "measures": [dims.measure.to_string()],
+        })
+    };
+    let first = post_plot(&server, &user, project_slug, &base_plot(0)).await;
+    let second = post_plot(&server, &user, project_slug, &base_plot(1)).await;
+
+    // Move the second plot to the front and replace its branches.
+    let patch = serde_json::json!({
+        "index": 0,
+        "branches": [dims.branch2.to_string()],
+    });
+    let updated = patch_plot(&server, &user, project_slug, second.uuid, &patch).await;
+    assert_eq!(updated.branches, vec![dims.branch2]);
+
+    // The plots list (rank order) now has the patched plot first.
+    let plots: JsonPlots = server
+        .client
+        .get(server.api_url(&format!("/v0/projects/{project_slug}/plots")))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .send()
+        .await
+        .expect("Request failed")
+        .json()
+        .await
+        .expect("Failed to parse plots");
+    let uuids: Vec<_> = plots.0.iter().map(|plot| plot.uuid).collect();
+    assert_eq!(uuids, vec![second.uuid, first.uuid]);
+}
+
+// Empty component lists are rejected on both POST and PATCH:
+// a plot missing any dimension would never render anything.
+#[tokio::test]
+async fn plot_rejects_empty_component_list() {
+    use bencher_api_tests::helpers::get_project_id;
+
+    let server = TestServer::new().await;
+    let user = server
+        .signup("Plot User Empty", "plotpatchempty@example.com")
+        .await;
+    let org = server.create_org(&user, "Plot Org Empty").await;
+    let project = server
+        .create_project(&user, &org, "Plot Project Empty")
+        .await;
+    let project_slug: &str = project.slug.as_ref();
+    let project_id = get_project_id(&server, project_slug);
+
+    let dims = seed_plot_dimensions(&server, project_id);
+
+    // POST with an empty branch list is rejected.
+    let empty_branches = serde_json::json!({
+        "lower_value": true,
+        "upper_value": true,
+        "lower_boundary": false,
+        "upper_boundary": false,
+        "x_axis": "date_time",
+        "window": 2_592_000,
+        "branches": [],
+        "testbeds": [dims.testbed.to_string()],
+        "benchmarks": [dims.benchmark.to_string()],
+        "measures": [dims.measure.to_string()],
+    });
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{project_slug}/plots")))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(&empty_branches)
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+    // Create a valid plot, then PATCH with an empty measure list is rejected.
+    let created = post_plot(
+        &server,
+        &user,
+        project_slug,
+        &serde_json::json!({
+            "lower_value": true,
+            "upper_value": true,
+            "lower_boundary": false,
+            "upper_boundary": false,
+            "x_axis": "date_time",
+            "window": 2_592_000,
+            "branches": [dims.branch1.to_string()],
+            "testbeds": [dims.testbed.to_string()],
+            "benchmarks": [dims.benchmark.to_string()],
+            "measures": [dims.measure.to_string()],
+        }),
+    )
+    .await;
+    let patch = serde_json::json!({ "measures": [] });
+    let resp = server
+        .client
+        .patch(server.api_url(&format!(
+            "/v0/projects/{project_slug}/plots/{}",
+            created.uuid
+        )))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(&patch)
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+// Duplicate UUIDs in a component list collapse to one entry instead of
+// failing with a conflict on the `(plot_id, component_id)` primary key.
+#[tokio::test]
+async fn plot_component_lists_dedupe() {
+    use bencher_api_tests::helpers::get_project_id;
+
+    let server = TestServer::new().await;
+    let user = server
+        .signup("Plot User Dupe", "plotpatchdupe@example.com")
+        .await;
+    let org = server.create_org(&user, "Plot Org Dupe").await;
+    let project = server
+        .create_project(&user, &org, "Plot Project Dupe")
+        .await;
+    let project_slug: &str = project.slug.as_ref();
+    let project_id = get_project_id(&server, project_slug);
+
+    let dims = seed_plot_dimensions(&server, project_id);
+    // POST with a duplicated branch dedupes on create.
+    let created = post_plot(
+        &server,
+        &user,
+        project_slug,
+        &serde_json::json!({
+            "lower_value": true,
+            "upper_value": true,
+            "lower_boundary": false,
+            "upper_boundary": false,
+            "x_axis": "date_time",
+            "window": 2_592_000,
+            "branches": [dims.branch1.to_string(), dims.branch1.to_string()],
+            "testbeds": [dims.testbed.to_string()],
+            "benchmarks": [dims.benchmark.to_string()],
+            "measures": [dims.measure.to_string()],
+        }),
+    )
+    .await;
+    assert_eq!(created.branches, vec![dims.branch1]);
+
+    // PATCH with a duplicated branch dedupes on update.
+    let patch = serde_json::json!({
+        "branches": [dims.branch2.to_string(), dims.branch2.to_string()],
+    });
+    let updated = patch_plot(&server, &user, project_slug, created.uuid, &patch).await;
+    assert_eq!(updated.branches, vec![dims.branch2]);
+}

--- a/lib/bencher_json/src/project/plot.rs
+++ b/lib/bencher_json/src/project/plot.rs
@@ -117,15 +117,19 @@ pub struct JsonPlotPatch {
     pub window: Option<Window>,
     /// The branches to include in the plot.
     /// Replaces the current branches for the plot.
+    /// At least one branch must be specified.
     pub branches: Option<Vec<BranchUuid>>,
     /// The testbeds to include in the plot.
     /// Replaces the current testbeds for the plot.
+    /// At least one testbed must be specified.
     pub testbeds: Option<Vec<TestbedUuid>>,
     /// The benchmarks to include in the plot.
     /// Replaces the current benchmarks for the plot.
+    /// At least one benchmark must be specified.
     pub benchmarks: Option<Vec<BenchmarkUuid>>,
     /// The measures to include in the plot.
     /// Replaces the current measures for the plot.
+    /// At least one measure must be specified.
     pub measures: Option<Vec<MeasureUuid>>,
 }
 
@@ -515,7 +519,9 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_empty_component_list_clears() {
+    fn deserialize_empty_component_list_parses() {
+        // An empty list is valid on the wire; the API layer rejects it (400)
+        // since a plot must have at least one of each dimension.
         let update: JsonUpdatePlot = serde_json::from_str(r#"{"branches": []}"#).unwrap();
         let JsonUpdatePlot::Patch(patch) = update else {
             panic!("expected Patch variant");

--- a/lib/bencher_json/src/project/plot.rs
+++ b/lib/bencher_json/src/project/plot.rs
@@ -102,9 +102,31 @@ pub struct JsonPlotPatch {
     /// Set to `null` to remove the current title.
     /// Maximum length is 64 characters.
     pub title: Option<ResourceName>,
+    /// Display metric lower values.
+    pub lower_value: Option<bool>,
+    /// Display metric upper values.
+    pub upper_value: Option<bool>,
+    /// Display lower boundary limits.
+    pub lower_boundary: Option<bool>,
+    /// Display upper boundary limits.
+    pub upper_boundary: Option<bool>,
+    /// The x-axis to use for the plot.
+    pub x_axis: Option<XAxis>,
     /// The window of time for the plot, in seconds.
     /// Metrics outside of this window will be omitted.
     pub window: Option<Window>,
+    /// The branches to include in the plot.
+    /// Replaces the current branches for the plot.
+    pub branches: Option<Vec<BranchUuid>>,
+    /// The testbeds to include in the plot.
+    /// Replaces the current testbeds for the plot.
+    pub testbeds: Option<Vec<TestbedUuid>>,
+    /// The benchmarks to include in the plot.
+    /// Replaces the current benchmarks for the plot.
+    pub benchmarks: Option<Vec<BenchmarkUuid>>,
+    /// The measures to include in the plot.
+    /// Replaces the current measures for the plot.
+    pub measures: Option<Vec<MeasureUuid>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -112,25 +134,66 @@ pub struct JsonPlotPatch {
 pub struct JsonPlotPatchNull {
     pub index: Option<Index>,
     pub title: (),
+    pub lower_value: Option<bool>,
+    pub upper_value: Option<bool>,
+    pub lower_boundary: Option<bool>,
+    pub upper_boundary: Option<bool>,
+    pub x_axis: Option<XAxis>,
     pub window: Option<Window>,
+    pub branches: Option<Vec<BranchUuid>>,
+    pub testbeds: Option<Vec<TestbedUuid>>,
+    pub benchmarks: Option<Vec<BenchmarkUuid>>,
+    pub measures: Option<Vec<MeasureUuid>>,
 }
 
 impl<'de> Deserialize<'de> for JsonUpdatePlot {
+    #[expect(clippy::too_many_lines, reason = "one match arm per updatable field")]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         const INDEX_FIELD: &str = "index";
         const TITLE_FIELD: &str = "title";
+        const LOWER_VALUE_FIELD: &str = "lower_value";
+        const UPPER_VALUE_FIELD: &str = "upper_value";
+        const LOWER_BOUNDARY_FIELD: &str = "lower_boundary";
+        const UPPER_BOUNDARY_FIELD: &str = "upper_boundary";
+        const X_AXIS_FIELD: &str = "x_axis";
         const WINDOW_FIELD: &str = "window";
-        const FIELDS: &[&str] = &[INDEX_FIELD, TITLE_FIELD, WINDOW_FIELD];
+        const BRANCHES_FIELD: &str = "branches";
+        const TESTBEDS_FIELD: &str = "testbeds";
+        const BENCHMARKS_FIELD: &str = "benchmarks";
+        const MEASURES_FIELD: &str = "measures";
+        const FIELDS: &[&str] = &[
+            INDEX_FIELD,
+            TITLE_FIELD,
+            LOWER_VALUE_FIELD,
+            UPPER_VALUE_FIELD,
+            LOWER_BOUNDARY_FIELD,
+            UPPER_BOUNDARY_FIELD,
+            X_AXIS_FIELD,
+            WINDOW_FIELD,
+            BRANCHES_FIELD,
+            TESTBEDS_FIELD,
+            BENCHMARKS_FIELD,
+            MEASURES_FIELD,
+        ];
 
         #[derive(Deserialize)]
         #[serde(field_identifier, rename_all = "snake_case")]
         enum Field {
             Index,
             Title,
+            LowerValue,
+            UpperValue,
+            LowerBoundary,
+            UpperBoundary,
+            XAxis,
             Window,
+            Branches,
+            Testbeds,
+            Benchmarks,
+            Measures,
         }
 
         struct UpdatePlotVisitor;
@@ -142,13 +205,23 @@ impl<'de> Deserialize<'de> for JsonUpdatePlot {
                 formatter.write_str("JsonUpdatePlot")
             }
 
+            #[expect(clippy::too_many_lines, reason = "one match arm per updatable field")]
             fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
             where
                 V: de::MapAccess<'de>,
             {
                 let mut index = None;
                 let mut title = None;
+                let mut lower_value = None;
+                let mut upper_value = None;
+                let mut lower_boundary = None;
+                let mut upper_boundary = None;
+                let mut x_axis = None;
                 let mut window = None;
+                let mut branches = None;
+                let mut testbeds = None;
+                let mut benchmarks = None;
+                let mut measures = None;
 
                 while let Some(key) = map.next_key()? {
                     match key {
@@ -164,11 +237,65 @@ impl<'de> Deserialize<'de> for JsonUpdatePlot {
                             }
                             title = Some(map.next_value()?);
                         },
+                        Field::LowerValue => {
+                            if lower_value.is_some() {
+                                return Err(de::Error::duplicate_field(LOWER_VALUE_FIELD));
+                            }
+                            lower_value = Some(map.next_value()?);
+                        },
+                        Field::UpperValue => {
+                            if upper_value.is_some() {
+                                return Err(de::Error::duplicate_field(UPPER_VALUE_FIELD));
+                            }
+                            upper_value = Some(map.next_value()?);
+                        },
+                        Field::LowerBoundary => {
+                            if lower_boundary.is_some() {
+                                return Err(de::Error::duplicate_field(LOWER_BOUNDARY_FIELD));
+                            }
+                            lower_boundary = Some(map.next_value()?);
+                        },
+                        Field::UpperBoundary => {
+                            if upper_boundary.is_some() {
+                                return Err(de::Error::duplicate_field(UPPER_BOUNDARY_FIELD));
+                            }
+                            upper_boundary = Some(map.next_value()?);
+                        },
+                        Field::XAxis => {
+                            if x_axis.is_some() {
+                                return Err(de::Error::duplicate_field(X_AXIS_FIELD));
+                            }
+                            x_axis = Some(map.next_value()?);
+                        },
                         Field::Window => {
                             if window.is_some() {
                                 return Err(de::Error::duplicate_field(WINDOW_FIELD));
                             }
                             window = Some(map.next_value()?);
+                        },
+                        Field::Branches => {
+                            if branches.is_some() {
+                                return Err(de::Error::duplicate_field(BRANCHES_FIELD));
+                            }
+                            branches = Some(map.next_value()?);
+                        },
+                        Field::Testbeds => {
+                            if testbeds.is_some() {
+                                return Err(de::Error::duplicate_field(TESTBEDS_FIELD));
+                            }
+                            testbeds = Some(map.next_value()?);
+                        },
+                        Field::Benchmarks => {
+                            if benchmarks.is_some() {
+                                return Err(de::Error::duplicate_field(BENCHMARKS_FIELD));
+                            }
+                            benchmarks = Some(map.next_value()?);
+                        },
+                        Field::Measures => {
+                            if measures.is_some() {
+                                return Err(de::Error::duplicate_field(MEASURES_FIELD));
+                            }
+                            measures = Some(map.next_value()?);
                         },
                     }
                 }
@@ -177,17 +304,44 @@ impl<'de> Deserialize<'de> for JsonUpdatePlot {
                     Some(Some(title)) => Self::Value::Patch(JsonPlotPatch {
                         index,
                         title: Some(title),
+                        lower_value,
+                        upper_value,
+                        lower_boundary,
+                        upper_boundary,
+                        x_axis,
                         window,
+                        branches,
+                        testbeds,
+                        benchmarks,
+                        measures,
                     }),
                     Some(None) => Self::Value::Null(JsonPlotPatchNull {
                         index,
                         title: (),
+                        lower_value,
+                        upper_value,
+                        lower_boundary,
+                        upper_boundary,
+                        x_axis,
                         window,
+                        branches,
+                        testbeds,
+                        benchmarks,
+                        measures,
                     }),
                     None => Self::Value::Patch(JsonPlotPatch {
                         index,
                         title: None,
+                        lower_value,
+                        upper_value,
+                        lower_boundary,
+                        upper_boundary,
+                        x_axis,
                         window,
+                        branches,
+                        testbeds,
+                        benchmarks,
+                        measures,
                     }),
                 })
             }
@@ -269,5 +423,109 @@ mod plot_x_axis {
                 value => Err(Box::new(XAxisError::Invalid(value))),
             }
         }
+    }
+}
+
+#[cfg(all(test, any(feature = "server", feature = "client")))]
+mod tests {
+    use super::{JsonUpdatePlot, XAxis};
+
+    #[test]
+    fn deserialize_empty_is_patch_with_all_none() {
+        let update: JsonUpdatePlot = serde_json::from_str("{}").unwrap();
+        let JsonUpdatePlot::Patch(patch) = update else {
+            panic!("expected Patch variant");
+        };
+        assert!(patch.index.is_none());
+        assert!(patch.title.is_none());
+        assert!(patch.lower_value.is_none());
+        assert!(patch.upper_value.is_none());
+        assert!(patch.lower_boundary.is_none());
+        assert!(patch.upper_boundary.is_none());
+        assert!(patch.x_axis.is_none());
+        assert!(patch.window.is_none());
+        assert!(patch.branches.is_none());
+        assert!(patch.testbeds.is_none());
+        assert!(patch.benchmarks.is_none());
+        assert!(patch.measures.is_none());
+    }
+
+    #[test]
+    fn deserialize_title_string_is_patch() {
+        let update: JsonUpdatePlot = serde_json::from_str(r#"{"title": "My Plot"}"#).unwrap();
+        let JsonUpdatePlot::Patch(patch) = update else {
+            panic!("expected Patch variant");
+        };
+        assert_eq!(patch.title.map(String::from), Some("My Plot".to_owned()));
+    }
+
+    #[test]
+    fn deserialize_null_title_is_null_variant() {
+        let update: JsonUpdatePlot =
+            serde_json::from_str(r#"{"title": null, "lower_value": true}"#).unwrap();
+        let JsonUpdatePlot::Null(patch) = update else {
+            panic!("expected Null variant");
+        };
+        assert_eq!(patch.lower_value, Some(true));
+    }
+
+    #[test]
+    fn deserialize_flags_and_x_axis() {
+        let update: JsonUpdatePlot = serde_json::from_str(
+            r#"{
+                "lower_value": true,
+                "upper_value": false,
+                "lower_boundary": true,
+                "upper_boundary": false,
+                "x_axis": "version"
+            }"#,
+        )
+        .unwrap();
+        let JsonUpdatePlot::Patch(patch) = update else {
+            panic!("expected Patch variant");
+        };
+        assert_eq!(patch.lower_value, Some(true));
+        assert_eq!(patch.upper_value, Some(false));
+        assert_eq!(patch.lower_boundary, Some(true));
+        assert_eq!(patch.upper_boundary, Some(false));
+        assert!(matches!(patch.x_axis, Some(XAxis::Version)));
+    }
+
+    #[test]
+    fn deserialize_component_lists() {
+        let update: JsonUpdatePlot = serde_json::from_str(
+            r#"{
+                "branches": ["11111111-1111-1111-1111-111111111111"],
+                "testbeds": ["22222222-2222-2222-2222-222222222222"],
+                "benchmarks": [
+                    "33333333-3333-3333-3333-333333333333",
+                    "44444444-4444-4444-4444-444444444444"
+                ],
+                "measures": ["55555555-5555-5555-5555-555555555555"]
+            }"#,
+        )
+        .unwrap();
+        let JsonUpdatePlot::Patch(patch) = update else {
+            panic!("expected Patch variant");
+        };
+        assert_eq!(patch.branches.as_ref().map(Vec::len), Some(1));
+        assert_eq!(patch.testbeds.as_ref().map(Vec::len), Some(1));
+        assert_eq!(patch.benchmarks.as_ref().map(Vec::len), Some(2));
+        assert_eq!(patch.measures.as_ref().map(Vec::len), Some(1));
+    }
+
+    #[test]
+    fn deserialize_empty_component_list_clears() {
+        let update: JsonUpdatePlot = serde_json::from_str(r#"{"branches": []}"#).unwrap();
+        let JsonUpdatePlot::Patch(patch) = update else {
+            panic!("expected Patch variant");
+        };
+        assert_eq!(patch.branches.as_ref().map(Vec::len), Some(0));
+    }
+
+    #[test]
+    fn deserialize_duplicate_field_errors() {
+        serde_json::from_str::<JsonUpdatePlot>(r#"{"lower_value": true, "lower_value": false}"#)
+            .unwrap_err();
     }
 }

--- a/lib/bencher_schema/src/model/project/plot/benchmark.rs
+++ b/lib/bencher_schema/src/model/project/plot/benchmark.rs
@@ -4,12 +4,10 @@ use diesel::{BelongingToDsl as _, ExpressionMethods as _, QueryDsl as _, RunQuer
 use dropshot::HttpError;
 
 use crate::{
-    auth_conn,
-    context::{ApiContext, DbConnection},
-    error::{resource_conflict_err, resource_not_found_err},
+    context::DbConnection,
+    error::resource_not_found_err,
     model::project::benchmark::{BenchmarkId, QueryBenchmark},
     schema::plot_benchmark as plot_benchmark_table,
-    write_conn,
 };
 
 use super::{PlotId, QueryPlot};
@@ -84,27 +82,6 @@ impl InsertPlotBenchmark {
             diesel::insert_into(plot_benchmark_table::table)
                 .values(&inserts)
                 .execute(conn)?;
-        }
-        Ok(())
-    }
-
-    pub async fn from_json(
-        context: &ApiContext,
-        plot_id: PlotId,
-        benchmarks: Vec<BenchmarkUuid>,
-    ) -> Result<(), HttpError> {
-        let ranker = RankGenerator::new(benchmarks.len());
-        for (uuid, rank) in benchmarks.into_iter().zip(ranker) {
-            let benchmark_id = QueryBenchmark::get_id(auth_conn!(context), uuid)?;
-            let insert_plot_benchmark = Self {
-                plot_id,
-                benchmark_id,
-                rank,
-            };
-            diesel::insert_into(plot_benchmark_table::table)
-                .values(&insert_plot_benchmark)
-                .execute(write_conn!(context))
-                .map_err(resource_conflict_err!(PlotBenchmark, insert_plot_benchmark))?;
         }
         Ok(())
     }

--- a/lib/bencher_schema/src/model/project/plot/branch.rs
+++ b/lib/bencher_schema/src/model/project/plot/branch.rs
@@ -4,12 +4,10 @@ use diesel::{BelongingToDsl as _, ExpressionMethods as _, QueryDsl as _, RunQuer
 use dropshot::HttpError;
 
 use crate::{
-    auth_conn,
-    context::{ApiContext, DbConnection},
-    error::{resource_conflict_err, resource_not_found_err},
+    context::DbConnection,
+    error::resource_not_found_err,
     model::project::branch::{BranchId, QueryBranch},
     schema::plot_branch as plot_branch_table,
-    write_conn,
 };
 
 use super::{PlotId, QueryPlot};
@@ -85,27 +83,6 @@ impl InsertPlotBranch {
             diesel::insert_into(plot_branch_table::table)
                 .values(&inserts)
                 .execute(conn)?;
-        }
-        Ok(())
-    }
-
-    pub async fn from_json(
-        context: &ApiContext,
-        plot_id: PlotId,
-        branches: Vec<BranchUuid>,
-    ) -> Result<(), HttpError> {
-        let ranker = RankGenerator::new(branches.len());
-        for (uuid, rank) in branches.into_iter().zip(ranker) {
-            let branch_id = QueryBranch::get_id(auth_conn!(context), uuid)?;
-            let insert_plot_branch = Self {
-                plot_id,
-                branch_id,
-                rank,
-            };
-            diesel::insert_into(plot_branch_table::table)
-                .values(&insert_plot_branch)
-                .execute(write_conn!(context))
-                .map_err(resource_conflict_err!(PlotBranch, insert_plot_branch))?;
         }
         Ok(())
     }

--- a/lib/bencher_schema/src/model/project/plot/measure.rs
+++ b/lib/bencher_schema/src/model/project/plot/measure.rs
@@ -4,12 +4,10 @@ use diesel::{BelongingToDsl as _, ExpressionMethods as _, QueryDsl as _, RunQuer
 use dropshot::HttpError;
 
 use crate::{
-    auth_conn,
-    context::{ApiContext, DbConnection},
-    error::{resource_conflict_err, resource_not_found_err},
+    context::DbConnection,
+    error::resource_not_found_err,
     model::project::measure::{MeasureId, QueryMeasure},
     schema::plot_measure as plot_measure_table,
-    write_conn,
 };
 
 use super::{PlotId, QueryPlot};
@@ -84,27 +82,6 @@ impl InsertPlotMeasure {
             diesel::insert_into(plot_measure_table::table)
                 .values(&inserts)
                 .execute(conn)?;
-        }
-        Ok(())
-    }
-
-    pub async fn from_json(
-        context: &ApiContext,
-        plot_id: PlotId,
-        measures: Vec<MeasureUuid>,
-    ) -> Result<(), HttpError> {
-        let ranker = RankGenerator::new(measures.len());
-        for (uuid, rank) in measures.into_iter().zip(ranker) {
-            let measure_id = QueryMeasure::get_id(auth_conn!(context), uuid)?;
-            let insert_plot_measure = Self {
-                plot_id,
-                measure_id,
-                rank,
-            };
-            diesel::insert_into(plot_measure_table::table)
-                .values(&insert_plot_measure)
-                .execute(write_conn!(context))
-                .map_err(resource_conflict_err!(PlotMeasure, insert_plot_measure))?;
         }
         Ok(())
     }

--- a/lib/bencher_schema/src/model/project/plot/mod.rs
+++ b/lib/bencher_schema/src/model/project/plot/mod.rs
@@ -1,5 +1,6 @@
 use bencher_json::{
-    DateTime, Index, JsonNewPlot, JsonPlot, PlotUuid, ResourceName, Window,
+    BenchmarkUuid, BranchUuid, DateTime, Index, JsonNewPlot, JsonPlot, MeasureUuid, PlotUuid,
+    ResourceName, TestbedUuid, Window,
     project::plot::{JsonPlotPatch, JsonPlotPatchNull, JsonUpdatePlot, XAxis},
 };
 use bencher_rank::{Rank, RankGenerator, Ranked};
@@ -17,8 +18,8 @@ use crate::{
     auth_conn,
     context::{ApiContext, DbConnection},
     error::{
-        BencherResource, assert_parentage, resource_conflict_err, resource_conflict_error,
-        resource_not_found_err,
+        BencherResource, assert_parentage, bad_request_error, resource_conflict_err,
+        resource_conflict_error, resource_not_found_err,
     },
     macros::sql::last_insert_rowid,
     schema::{
@@ -40,6 +41,32 @@ use measure::{InsertPlotMeasure, QueryPlotMeasure};
 use testbed::{InsertPlotTestbed, QueryPlotTestbed};
 
 crate::macros::typed_id::typed_id!(PlotId);
+
+/// Resolve component UUIDs to IDs via read connections, scoped to the project
+/// so a foreign or missing UUID is rejected (404) up front. An empty list is
+/// rejected (400): a plot missing any dimension would never render anything.
+/// Duplicate UUIDs collapse to a single ID, preserving first-occurrence order,
+/// since a repeat would violate the `(plot_id, component_id)` primary key on
+/// insert.
+macro_rules! resolve_component_ids {
+    ($context:expr, $query_project:expr, $uuids:expr, $query:ty, $name:literal) => {{
+        let uuids = $uuids;
+        if uuids.is_empty() {
+            return Err(bad_request_error(concat!(
+                "A plot must have at least one ",
+                $name
+            )));
+        }
+        let mut ids = Vec::with_capacity(uuids.len());
+        for uuid in &uuids {
+            let id = <$query>::from_uuid(auth_conn!($context), $query_project.id, *uuid)?.id;
+            if !ids.contains(&id) {
+                ids.push(id);
+            }
+        }
+        ids
+    }};
+}
 
 #[derive(
     Debug, Clone, diesel::Queryable, diesel::Identifiable, diesel::Associations, diesel::Selectable,
@@ -81,23 +108,21 @@ impl QueryPlot {
     fn all_for_project(
         conn: &mut DbConnection,
         query_project: &QueryProject,
-    ) -> Result<Vec<Self>, HttpError> {
+    ) -> diesel::QueryResult<Vec<Self>> {
         Self::belonging_to(query_project)
             .order(plot_table::rank.asc())
             .load::<Self>(conn)
-            .map_err(resource_not_found_err!(Plot, &query_project))
     }
 
     fn all_others_for_project(
         &self,
         conn: &mut DbConnection,
         query_project: &QueryProject,
-    ) -> Result<Vec<Self>, HttpError> {
+    ) -> diesel::QueryResult<Vec<Self>> {
         Self::belonging_to(query_project)
             .filter(plot_table::id.ne(self.id))
             .order(plot_table::rank.asc())
             .load::<Self>(conn)
-            .map_err(resource_not_found_err!(Plot, &query_project))
     }
 
     fn new_rank(
@@ -108,7 +133,8 @@ impl QueryPlot {
         let index = u8::from(index.unwrap_or_default()).into();
 
         // Get the current plots.
-        let plots = QueryPlot::all_for_project(conn, query_project)?;
+        let plots = QueryPlot::all_for_project(conn, query_project)
+            .map_err(resource_not_found_err!(Plot, &query_project))?;
 
         // Try to calculate the rank within the current plots.
         if let Some(rank) = Rank::calculate(&plots, index) {
@@ -141,7 +167,8 @@ impl QueryPlot {
         .map_err(|e| resource_conflict_error(BencherResource::Plot, &plots, e))?;
 
         // Try to calculate the rank within the redistributed plots.
-        let redistributed_plots = QueryPlot::all_for_project(conn, query_project)?;
+        let redistributed_plots = QueryPlot::all_for_project(conn, query_project)
+            .map_err(resource_not_found_err!(Plot, &query_project))?;
         Rank::calculate(&redistributed_plots, index).ok_or_else(|| {
             resource_conflict_error(
                 BencherResource::Plot,
@@ -151,12 +178,16 @@ impl QueryPlot {
         })
     }
 
+    /// Recompute this plot's rank for the requested index, redistributing all
+    /// plot ranks when the index cannot fit between the current ranks.
+    /// Must be called within a write transaction: the redistribution writes
+    /// rely on the caller's transaction for atomicity.
     fn update_rank(
         &self,
         conn: &mut DbConnection,
         query_project: &QueryProject,
         index: Index,
-    ) -> Result<Rank, HttpError> {
+    ) -> diesel::QueryResult<Rank> {
         let index = u8::from(index).into();
 
         // Get the current plots, except for self.
@@ -167,41 +198,34 @@ impl QueryPlot {
             return Ok(rank);
         }
 
-        // If the rank cannot be calculated, then we need to redistribute all the ranks.
-        // Wrap the redistribution in a transaction for atomicity.
+        // If the rank cannot be calculated, then we need to redistribute all the
+        // ranks within the caller's transaction.
         let all_plots = QueryPlot::all_for_project(conn, query_project)?;
         let now = DateTime::now();
-        conn.immediate_transaction(|conn| {
-            let plot_ranker = RankGenerator::new(all_plots.len());
-            for (plot, rank) in all_plots.iter().zip(plot_ranker) {
-                let update_plot = UpdatePlot {
-                    rank: Some(rank),
-                    title: None,
-                    lower_value: None,
-                    upper_value: None,
-                    lower_boundary: None,
-                    upper_boundary: None,
-                    x_axis: None,
-                    window: None,
-                    modified: now,
-                };
-                diesel::update(plot_table::table.filter(plot_table::id.eq(plot.id)))
-                    .set(&update_plot)
-                    .execute(conn)?;
-            }
-            diesel::QueryResult::Ok(())
-        })
-        .map_err(|e| resource_conflict_error(BencherResource::Plot, &all_plots, e))?;
+        let plot_ranker = RankGenerator::new(all_plots.len());
+        for (plot, rank) in all_plots.iter().zip(plot_ranker) {
+            let update_plot = UpdatePlot {
+                rank: Some(rank),
+                title: None,
+                lower_value: None,
+                upper_value: None,
+                lower_boundary: None,
+                upper_boundary: None,
+                x_axis: None,
+                window: None,
+                modified: now,
+            };
+            diesel::update(plot_table::table.filter(plot_table::id.eq(plot.id)))
+                .set(&update_plot)
+                .execute(conn)?;
+        }
 
         // Try to calculate the rank within the redistributed plots.
+        // Redistribution guarantees well-spaced ranks, so this should never fail;
+        // roll back the enclosing transaction if it somehow does.
         let redistributed_plots = self.all_others_for_project(conn, query_project)?;
-        Rank::calculate(&redistributed_plots, index).ok_or_else(|| {
-            resource_conflict_error(
-                BencherResource::Plot,
-                (redistributed_plots, index),
-                "Failed to redistribute plots.",
-            )
-        })
+        Rank::calculate(&redistributed_plots, index)
+            .ok_or(diesel::result::Error::RollbackTransaction)
     }
 
     pub fn into_json_for_project(
@@ -251,14 +275,13 @@ impl QueryPlot {
         })
     }
 
-    #[expect(clippy::too_many_lines, reason = "one branch per updatable component")]
     pub async fn update(
         &self,
         context: &ApiContext,
         query_project: &QueryProject,
         update: JsonUpdatePlot,
     ) -> Result<(), HttpError> {
-        let (
+        let UpdatePlotFields {
             index,
             title,
             lower_value,
@@ -271,125 +294,82 @@ impl QueryPlot {
             testbeds,
             benchmarks,
             measures,
-        ) = match update {
-            JsonUpdatePlot::Patch(patch) => {
-                let JsonPlotPatch {
-                    index,
-                    title,
-                    lower_value,
-                    upper_value,
-                    lower_boundary,
-                    upper_boundary,
-                    x_axis,
-                    window,
-                    branches,
-                    testbeds,
-                    benchmarks,
-                    measures,
-                } = patch;
-                (
-                    index,
-                    title.map(Some),
-                    lower_value,
-                    upper_value,
-                    lower_boundary,
-                    upper_boundary,
-                    x_axis,
-                    window,
-                    branches,
-                    testbeds,
-                    benchmarks,
-                    measures,
-                )
-            },
-            JsonUpdatePlot::Null(patch_null) => {
-                let JsonPlotPatchNull {
-                    index,
-                    title: (),
-                    lower_value,
-                    upper_value,
-                    lower_boundary,
-                    upper_boundary,
-                    x_axis,
-                    window,
-                    branches,
-                    testbeds,
-                    benchmarks,
-                    measures,
-                } = patch_null;
-                (
-                    index,
-                    Some(None),
-                    lower_value,
-                    upper_value,
-                    lower_boundary,
-                    upper_boundary,
-                    x_axis,
-                    window,
-                    branches,
-                    testbeds,
-                    benchmarks,
-                    measures,
-                )
-            },
-        };
+        } = update.into();
 
-        // Phase 1: resolve the provided component UUIDs to IDs, scoped to the
-        // project so a foreign or missing UUID is rejected (404) up front.
+        // Phase 1: resolve the provided component UUIDs to IDs.
         // A `None` list leaves that component unchanged; a `Some` list replaces it.
-        macro_rules! resolve_ids {
-            ($uuids:expr, $query:ty) => {
-                match $uuids {
-                    Some(uuids) => {
-                        let mut ids = Vec::with_capacity(uuids.len());
-                        for uuid in &uuids {
-                            ids.push(
-                                <$query>::from_uuid(auth_conn!(context), query_project.id, *uuid)?
-                                    .id,
-                            );
-                        }
-                        Some(ids)
-                    },
-                    None => None,
-                }
+        let branch_ids = match branches {
+            Some(uuids) => Some(resolve_component_ids!(
+                context,
+                query_project,
+                uuids,
+                QueryBranch,
+                "branch"
+            )),
+            None => None,
+        };
+        let testbed_ids = match testbeds {
+            Some(uuids) => Some(resolve_component_ids!(
+                context,
+                query_project,
+                uuids,
+                QueryTestbed,
+                "testbed"
+            )),
+            None => None,
+        };
+        let benchmark_ids = match benchmarks {
+            Some(uuids) => Some(resolve_component_ids!(
+                context,
+                query_project,
+                uuids,
+                QueryBenchmark,
+                "benchmark"
+            )),
+            None => None,
+        };
+        let measure_ids = match measures {
+            Some(uuids) => Some(resolve_component_ids!(
+                context,
+                query_project,
+                uuids,
+                QueryMeasure,
+                "measure"
+            )),
+            None => None,
+        };
+
+        // Phase 2: apply everything atomically in a single write transaction:
+        // recompute the rank when a new index is requested (which may
+        // redistribute all plot ranks), apply the scalar changeset, and replace
+        // each provided component list (delete then re-insert).
+        write_transaction!(context, |conn| {
+            let rank = if let Some(index) = index {
+                Some(self.update_rank(conn, query_project, index)?)
+            } else {
+                None
             };
-        }
-        let branch_ids = resolve_ids!(branches, QueryBranch);
-        let testbed_ids = resolve_ids!(testbeds, QueryTestbed);
-        let benchmark_ids = resolve_ids!(benchmarks, QueryBenchmark);
-        let measure_ids = resolve_ids!(measures, QueryMeasure);
-
-        // Recompute the rank when a new index is requested (may redistribute atomically).
-        let rank = if let Some(index) = index {
-            Some(self.update_rank(write_conn!(context), query_project, index)?)
-        } else {
-            None
-        };
-
-        let update_plot = UpdatePlot {
-            rank,
-            title,
-            lower_value,
-            upper_value,
-            lower_boundary,
-            upper_boundary,
-            x_axis,
-            window,
-            modified: DateTime::now(),
-        };
-
-        // Phase 2: apply the scalar changeset and replace each provided component
-        // list (delete then re-insert) atomically in a single write transaction.
-        let plot_id = self.id;
-        write_transaction!(context, |conn| Self::apply_update(
-            conn,
-            plot_id,
-            &update_plot,
-            branch_ids.as_deref(),
-            testbed_ids.as_deref(),
-            benchmark_ids.as_deref(),
-            measure_ids.as_deref(),
-        ))
+            let update_plot = UpdatePlot {
+                rank,
+                title,
+                lower_value,
+                upper_value,
+                lower_boundary,
+                upper_boundary,
+                x_axis,
+                window,
+                modified: DateTime::now(),
+            };
+            Self::apply_update(
+                conn,
+                self.id,
+                &update_plot,
+                branch_ids.as_deref(),
+                testbed_ids.as_deref(),
+                benchmark_ids.as_deref(),
+                measure_ids.as_deref(),
+            )
+        })
         .map_err(resource_conflict_err!(Plot, self))?;
 
         Ok(())
@@ -491,28 +471,20 @@ impl InsertPlot {
             measures,
         } = plot;
 
-        // Phase 1: Resolve UUIDs to IDs via read connections, scoped to the
-        // project so a foreign or missing UUID is rejected (404) up front.
-        let mut branch_ids = Vec::with_capacity(branches.len());
-        for uuid in &branches {
-            branch_ids
-                .push(QueryBranch::from_uuid(auth_conn!(context), query_project.id, *uuid)?.id);
-        }
-        let mut testbed_ids = Vec::with_capacity(testbeds.len());
-        for uuid in &testbeds {
-            testbed_ids
-                .push(QueryTestbed::from_uuid(auth_conn!(context), query_project.id, *uuid)?.id);
-        }
-        let mut benchmark_ids = Vec::with_capacity(benchmarks.len());
-        for uuid in &benchmarks {
-            benchmark_ids
-                .push(QueryBenchmark::from_uuid(auth_conn!(context), query_project.id, *uuid)?.id);
-        }
-        let mut measure_ids = Vec::with_capacity(measures.len());
-        for uuid in &measures {
-            measure_ids
-                .push(QueryMeasure::from_uuid(auth_conn!(context), query_project.id, *uuid)?.id);
-        }
+        // Phase 1: Resolve UUIDs to IDs via read connections
+        let branch_ids =
+            resolve_component_ids!(context, query_project, branches, QueryBranch, "branch");
+        let testbed_ids =
+            resolve_component_ids!(context, query_project, testbeds, QueryTestbed, "testbed");
+        let benchmark_ids = resolve_component_ids!(
+            context,
+            query_project,
+            benchmarks,
+            QueryBenchmark,
+            "benchmark"
+        );
+        let measure_ids =
+            resolve_component_ids!(context, query_project, measures, QueryMeasure, "measure");
 
         // Phase 2: Single write_conn + transaction for all writes
         let conn = write_conn!(context);
@@ -568,6 +540,94 @@ pub struct UpdatePlot {
     pub x_axis: Option<XAxis>,
     pub window: Option<Window>,
     pub modified: DateTime,
+}
+
+/// The fields of a [`JsonUpdatePlot`], unified across its `Patch` and `Null`
+/// variants. A `Some(None)` title clears the current title.
+#[expect(
+    clippy::option_option,
+    reason = "None = not specified, Some(None) = explicitly unset"
+)]
+struct UpdatePlotFields {
+    index: Option<Index>,
+    title: Option<Option<ResourceName>>,
+    lower_value: Option<bool>,
+    upper_value: Option<bool>,
+    lower_boundary: Option<bool>,
+    upper_boundary: Option<bool>,
+    x_axis: Option<XAxis>,
+    window: Option<Window>,
+    branches: Option<Vec<BranchUuid>>,
+    testbeds: Option<Vec<TestbedUuid>>,
+    benchmarks: Option<Vec<BenchmarkUuid>>,
+    measures: Option<Vec<MeasureUuid>>,
+}
+
+impl From<JsonUpdatePlot> for UpdatePlotFields {
+    fn from(update: JsonUpdatePlot) -> Self {
+        match update {
+            JsonUpdatePlot::Patch(patch) => {
+                let JsonPlotPatch {
+                    index,
+                    title,
+                    lower_value,
+                    upper_value,
+                    lower_boundary,
+                    upper_boundary,
+                    x_axis,
+                    window,
+                    branches,
+                    testbeds,
+                    benchmarks,
+                    measures,
+                } = patch;
+                Self {
+                    index,
+                    title: title.map(Some),
+                    lower_value,
+                    upper_value,
+                    lower_boundary,
+                    upper_boundary,
+                    x_axis,
+                    window,
+                    branches,
+                    testbeds,
+                    benchmarks,
+                    measures,
+                }
+            },
+            JsonUpdatePlot::Null(patch_null) => {
+                let JsonPlotPatchNull {
+                    index,
+                    title: (),
+                    lower_value,
+                    upper_value,
+                    lower_boundary,
+                    upper_boundary,
+                    x_axis,
+                    window,
+                    branches,
+                    testbeds,
+                    benchmarks,
+                    measures,
+                } = patch_null;
+                Self {
+                    index,
+                    title: Some(None),
+                    lower_value,
+                    upper_value,
+                    lower_boundary,
+                    upper_boundary,
+                    x_axis,
+                    window,
+                    branches,
+                    testbeds,
+                    benchmarks,
+                    measures,
+                }
+            },
+        }
+    }
 }
 
 #[cfg(test)]
@@ -750,12 +810,13 @@ mod tests {
             .first(&mut conn)
             .expect("Failed to get plot");
 
+        // Atomicity comes from the caller's transaction.
         let index = bencher_json::Index::try_from(0u8).unwrap();
-        let _rank = query_p3
-            .update_rank(&mut conn, &project, index)
+        let _rank = conn
+            .immediate_transaction(|conn| query_p3.update_rank(conn, &project, index))
             .expect("Failed to update rank");
 
-        // Redistribution should have happened — all plots now have well-spaced ranks
+        // Redistribution should have happened; all plots now have well-spaced ranks
         let p1_rank = get_plot_rank(&mut conn, p1);
         let p2_rank = get_plot_rank(&mut conn, p2);
         let p3_rank = get_plot_rank(&mut conn, p3);
@@ -766,6 +827,52 @@ mod tests {
         assert_ne!(p1_rank, p3_rank);
         // p1 and p2 should still be ordered
         assert!(p1_rank < p2_rank);
+    }
+
+    #[test]
+    fn update_rank_redistribution_rolls_back_with_transaction() {
+        let mut conn = setup_test_db();
+        let base = create_base_entities(&mut conn);
+        let project = get_query_project(&mut conn, base.project_id);
+
+        // Create 3 plots with adjacent ranks so moving p3 forces redistribution
+        let p1 = create_plot(
+            &mut conn,
+            base.project_id,
+            "00000000-0000-0000-0000-000000000010",
+            100,
+        );
+        let p2 = create_plot(
+            &mut conn,
+            base.project_id,
+            "00000000-0000-0000-0000-000000000011",
+            101,
+        );
+        let p3 = create_plot(
+            &mut conn,
+            base.project_id,
+            "00000000-0000-0000-0000-000000000012",
+            102,
+        );
+
+        let query_p3: QueryPlot = schema::plot::table
+            .filter(schema::plot::id.eq(p3))
+            .select(QueryPlot::as_select())
+            .first(&mut conn)
+            .expect("Failed to get plot");
+
+        // Fail the transaction after the rank redistribution has run.
+        let index = bencher_json::Index::try_from(0u8).unwrap();
+        let result: diesel::QueryResult<()> = conn.immediate_transaction(|conn| {
+            query_p3.update_rank(conn, &project, index)?;
+            Err(diesel::result::Error::RollbackTransaction)
+        });
+        assert!(result.is_err());
+
+        // The redistribution was rolled back with the transaction.
+        assert_eq!(get_plot_rank(&mut conn, p1), 100);
+        assert_eq!(get_plot_rank(&mut conn, p2), 101);
+        assert_eq!(get_plot_rank(&mut conn, p3), 102);
     }
 
     /// Test that a plot and all its components can be inserted in a single transaction.
@@ -1047,30 +1154,6 @@ mod tests {
         assert_eq!(get_plot_benchmarks(&mut conn, plot_id), vec![benchmark]);
         // The originally seeded measure was replaced.
         assert!(!get_plot_measures(&mut conn, plot_id).contains(&measure));
-    }
-
-    #[test]
-    fn apply_update_empty_list_clears_component() {
-        let mut conn = setup_test_db();
-        let base = create_base_entities(&mut conn);
-        let (plot_id, _branch, testbed, _benchmark, _measure) =
-            seed_plot_with_components(&mut conn, base.project_id);
-
-        // An empty branch list clears all branches for the plot.
-        QueryPlot::apply_update(
-            &mut conn,
-            plot_id,
-            &noop_update(),
-            Some(&[]),
-            None,
-            None,
-            None,
-        )
-        .expect("apply_update failed");
-
-        assert!(get_plot_branches(&mut conn, plot_id).is_empty());
-        // Other components are untouched.
-        assert_eq!(get_plot_testbeds(&mut conn, plot_id), vec![testbed]);
     }
 
     #[test]

--- a/lib/bencher_schema/src/model/project/plot/mod.rs
+++ b/lib/bencher_schema/src/model/project/plot/mod.rs
@@ -343,6 +343,7 @@ impl QueryPlot {
         // recompute the rank when a new index is requested (which may
         // redistribute all plot ranks), apply the scalar changeset, and replace
         // each provided component list (delete then re-insert).
+        let modified = context.clock.now();
         write_transaction!(context, |conn| {
             let rank = if let Some(index) = index {
                 Some(self.update_rank(conn, query_project, index)?)
@@ -358,7 +359,7 @@ impl QueryPlot {
                 upper_boundary,
                 x_axis,
                 window,
-                modified: DateTime::now(),
+                modified,
             };
             Self::apply_update(
                 conn,

--- a/lib/bencher_schema/src/model/project/plot/mod.rs
+++ b/lib/bencher_schema/src/model/project/plot/mod.rs
@@ -187,6 +187,7 @@ impl QueryPlot {
         conn: &mut DbConnection,
         query_project: &QueryProject,
         index: Index,
+        modified: DateTime,
     ) -> diesel::QueryResult<Rank> {
         let index = u8::from(index).into();
 
@@ -201,7 +202,6 @@ impl QueryPlot {
         // If the rank cannot be calculated, then we need to redistribute all the
         // ranks within the caller's transaction.
         let all_plots = QueryPlot::all_for_project(conn, query_project)?;
-        let now = DateTime::now();
         let plot_ranker = RankGenerator::new(all_plots.len());
         for (plot, rank) in all_plots.iter().zip(plot_ranker) {
             let update_plot = UpdatePlot {
@@ -213,7 +213,7 @@ impl QueryPlot {
                 upper_boundary: None,
                 x_axis: None,
                 window: None,
-                modified: now,
+                modified,
             };
             diesel::update(plot_table::table.filter(plot_table::id.eq(plot.id)))
                 .set(&update_plot)
@@ -346,7 +346,7 @@ impl QueryPlot {
         let modified = context.clock.now();
         write_transaction!(context, |conn| {
             let rank = if let Some(index) = index {
-                Some(self.update_rank(conn, query_project, index)?)
+                Some(self.update_rank(conn, query_project, index, modified)?)
             } else {
                 None
             };
@@ -814,7 +814,9 @@ mod tests {
         // Atomicity comes from the caller's transaction.
         let index = bencher_json::Index::try_from(0u8).unwrap();
         let _rank = conn
-            .immediate_transaction(|conn| query_p3.update_rank(conn, &project, index))
+            .immediate_transaction(|conn| {
+                query_p3.update_rank(conn, &project, index, DateTime::TEST)
+            })
             .expect("Failed to update rank");
 
         // Redistribution should have happened; all plots now have well-spaced ranks
@@ -865,7 +867,7 @@ mod tests {
         // Fail the transaction after the rank redistribution has run.
         let index = bencher_json::Index::try_from(0u8).unwrap();
         let result: diesel::QueryResult<()> = conn.immediate_transaction(|conn| {
-            query_p3.update_rank(conn, &project, index)?;
+            query_p3.update_rank(conn, &project, index, DateTime::TEST)?;
             Err(diesel::result::Error::RollbackTransaction)
         });
         assert!(result.is_err());

--- a/lib/bencher_schema/src/model/project/plot/mod.rs
+++ b/lib/bencher_schema/src/model/project/plot/mod.rs
@@ -7,8 +7,11 @@ use diesel::{BelongingToDsl as _, ExpressionMethods as _, QueryDsl as _, RunQuer
 use dropshot::HttpError;
 
 use super::{
-    ProjectId, QueryProject, benchmark::QueryBenchmark, branch::QueryBranch, measure::QueryMeasure,
-    testbed::QueryTestbed,
+    ProjectId, QueryProject,
+    benchmark::{BenchmarkId, QueryBenchmark},
+    branch::{BranchId, QueryBranch},
+    measure::{MeasureId, QueryMeasure},
+    testbed::{QueryTestbed, TestbedId},
 };
 use crate::{
     auth_conn,
@@ -18,8 +21,12 @@ use crate::{
         resource_not_found_err,
     },
     macros::sql::last_insert_rowid,
-    schema::plot as plot_table,
-    write_conn,
+    schema::{
+        plot as plot_table, plot_benchmark as plot_benchmark_table,
+        plot_branch as plot_branch_table, plot_measure as plot_measure_table,
+        plot_testbed as plot_testbed_table,
+    },
+    write_conn, write_transaction,
 };
 
 mod benchmark;
@@ -117,6 +124,11 @@ impl QueryPlot {
                 let update_plot = UpdatePlot {
                     rank: Some(rank),
                     title: None,
+                    lower_value: None,
+                    upper_value: None,
+                    lower_boundary: None,
+                    upper_boundary: None,
+                    x_axis: None,
                     window: None,
                     modified: now,
                 };
@@ -165,6 +177,11 @@ impl QueryPlot {
                 let update_plot = UpdatePlot {
                     rank: Some(rank),
                     title: None,
+                    lower_value: None,
+                    upper_value: None,
+                    lower_boundary: None,
+                    upper_boundary: None,
+                    x_axis: None,
                     window: None,
                     modified: now,
                 };
@@ -233,6 +250,194 @@ impl QueryPlot {
             modified,
         })
     }
+
+    #[expect(clippy::too_many_lines, reason = "one branch per updatable component")]
+    pub async fn update(
+        &self,
+        context: &ApiContext,
+        query_project: &QueryProject,
+        update: JsonUpdatePlot,
+    ) -> Result<(), HttpError> {
+        let (
+            index,
+            title,
+            lower_value,
+            upper_value,
+            lower_boundary,
+            upper_boundary,
+            x_axis,
+            window,
+            branches,
+            testbeds,
+            benchmarks,
+            measures,
+        ) = match update {
+            JsonUpdatePlot::Patch(patch) => {
+                let JsonPlotPatch {
+                    index,
+                    title,
+                    lower_value,
+                    upper_value,
+                    lower_boundary,
+                    upper_boundary,
+                    x_axis,
+                    window,
+                    branches,
+                    testbeds,
+                    benchmarks,
+                    measures,
+                } = patch;
+                (
+                    index,
+                    title.map(Some),
+                    lower_value,
+                    upper_value,
+                    lower_boundary,
+                    upper_boundary,
+                    x_axis,
+                    window,
+                    branches,
+                    testbeds,
+                    benchmarks,
+                    measures,
+                )
+            },
+            JsonUpdatePlot::Null(patch_null) => {
+                let JsonPlotPatchNull {
+                    index,
+                    title: (),
+                    lower_value,
+                    upper_value,
+                    lower_boundary,
+                    upper_boundary,
+                    x_axis,
+                    window,
+                    branches,
+                    testbeds,
+                    benchmarks,
+                    measures,
+                } = patch_null;
+                (
+                    index,
+                    Some(None),
+                    lower_value,
+                    upper_value,
+                    lower_boundary,
+                    upper_boundary,
+                    x_axis,
+                    window,
+                    branches,
+                    testbeds,
+                    benchmarks,
+                    measures,
+                )
+            },
+        };
+
+        // Phase 1: resolve the provided component UUIDs to IDs, scoped to the
+        // project so a foreign or missing UUID is rejected (404) up front.
+        // A `None` list leaves that component unchanged; a `Some` list replaces it.
+        macro_rules! resolve_ids {
+            ($uuids:expr, $query:ty) => {
+                match $uuids {
+                    Some(uuids) => {
+                        let mut ids = Vec::with_capacity(uuids.len());
+                        for uuid in &uuids {
+                            ids.push(
+                                <$query>::from_uuid(auth_conn!(context), query_project.id, *uuid)?
+                                    .id,
+                            );
+                        }
+                        Some(ids)
+                    },
+                    None => None,
+                }
+            };
+        }
+        let branch_ids = resolve_ids!(branches, QueryBranch);
+        let testbed_ids = resolve_ids!(testbeds, QueryTestbed);
+        let benchmark_ids = resolve_ids!(benchmarks, QueryBenchmark);
+        let measure_ids = resolve_ids!(measures, QueryMeasure);
+
+        // Recompute the rank when a new index is requested (may redistribute atomically).
+        let rank = if let Some(index) = index {
+            Some(self.update_rank(write_conn!(context), query_project, index)?)
+        } else {
+            None
+        };
+
+        let update_plot = UpdatePlot {
+            rank,
+            title,
+            lower_value,
+            upper_value,
+            lower_boundary,
+            upper_boundary,
+            x_axis,
+            window,
+            modified: DateTime::now(),
+        };
+
+        // Phase 2: apply the scalar changeset and replace each provided component
+        // list (delete then re-insert) atomically in a single write transaction.
+        let plot_id = self.id;
+        write_transaction!(context, |conn| Self::apply_update(
+            conn,
+            plot_id,
+            &update_plot,
+            branch_ids.as_deref(),
+            testbed_ids.as_deref(),
+            benchmark_ids.as_deref(),
+            measure_ids.as_deref(),
+        ))
+        .map_err(resource_conflict_err!(Plot, self))?;
+
+        Ok(())
+    }
+
+    /// Apply a scalar changeset and replace each provided component list within an
+    /// existing transaction. A `None` list leaves that component unchanged; a `Some`
+    /// list replaces it wholesale (delete then re-insert with fresh ranks).
+    fn apply_update(
+        conn: &mut DbConnection,
+        plot_id: PlotId,
+        update_plot: &UpdatePlot,
+        branch_ids: Option<&[BranchId]>,
+        testbed_ids: Option<&[TestbedId]>,
+        benchmark_ids: Option<&[BenchmarkId]>,
+        measure_ids: Option<&[MeasureId]>,
+    ) -> diesel::QueryResult<()> {
+        diesel::update(plot_table::table.filter(plot_table::id.eq(plot_id)))
+            .set(update_plot)
+            .execute(conn)?;
+        if let Some(branch_ids) = branch_ids {
+            diesel::delete(plot_branch_table::table.filter(plot_branch_table::plot_id.eq(plot_id)))
+                .execute(conn)?;
+            InsertPlotBranch::from_resolved(conn, plot_id, branch_ids)?;
+        }
+        if let Some(testbed_ids) = testbed_ids {
+            diesel::delete(
+                plot_testbed_table::table.filter(plot_testbed_table::plot_id.eq(plot_id)),
+            )
+            .execute(conn)?;
+            InsertPlotTestbed::from_resolved(conn, plot_id, testbed_ids)?;
+        }
+        if let Some(benchmark_ids) = benchmark_ids {
+            diesel::delete(
+                plot_benchmark_table::table.filter(plot_benchmark_table::plot_id.eq(plot_id)),
+            )
+            .execute(conn)?;
+            InsertPlotBenchmark::from_resolved(conn, plot_id, benchmark_ids)?;
+        }
+        if let Some(measure_ids) = measure_ids {
+            diesel::delete(
+                plot_measure_table::table.filter(plot_measure_table::plot_id.eq(plot_id)),
+            )
+            .execute(conn)?;
+            InsertPlotMeasure::from_resolved(conn, plot_id, measure_ids)?;
+        }
+        Ok(())
+    }
 }
 
 impl Ranked for QueryPlot {
@@ -286,22 +491,27 @@ impl InsertPlot {
             measures,
         } = plot;
 
-        // Phase 1: Resolve UUIDs to IDs via read connections
+        // Phase 1: Resolve UUIDs to IDs via read connections, scoped to the
+        // project so a foreign or missing UUID is rejected (404) up front.
         let mut branch_ids = Vec::with_capacity(branches.len());
         for uuid in &branches {
-            branch_ids.push(QueryBranch::get_id(auth_conn!(context), *uuid)?);
+            branch_ids
+                .push(QueryBranch::from_uuid(auth_conn!(context), query_project.id, *uuid)?.id);
         }
         let mut testbed_ids = Vec::with_capacity(testbeds.len());
         for uuid in &testbeds {
-            testbed_ids.push(QueryTestbed::get_id(auth_conn!(context), *uuid)?);
+            testbed_ids
+                .push(QueryTestbed::from_uuid(auth_conn!(context), query_project.id, *uuid)?.id);
         }
         let mut benchmark_ids = Vec::with_capacity(benchmarks.len());
         for uuid in &benchmarks {
-            benchmark_ids.push(QueryBenchmark::get_id(auth_conn!(context), *uuid)?);
+            benchmark_ids
+                .push(QueryBenchmark::from_uuid(auth_conn!(context), query_project.id, *uuid)?.id);
         }
         let mut measure_ids = Vec::with_capacity(measures.len());
         for uuid in &measures {
-            measure_ids.push(QueryMeasure::get_id(auth_conn!(context), *uuid)?);
+            measure_ids
+                .push(QueryMeasure::from_uuid(auth_conn!(context), query_project.id, *uuid)?.id);
         }
 
         // Phase 2: Single write_conn + transaction for all writes
@@ -351,57 +561,24 @@ impl InsertPlot {
 pub struct UpdatePlot {
     pub rank: Option<Rank>,
     pub title: Option<Option<ResourceName>>,
+    pub lower_value: Option<bool>,
+    pub upper_value: Option<bool>,
+    pub lower_boundary: Option<bool>,
+    pub upper_boundary: Option<bool>,
+    pub x_axis: Option<XAxis>,
     pub window: Option<Window>,
     pub modified: DateTime,
-}
-
-impl UpdatePlot {
-    pub async fn from_json(
-        context: &ApiContext,
-        query_project: &QueryProject,
-        query_plot: &QueryPlot,
-        update: JsonUpdatePlot,
-    ) -> Result<Self, HttpError> {
-        let (index, title, window) = match update {
-            JsonUpdatePlot::Patch(patch) => {
-                let JsonPlotPatch {
-                    index,
-                    title,
-                    window,
-                } = patch;
-                (index, title.map(Some), window)
-            },
-            JsonUpdatePlot::Null(patch_url) => {
-                let JsonPlotPatchNull {
-                    index,
-                    title: (),
-                    window,
-                } = patch_url;
-                (index, Some(None), window)
-            },
-        };
-        let rank = if let Some(index) = index {
-            Some(query_plot.update_rank(write_conn!(context), query_project, index)?)
-        } else {
-            None
-        };
-        Ok(Self {
-            rank,
-            title,
-            window,
-            modified: DateTime::now(),
-        })
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _, SelectableHelper as _};
 
-    use bencher_json::project::plot::XAxis;
+    use bencher_json::{DateTime, project::plot::XAxis};
 
     use super::{
-        InsertPlot, PlotId, QueryPlot, branch::InsertPlotBranch, measure::InsertPlotMeasure,
+        InsertPlot, PlotId, QueryPlot, UpdatePlot, benchmark::InsertPlotBenchmark,
+        branch::InsertPlotBranch, measure::InsertPlotMeasure, testbed::InsertPlotTestbed,
     };
     use crate::{
         context::DbConnection,
@@ -634,7 +811,7 @@ mod tests {
         // Insert plot + all components in a single transaction
         let plot_id = conn
             .immediate_transaction(|conn| {
-                let timestamp = bencher_json::DateTime::now();
+                let timestamp = DateTime::now();
                 let insert_plot = InsertPlot {
                     uuid: bencher_json::PlotUuid::new(),
                     project_id: base.project_id,
@@ -754,5 +931,185 @@ mod tests {
         assert_eq!(measures.len(), 2);
         assert!(measures.contains(&m1));
         assert!(measures.contains(&m2));
+    }
+
+    /// Build a plot seeded with a single branch, testbed, benchmark, and measure.
+    fn seed_plot_with_components(
+        conn: &mut DbConnection,
+        project_id: ProjectId,
+    ) -> (
+        PlotId,
+        super::BranchId,
+        super::TestbedId,
+        super::BenchmarkId,
+        super::MeasureId,
+    ) {
+        let branch = create_branch_with_head(
+            conn,
+            project_id,
+            "00000000-0000-0000-0000-000000000010",
+            "main",
+            "main",
+            "00000000-0000-0000-0000-000000000011",
+        )
+        .branch_id;
+        let testbed = create_testbed(
+            conn,
+            project_id,
+            "00000000-0000-0000-0000-000000000020",
+            "localhost",
+            "localhost",
+        );
+        let benchmark = create_benchmark(
+            conn,
+            project_id,
+            "00000000-0000-0000-0000-000000000030",
+            "bench1",
+            "bench1",
+        );
+        let measure = create_measure(
+            conn,
+            project_id,
+            "00000000-0000-0000-0000-000000000040",
+            "latency",
+            "latency",
+        );
+        let plot_id = create_plot(
+            conn,
+            project_id,
+            "00000000-0000-0000-0000-000000000050",
+            1_000_000,
+        );
+        InsertPlotBranch::from_resolved(conn, plot_id, &[branch]).expect("seed branch");
+        InsertPlotTestbed::from_resolved(conn, plot_id, &[testbed]).expect("seed testbed");
+        InsertPlotBenchmark::from_resolved(conn, plot_id, &[benchmark]).expect("seed benchmark");
+        InsertPlotMeasure::from_resolved(conn, plot_id, &[measure]).expect("seed measure");
+        (plot_id, branch, testbed, benchmark, measure)
+    }
+
+    /// A changeset that touches only `modified` (all other fields left unchanged).
+    fn noop_update() -> UpdatePlot {
+        UpdatePlot {
+            rank: None,
+            title: None,
+            lower_value: None,
+            upper_value: None,
+            lower_boundary: None,
+            upper_boundary: None,
+            x_axis: None,
+            window: None,
+            modified: DateTime::TEST,
+        }
+    }
+
+    #[test]
+    fn apply_update_replaces_only_provided_components() {
+        let mut conn = setup_test_db();
+        let base = create_base_entities(&mut conn);
+        let (plot_id, branch, testbed, benchmark, measure) =
+            seed_plot_with_components(&mut conn, base.project_id);
+
+        // A second branch and measure to switch to.
+        let branch2 = create_branch_with_head(
+            &mut conn,
+            base.project_id,
+            "00000000-0000-0000-0000-000000000012",
+            "dev",
+            "dev",
+            "00000000-0000-0000-0000-000000000013",
+        )
+        .branch_id;
+        let measure2 = create_measure(
+            &mut conn,
+            base.project_id,
+            "00000000-0000-0000-0000-000000000041",
+            "throughput",
+            "throughput",
+        );
+
+        // Replace branches with [branch, branch2] and measures with [measure2];
+        // leave testbeds and benchmarks untouched (None).
+        QueryPlot::apply_update(
+            &mut conn,
+            plot_id,
+            &noop_update(),
+            Some(&[branch, branch2]),
+            None,
+            None,
+            Some(&[measure2]),
+        )
+        .expect("apply_update failed");
+
+        assert_eq!(get_plot_branches(&mut conn, plot_id), vec![branch, branch2]);
+        assert_eq!(get_plot_measures(&mut conn, plot_id), vec![measure2]);
+        // Unprovided components are left as-is.
+        assert_eq!(get_plot_testbeds(&mut conn, plot_id), vec![testbed]);
+        assert_eq!(get_plot_benchmarks(&mut conn, plot_id), vec![benchmark]);
+        // The originally seeded measure was replaced.
+        assert!(!get_plot_measures(&mut conn, plot_id).contains(&measure));
+    }
+
+    #[test]
+    fn apply_update_empty_list_clears_component() {
+        let mut conn = setup_test_db();
+        let base = create_base_entities(&mut conn);
+        let (plot_id, _branch, testbed, _benchmark, _measure) =
+            seed_plot_with_components(&mut conn, base.project_id);
+
+        // An empty branch list clears all branches for the plot.
+        QueryPlot::apply_update(
+            &mut conn,
+            plot_id,
+            &noop_update(),
+            Some(&[]),
+            None,
+            None,
+            None,
+        )
+        .expect("apply_update failed");
+
+        assert!(get_plot_branches(&mut conn, plot_id).is_empty());
+        // Other components are untouched.
+        assert_eq!(get_plot_testbeds(&mut conn, plot_id), vec![testbed]);
+    }
+
+    #[test]
+    fn apply_update_scalar_flags_and_x_axis() {
+        let mut conn = setup_test_db();
+        let base = create_base_entities(&mut conn);
+        let (plot_id, branch, testbed, benchmark, measure) =
+            seed_plot_with_components(&mut conn, base.project_id);
+
+        // Toggle some flags and the x-axis; leave the rest unchanged (None).
+        let update_plot = UpdatePlot {
+            rank: None,
+            title: None,
+            lower_value: Some(false),
+            upper_value: None,
+            lower_boundary: Some(true),
+            upper_boundary: None,
+            x_axis: Some(XAxis::Version),
+            window: None,
+            modified: DateTime::TEST,
+        };
+        QueryPlot::apply_update(&mut conn, plot_id, &update_plot, None, None, None, None)
+            .expect("apply_update failed");
+
+        let plot: QueryPlot = schema::plot::table
+            .filter(schema::plot::id.eq(plot_id))
+            .select(QueryPlot::as_select())
+            .first(&mut conn)
+            .expect("Failed to get plot");
+        assert!(!plot.lower_value); // set to false
+        assert!(plot.upper_value); // unchanged (create default true)
+        assert!(plot.lower_boundary); // set to true
+        assert!(!plot.upper_boundary); // unchanged (create default false)
+        assert!(matches!(plot.x_axis, XAxis::Version));
+
+        // Components were not provided, so they remain intact.
+        assert_eq!(get_plot_branches(&mut conn, plot_id), vec![branch]);
+        assert_eq!(get_plot_testbeds(&mut conn, plot_id), vec![testbed]);
+        assert_eq!(get_plot_benchmarks(&mut conn, plot_id), vec![benchmark]);
+        assert_eq!(get_plot_measures(&mut conn, plot_id), vec![measure]);
     }
 }

--- a/lib/bencher_schema/src/model/project/plot/testbed.rs
+++ b/lib/bencher_schema/src/model/project/plot/testbed.rs
@@ -4,12 +4,10 @@ use diesel::{BelongingToDsl as _, ExpressionMethods as _, QueryDsl as _, RunQuer
 use dropshot::HttpError;
 
 use crate::{
-    auth_conn,
-    context::{ApiContext, DbConnection},
-    error::{resource_conflict_err, resource_not_found_err},
+    context::DbConnection,
+    error::resource_not_found_err,
     model::project::testbed::{QueryTestbed, TestbedId},
     schema::plot_testbed as plot_testbed_table,
-    write_conn,
 };
 
 use super::{PlotId, QueryPlot};
@@ -84,27 +82,6 @@ impl InsertPlotTestbed {
             diesel::insert_into(plot_testbed_table::table)
                 .values(&inserts)
                 .execute(conn)?;
-        }
-        Ok(())
-    }
-
-    pub async fn from_json(
-        context: &ApiContext,
-        plot_id: PlotId,
-        testbeds: Vec<TestbedUuid>,
-    ) -> Result<(), HttpError> {
-        let ranker = RankGenerator::new(testbeds.len());
-        for (uuid, rank) in testbeds.into_iter().zip(ranker) {
-            let testbed_id = QueryTestbed::get_id(auth_conn!(context), uuid)?;
-            let insert_plot_testbed = Self {
-                plot_id,
-                testbed_id,
-                rank,
-            };
-            diesel::insert_into(plot_testbed_table::table)
-                .values(&insert_plot_testbed)
-                .execute(write_conn!(context))
-                .map_err(resource_conflict_err!(PlotTestbed, insert_plot_testbed))?;
         }
         Ok(())
     }

--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -15066,6 +15066,22 @@
       "JsonPlotPatch": {
         "type": "object",
         "properties": {
+          "benchmarks": {
+            "nullable": true,
+            "description": "The benchmarks to include in the plot. Replaces the current benchmarks for the plot.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BenchmarkUuid"
+            }
+          },
+          "branches": {
+            "nullable": true,
+            "description": "The branches to include in the plot. Replaces the current branches for the plot.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BranchUuid"
+            }
+          },
           "index": {
             "nullable": true,
             "description": "The new index for the plot. Maximum index is 64.",
@@ -15074,6 +15090,32 @@
                 "$ref": "#/components/schemas/Index"
               }
             ]
+          },
+          "lower_boundary": {
+            "nullable": true,
+            "description": "Display lower boundary limits.",
+            "type": "boolean"
+          },
+          "lower_value": {
+            "nullable": true,
+            "description": "Display metric lower values.",
+            "type": "boolean"
+          },
+          "measures": {
+            "nullable": true,
+            "description": "The measures to include in the plot. Replaces the current measures for the plot.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MeasureUuid"
+            }
+          },
+          "testbeds": {
+            "nullable": true,
+            "description": "The testbeds to include in the plot. Replaces the current testbeds for the plot.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TestbedUuid"
+            }
           },
           "title": {
             "nullable": true,
@@ -15084,6 +15126,16 @@
               }
             ]
           },
+          "upper_boundary": {
+            "nullable": true,
+            "description": "Display upper boundary limits.",
+            "type": "boolean"
+          },
+          "upper_value": {
+            "nullable": true,
+            "description": "Display metric upper values.",
+            "type": "boolean"
+          },
           "window": {
             "nullable": true,
             "description": "The window of time for the plot, in seconds. Metrics outside of this window will be omitted.",
@@ -15092,12 +15144,35 @@
                 "$ref": "#/components/schemas/Window"
               }
             ]
+          },
+          "x_axis": {
+            "nullable": true,
+            "description": "The x-axis to use for the plot.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/XAxis"
+              }
+            ]
           }
         }
       },
       "JsonPlotPatchNull": {
         "type": "object",
         "properties": {
+          "benchmarks": {
+            "nullable": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BenchmarkUuid"
+            }
+          },
+          "branches": {
+            "nullable": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BranchUuid"
+            }
+          },
           "index": {
             "nullable": true,
             "allOf": [
@@ -15106,17 +15181,55 @@
               }
             ]
           },
+          "lower_boundary": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "lower_value": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "measures": {
+            "nullable": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MeasureUuid"
+            }
+          },
+          "testbeds": {
+            "nullable": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TestbedUuid"
+            }
+          },
           "title": {
             "type": "string",
             "enum": [
               null
             ]
           },
+          "upper_boundary": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "upper_value": {
+            "nullable": true,
+            "type": "boolean"
+          },
           "window": {
             "nullable": true,
             "allOf": [
               {
                 "$ref": "#/components/schemas/Window"
+              }
+            ]
+          },
+          "x_axis": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/XAxis"
               }
             ]
           }

--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -15068,7 +15068,7 @@
         "properties": {
           "benchmarks": {
             "nullable": true,
-            "description": "The benchmarks to include in the plot. Replaces the current benchmarks for the plot.",
+            "description": "The benchmarks to include in the plot. Replaces the current benchmarks for the plot. At least one benchmark must be specified.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/BenchmarkUuid"
@@ -15076,7 +15076,7 @@
           },
           "branches": {
             "nullable": true,
-            "description": "The branches to include in the plot. Replaces the current branches for the plot.",
+            "description": "The branches to include in the plot. Replaces the current branches for the plot. At least one branch must be specified.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/BranchUuid"
@@ -15103,7 +15103,7 @@
           },
           "measures": {
             "nullable": true,
-            "description": "The measures to include in the plot. Replaces the current measures for the plot.",
+            "description": "The measures to include in the plot. Replaces the current measures for the plot. At least one measure must be specified.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/MeasureUuid"
@@ -15111,7 +15111,7 @@
           },
           "testbeds": {
             "nullable": true,
-            "description": "The testbeds to include in the plot. Replaces the current testbeds for the plot.",
+            "description": "The testbeds to include in the plot. Replaces the current testbeds for the plot. At least one testbed must be specified.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/TestbedUuid"

--- a/services/cli/src/bencher/sub/project/plot/update.rs
+++ b/services/cli/src/bencher/sub/project/plot/update.rs
@@ -1,10 +1,13 @@
 use bencher_client::types::{JsonPlotPatch, JsonPlotPatchNull, JsonUpdatePlot};
-use bencher_json::{Index, PlotUuid, ProjectResourceId, ResourceName, Window};
+use bencher_json::{
+    BenchmarkUuid, BranchUuid, Index, MeasureUuid, PlotUuid, ProjectResourceId, ResourceName,
+    TestbedUuid, Window, project::plot::XAxis,
+};
 
 use crate::{
     CliError,
     bencher::{backend::AuthBackend, sub::SubCmd},
-    parser::project::plot::CliPlotUpdate,
+    parser::project::plot::{CliPlotUpdate, CliXAxis},
 };
 
 #[derive(Debug, Clone)]
@@ -17,28 +20,58 @@ pub struct Update {
     pub plot: PlotUuid,
     pub index: Option<Index>,
     pub title: Option<Option<ResourceName>>,
+    pub lower_value: Option<bool>,
+    pub upper_value: Option<bool>,
+    pub lower_boundary: Option<bool>,
+    pub upper_boundary: Option<bool>,
+    pub x_axis: Option<XAxis>,
     pub window: Option<Window>,
+    pub branches: Option<Vec<BranchUuid>>,
+    pub testbeds: Option<Vec<TestbedUuid>>,
+    pub benchmarks: Option<Vec<BenchmarkUuid>>,
+    pub measures: Option<Vec<MeasureUuid>>,
     pub backend: AuthBackend,
 }
 
 impl TryFrom<CliPlotUpdate> for Update {
     type Error = CliError;
 
-    fn try_from(create: CliPlotUpdate) -> Result<Self, Self::Error> {
+    fn try_from(update: CliPlotUpdate) -> Result<Self, Self::Error> {
         let CliPlotUpdate {
             project,
             plot,
             index,
             title,
+            lower_value,
+            upper_value,
+            lower_boundary,
+            upper_boundary,
+            x_axis,
             window,
+            branches,
+            testbeds,
+            benchmarks,
+            measures,
             backend,
-        } = create;
+        } = update;
         Ok(Self {
             project,
             plot,
             index,
             title: title.map(Into::into),
+            lower_value,
+            upper_value,
+            lower_boundary,
+            upper_boundary,
+            x_axis: x_axis.map(|x_axis| match x_axis {
+                CliXAxis::DateTime => XAxis::DateTime,
+                CliXAxis::Version => XAxis::Version,
+            }),
             window,
+            branches,
+            testbeds,
+            benchmarks,
+            measures,
             backend: backend.try_into()?,
         })
     }
@@ -49,31 +82,78 @@ impl From<Update> for JsonUpdatePlot {
         let Update {
             index,
             title,
+            lower_value,
+            upper_value,
+            lower_boundary,
+            upper_boundary,
+            x_axis,
             window,
+            branches,
+            testbeds,
+            benchmarks,
+            measures,
             ..
         } = update;
+        let index = index.map(Into::into);
+        let x_axis = x_axis.map(|x_axis| match x_axis {
+            XAxis::DateTime => bencher_client::types::XAxis::DateTime,
+            XAxis::Version => bencher_client::types::XAxis::Version,
+        });
+        let window = window.map(Into::into);
+        let branches = branches.map(|branches| branches.into_iter().map(Into::into).collect());
+        let testbeds = testbeds.map(|testbeds| testbeds.into_iter().map(Into::into).collect());
+        let benchmarks =
+            benchmarks.map(|benchmarks| benchmarks.into_iter().map(Into::into).collect());
+        let measures = measures.map(|measures| measures.into_iter().map(Into::into).collect());
         match title {
             Some(Some(title)) => Self {
                 subtype_0: Some(JsonPlotPatch {
-                    index: index.map(Into::into),
+                    index,
                     title: Some(title.into()),
-                    window: window.map(Into::into),
+                    lower_value,
+                    upper_value,
+                    lower_boundary,
+                    upper_boundary,
+                    x_axis,
+                    window,
+                    branches,
+                    testbeds,
+                    benchmarks,
+                    measures,
                 }),
                 subtype_1: None,
             },
             Some(None) => Self {
                 subtype_0: None,
                 subtype_1: Some(JsonPlotPatchNull {
-                    index: index.map(Into::into),
+                    index,
                     title: (),
-                    window: window.map(Into::into),
+                    lower_value,
+                    upper_value,
+                    lower_boundary,
+                    upper_boundary,
+                    x_axis,
+                    window,
+                    branches,
+                    testbeds,
+                    benchmarks,
+                    measures,
                 }),
             },
             None => Self {
                 subtype_0: Some(JsonPlotPatch {
-                    index: index.map(Into::into),
+                    index,
                     title: None,
-                    window: window.map(Into::into),
+                    lower_value,
+                    upper_value,
+                    lower_boundary,
+                    upper_boundary,
+                    x_axis,
+                    window,
+                    branches,
+                    testbeds,
+                    benchmarks,
+                    measures,
                 }),
                 subtype_1: None,
             },

--- a/services/cli/src/parser/project/plot.rs
+++ b/services/cli/src/parser/project/plot.rs
@@ -161,10 +161,50 @@ pub struct CliPlotUpdate {
     #[clap(long)]
     pub title: Option<ElidedOption<ResourceName>>,
 
+    /// Display metric lower values.
+    #[clap(long, value_name = "BOOL")]
+    pub lower_value: Option<bool>,
+
+    /// Display metric upper values.
+    #[clap(long, value_name = "BOOL")]
+    pub upper_value: Option<bool>,
+
+    /// Display lower boundary limits.
+    #[clap(long, value_name = "BOOL")]
+    pub lower_boundary: Option<bool>,
+
+    /// Display upper boundary limits.
+    #[clap(long, value_name = "BOOL")]
+    pub upper_boundary: Option<bool>,
+
+    /// The x-axis to use for the plot.
+    #[clap(long)]
+    pub x_axis: Option<CliXAxis>,
+
     /// The window of time for the plot, in seconds.
     /// Metrics outside of this window will be omitted.
     #[clap(long, value_name = "SECONDS")]
     pub window: Option<Window>,
+
+    /// The branches to include in the plot.
+    /// Replaces the current branches for the plot.
+    #[clap(long, value_name = "BRANCH")]
+    pub branches: Option<Vec<BranchUuid>>,
+
+    /// The testbeds to include in the plot.
+    /// Replaces the current testbeds for the plot.
+    #[clap(long, value_name = "TESTBED")]
+    pub testbeds: Option<Vec<TestbedUuid>>,
+
+    /// The benchmarks to include in the plot.
+    /// Replaces the current benchmarks for the plot.
+    #[clap(long, value_name = "BENCHMARK")]
+    pub benchmarks: Option<Vec<BenchmarkUuid>>,
+
+    /// The measures to include in the plot.
+    /// Replaces the current measures for the plot.
+    #[clap(long, value_name = "MEASURE")]
+    pub measures: Option<Vec<MeasureUuid>>,
 
     #[clap(flatten)]
     pub backend: CliBackend,

--- a/services/cli/src/parser/project/plot.rs
+++ b/services/cli/src/parser/project/plot.rs
@@ -188,21 +188,25 @@ pub struct CliPlotUpdate {
 
     /// The branches to include in the plot.
     /// Replaces the current branches for the plot.
+    /// At least one branch must be specified.
     #[clap(long, value_name = "BRANCH")]
     pub branches: Option<Vec<BranchUuid>>,
 
     /// The testbeds to include in the plot.
     /// Replaces the current testbeds for the plot.
+    /// At least one testbed must be specified.
     #[clap(long, value_name = "TESTBED")]
     pub testbeds: Option<Vec<TestbedUuid>>,
 
     /// The benchmarks to include in the plot.
     /// Replaces the current benchmarks for the plot.
+    /// At least one benchmark must be specified.
     #[clap(long, value_name = "BENCHMARK")]
     pub benchmarks: Option<Vec<BenchmarkUuid>>,
 
     /// The measures to include in the plot.
     /// Replaces the current measures for the plot.
+    /// At least one measure must be specified.
     #[clap(long, value_name = "MEASURE")]
     pub measures: Option<Vec<MeasureUuid>>,
 

--- a/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
+++ b/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
@@ -1,8 +1,8 @@
 ## Pending
 - Add Vitest adapter (`js_vitest`)
 - Add a `database.cache_size` server config option for the writer connection page cache in KiB (default 64 MiB)
-- Update a pinned plot in place: `PATCH /v0/projects/{project}/plots/{plot}` now also accepts the value/boundary toggles, x-axis, and the branches, testbeds, benchmarks, and measures lists (a provided list replaces the current one; duplicates are ignored). The Console adds an "Update Pin" button to the Perf explorer so an edited pinned plot can be saved without re-pinning, and the Pinned tab now shows the loaded plot above the search box with an `x` to deselect it, like the other dimension tabs. `bencher plot update` gains matching flags.
-- The plot endpoints now validate the branch, testbed, benchmark, and measure lists: a UUID that does not belong to the project is rejected with a `404 Not Found`, and an empty list is rejected with a `400 Bad Request`. Previously, `POST /v0/projects/{project}/plots` accepted UUIDs from other projects and empty lists.
+- Update a pinned plot in place with `PATCH /v0/projects/{project}/plots/{plot}`, the Perf explorer "Update Pin" button, or `bencher plot update`
+- Reject plot dimension UUIDs from other projects with a `404 Not Found` and empty dimension lists with a `400 Bad Request`
 
 ## `v0.6.8`
 - **BREAKING CHANGE** Change the default self-hosted API server port from `61016` to the newly [IANA-registered](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=6610) `6610`. Deployments relying on the default now serve the API on `6610`. Update clients, reverse proxies, and `--host`/`BENCHER_HOST` references (Docker Compose, devcontainer, and docs are updated to match). To stay on `61016`, set `server.bind_address` to `0.0.0.0:61016` (or run `bencher up --api-port 61016`).

--- a/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
+++ b/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
@@ -1,7 +1,8 @@
 ## Pending
 - Add Vitest adapter (`js_vitest`)
 - Add a `database.cache_size` server config option for the writer connection page cache in KiB (default 64 MiB)
-- Update a pinned plot in place: `PATCH /v0/projects/{project}/plots/{plot}` now also accepts the value/boundary toggles, x-axis, and the branches, testbeds, benchmarks, and measures lists (a provided list replaces the current one). The Console adds an "Update Pin" button to the Perf explorer so an edited pinned plot can be saved without re-pinning, and `bencher plot update` gains matching flags.
+- Update a pinned plot in place: `PATCH /v0/projects/{project}/plots/{plot}` now also accepts the value/boundary toggles, x-axis, and the branches, testbeds, benchmarks, and measures lists (a provided list replaces the current one; duplicates are ignored). The Console adds an "Update Pin" button to the Perf explorer so an edited pinned plot can be saved without re-pinning, and `bencher plot update` gains matching flags.
+- The plot endpoints now validate the branch, testbed, benchmark, and measure lists: a UUID that does not belong to the project is rejected with a `404 Not Found`, and an empty list is rejected with a `400 Bad Request`. Previously, `POST /v0/projects/{project}/plots` accepted UUIDs from other projects and empty lists.
 
 ## `v0.6.8`
 - **BREAKING CHANGE** Change the default self-hosted API server port from `61016` to the newly [IANA-registered](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=6610) `6610`. Deployments relying on the default now serve the API on `6610`. Update clients, reverse proxies, and `--host`/`BENCHER_HOST` references (Docker Compose, devcontainer, and docs are updated to match). To stay on `61016`, set `server.bind_address` to `0.0.0.0:61016` (or run `bencher up --api-port 61016`).

--- a/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
+++ b/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
@@ -1,7 +1,7 @@
 ## Pending
 - Add Vitest adapter (`js_vitest`)
 - Add a `database.cache_size` server config option for the writer connection page cache in KiB (default 64 MiB)
-- Update a pinned plot in place: `PATCH /v0/projects/{project}/plots/{plot}` now also accepts the value/boundary toggles, x-axis, and the branches, testbeds, benchmarks, and measures lists (a provided list replaces the current one; duplicates are ignored). The Console adds an "Update Pin" button to the Perf explorer so an edited pinned plot can be saved without re-pinning, and `bencher plot update` gains matching flags.
+- Update a pinned plot in place: `PATCH /v0/projects/{project}/plots/{plot}` now also accepts the value/boundary toggles, x-axis, and the branches, testbeds, benchmarks, and measures lists (a provided list replaces the current one; duplicates are ignored). The Console adds an "Update Pin" button to the Perf explorer so an edited pinned plot can be saved without re-pinning, and the Pinned tab now shows the loaded plot above the search box with an `x` to deselect it, like the other dimension tabs. `bencher plot update` gains matching flags.
 - The plot endpoints now validate the branch, testbed, benchmark, and measure lists: a UUID that does not belong to the project is rejected with a `404 Not Found`, and an empty list is rejected with a `400 Bad Request`. Previously, `POST /v0/projects/{project}/plots` accepted UUIDs from other projects and empty lists.
 
 ## `v0.6.8`

--- a/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
+++ b/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
@@ -1,6 +1,7 @@
 ## Pending
 - Add Vitest adapter (`js_vitest`)
 - Add a `database.cache_size` server config option for the writer connection page cache in KiB (default 64 MiB)
+- Update a pinned plot in place: `PATCH /v0/projects/{project}/plots/{plot}` now also accepts the value/boundary toggles, x-axis, and the branches, testbeds, benchmarks, and measures lists (a provided list replaces the current one). The Console adds an "Update Pin" button to the Perf explorer so an edited pinned plot can be saved without re-pinning, and `bencher plot update` gains matching flags.
 
 ## `v0.6.8`
 - **BREAKING CHANGE** Change the default self-hosted API server port from `61016` to the newly [IANA-registered](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=6610) `6610`. Deployments relying on the default now serve the API on `6610`. Update clients, reverse proxies, and `--host`/`BENCHER_HOST` references (Docker Compose, devcontainer, and docs are updated to match). To stay on `61016`, set `server.bind_address` to `0.0.0.0:61016` (or run `bencher up --api-port 61016`).

--- a/services/console/src/components/console/perf/PerfPanel.tsx
+++ b/services/console/src/components/console/perf/PerfPanel.tsx
@@ -725,26 +725,40 @@ const PerfPanel = (props: Props) => {
 		});
 	};
 
-	const [plot_memo, setPlotMemo] = createStore<JsonPlot[]>([]);
+	// The loaded pinned plot; refetched on refresh so an in-place update
+	// (e.g. a new title) is reflected without reloading the page.
 	const selectedPlotFetcher = createMemo(() => {
-		const plot_uuid = plot();
 		return {
 			bencher_valid: bencher_valid(),
 			project_slug: project_slug(),
-			param_uuids: plot_uuid ? [plot_uuid] : [],
+			plot: plot(),
+			refresh: refresh(),
 			token: user?.token,
 		};
 	});
 	const [plot_selected] = createResource<JsonPlot[]>(
 		selectedPlotFetcher,
-		async (fetcher) => getSelected<JsonPlot>(PerfTab.PLOTS, plot_memo, fetcher),
+		async (fetcher) => {
+			if (
+				!fetcher.bencher_valid ||
+				!fetcher.plot ||
+				!fetcher.project_slug ||
+				fetcher.project_slug === "undefined" ||
+				(props.isConsole && !validJwt(fetcher.token)) ||
+				props.isEmbed === true
+			) {
+				return [];
+			}
+			const path = `/v0/projects/${fetcher.project_slug}/plots/${fetcher.plot}`;
+			return await httpGet(props.apiUrl, path, fetcher.token)
+				.then((resp) => [resp?.data as JsonPlot])
+				.catch((error) => {
+					console.error(error);
+					Sentry.captureException(error);
+					return [];
+				});
+		},
 	);
-	createEffect(() => {
-		const data = plot_selected();
-		if (data) {
-			setPlotMemo(data);
-		}
-	});
 	// Drop only the pinned plot association; the rest of the view is untouched.
 	const handlePlotSelected = () => {
 		setSearchParams({
@@ -1284,6 +1298,7 @@ const PerfPanel = (props: Props) => {
 					benchmarks={benchmarks}
 					measures={measures}
 					plot={plot}
+					plot_selected={plot_selected}
 					handleRefresh={handleRefresh}
 				/>
 			</Show>

--- a/services/console/src/components/console/perf/PerfPanel.tsx
+++ b/services/console/src/components/console/perf/PerfPanel.tsx
@@ -961,9 +961,9 @@ const PerfPanel = (props: Props) => {
 	) => {
 		// Uncheck all
 		if (index === undefined) {
+			// Keep PLOT_PARAM so an edited pinned plot can be updated in place.
 			setSearchParams({
 				[REPORT_PARAM]: null,
-				[PLOT_PARAM]: null,
 				[param]: null,
 				[CLEAR_PARAM]: true,
 			});
@@ -983,7 +983,6 @@ const PerfPanel = (props: Props) => {
 			: addToArray(param_array, uuid);
 		setSearchParams({
 			[REPORT_PARAM]: null,
-			[PLOT_PARAM]: null,
 			[param]: arrayToString(array),
 			[CLEAR_PARAM]: true,
 			...customParams?.(checked, i),
@@ -1082,7 +1081,6 @@ const PerfPanel = (props: Props) => {
 		setSearchParams({
 			[REPORT_PARAM]: null,
 			[MEASURES_PARAM]: arrayToString(array),
-			[PLOT_PARAM]: null,
 			[CLEAR_PARAM]: true,
 		});
 	};
@@ -1110,11 +1108,10 @@ const PerfPanel = (props: Props) => {
 
 	const handleStartTime = (date: string) =>
 		setSearchParams({
-			[PLOT_PARAM]: null,
 			[START_TIME_PARAM]: dateToTime(date),
 		});
 	const handleEndTime = (date: string) =>
-		setSearchParams({ [PLOT_PARAM]: null, [END_TIME_PARAM]: dateToTime(date) });
+		setSearchParams({ [END_TIME_PARAM]: dateToTime(date) });
 
 	const handleTab = (tab: PerfTab) => {
 		if (isPerfTab(tab)) {
@@ -1124,7 +1121,7 @@ const PerfPanel = (props: Props) => {
 
 	const handleBool = (param: string, value: boolean) => {
 		if (typeof value === "boolean") {
-			setSearchParams({ [PLOT_PARAM]: null, [param]: value });
+			setSearchParams({ [param]: value });
 		}
 	};
 
@@ -1134,7 +1131,7 @@ const PerfPanel = (props: Props) => {
 
 	const handleXAxis = (x_axis: XAxis) => {
 		if (isXAxis(x_axis)) {
-			setSearchParams({ [PLOT_PARAM]: null, [X_AXIS_PARAM]: x_axis });
+			setSearchParams({ [X_AXIS_PARAM]: x_axis });
 		}
 	};
 

--- a/services/console/src/components/console/perf/PerfPanel.tsx
+++ b/services/console/src/components/console/perf/PerfPanel.tsx
@@ -725,6 +725,33 @@ const PerfPanel = (props: Props) => {
 		});
 	};
 
+	const [plot_memo, setPlotMemo] = createStore<JsonPlot[]>([]);
+	const selectedPlotFetcher = createMemo(() => {
+		const plot_uuid = plot();
+		return {
+			bencher_valid: bencher_valid(),
+			project_slug: project_slug(),
+			param_uuids: plot_uuid ? [plot_uuid] : [],
+			token: user?.token,
+		};
+	});
+	const [plot_selected] = createResource<JsonPlot[]>(
+		selectedPlotFetcher,
+		async (fetcher) => getSelected<JsonPlot>(PerfTab.PLOTS, plot_memo, fetcher),
+	);
+	createEffect(() => {
+		const data = plot_selected();
+		if (data) {
+			setPlotMemo(data);
+		}
+	});
+	// Drop only the pinned plot association; the rest of the view is untouched.
+	const handlePlotSelected = () => {
+		setSearchParams({
+			[PLOT_PARAM]: null,
+		});
+	};
+
 	// Resource tabs data: Reports, Branches, Testbeds, Benchmarks, Plots
 	async function getPerfTab<T>(
 		perfTab: PerfTab,
@@ -1315,6 +1342,7 @@ const PerfPanel = (props: Props) => {
 						branches_selected={branches_selected}
 						testbeds_selected={testbeds_selected}
 						benchmarks_selected={benchmarks_selected}
+						plot_selected={plot_selected}
 						reports_data={reports_data}
 						branches_data={branches_data}
 						testbeds_data={testbeds_data}
@@ -1350,6 +1378,7 @@ const PerfPanel = (props: Props) => {
 						handleBranchSelected={handleBranchSelected}
 						handleTestbedSelected={handleTestbedSelected}
 						handleBenchmarkSelected={handleBenchmarkSelected}
+						handlePlotSelected={handlePlotSelected}
 						handleReportChecked={handleReportChecked}
 						handleBranchChecked={handleBranchChecked}
 						handleTestbedChecked={handleTestbedChecked}

--- a/services/console/src/components/console/perf/header/PerfHeader.tsx
+++ b/services/console/src/components/console/perf/header/PerfHeader.tsx
@@ -108,6 +108,7 @@ const PerfHeader = (props: Props) => {
 				apiUrl={props.apiUrl}
 				user={props.user}
 				project={props.project}
+				isPlotInit={props.isPlotInit}
 				plot={props.plot}
 				lower_value={props.lower_value}
 				upper_value={props.upper_value}

--- a/services/console/src/components/console/perf/header/PerfHeader.tsx
+++ b/services/console/src/components/console/perf/header/PerfHeader.tsx
@@ -11,6 +11,7 @@ import { resourcePath } from "../../../../config/util";
 import {
 	type JsonAuthUser,
 	type JsonPerfQuery,
+	type JsonPlot,
 	type JsonProject,
 	Visibility,
 	type XAxis,
@@ -39,6 +40,7 @@ export interface Props {
 	benchmarks: Accessor<string[]>;
 	measures: Accessor<string[]>;
 	plot: Accessor<undefined | string>;
+	plot_selected: Resource<JsonPlot[]>;
 	handleRefresh: () => void;
 }
 
@@ -110,6 +112,7 @@ const PerfHeader = (props: Props) => {
 				project={props.project}
 				isPlotInit={props.isPlotInit}
 				plot={props.plot}
+				plot_selected={props.plot_selected}
 				lower_value={props.lower_value}
 				upper_value={props.upper_value}
 				lower_boundary={props.lower_boundary}

--- a/services/console/src/components/console/perf/header/PerfHeader.tsx
+++ b/services/console/src/components/console/perf/header/PerfHeader.tsx
@@ -19,6 +19,7 @@ import { isAllowedProjectManage } from "../../../../util/auth";
 import { setPageTitle } from "../../../../util/resource";
 import PinModal from "./PinModal";
 import ShareModal from "./ShareModal";
+import UpdateModal from "./UpdateModal";
 
 export interface Props {
 	isConsole: boolean;
@@ -44,6 +45,7 @@ export interface Props {
 const PerfHeader = (props: Props) => {
 	const [share, setShare] = createSignal(false);
 	const [pin, setPin] = createSignal(false);
+	const [update, setUpdate] = createSignal(false);
 
 	const isAllowedFetcher = createMemo(() => {
 		return {
@@ -59,6 +61,9 @@ const PerfHeader = (props: Props) => {
 			}),
 	);
 	const showPin = createMemo(() => isAllowed() && props.plot() === undefined);
+	const showUpdate = createMemo(
+		() => isAllowed() && props.plot() !== undefined,
+	);
 
 	createEffect(() => {
 		setPageTitle(props.project()?.name);
@@ -98,6 +103,24 @@ const PerfHeader = (props: Props) => {
 				measures={props.measures}
 				pin={pin}
 				setPin={setPin}
+			/>
+			<UpdateModal
+				apiUrl={props.apiUrl}
+				user={props.user}
+				project={props.project}
+				plot={props.plot}
+				lower_value={props.lower_value}
+				upper_value={props.upper_value}
+				lower_boundary={props.lower_boundary}
+				upper_boundary={props.upper_boundary}
+				x_axis={props.x_axis}
+				branches={props.branches}
+				testbeds={props.testbeds}
+				benchmarks={props.benchmarks}
+				measures={props.measures}
+				update={update}
+				setUpdate={setUpdate}
+				handleRefresh={props.handleRefresh}
 			/>
 			<div class="column is-narrow">
 				<nav class="level">
@@ -154,6 +177,25 @@ const PerfHeader = (props: Props) => {
 												<i class="fas fa-thumbtack" />
 											</span>
 											<span>Pin</span>
+										</button>
+									</div>
+								</Show>
+
+								<Show when={showUpdate()}>
+									<div class="level-item">
+										<button
+											class="button is-fullwidth"
+											type="button"
+											title="Update this pinned plot"
+											onMouseDown={(e) => {
+												e.preventDefault();
+												setUpdate(true);
+											}}
+										>
+											<span class="icon">
+												<i class="fas fa-thumbtack" />
+											</span>
+											<span>Update Pin</span>
 										</button>
 									</div>
 								</Show>

--- a/services/console/src/components/console/perf/header/UpdateModal.tsx
+++ b/services/console/src/components/console/perf/header/UpdateModal.tsx
@@ -1,12 +1,28 @@
 import * as Sentry from "@sentry/astro";
-import { type Accessor, createEffect, createSignal } from "solid-js";
+import {
+	type Accessor,
+	type Resource,
+	createEffect,
+	createMemo,
+	createResource,
+	createSignal,
+} from "solid-js";
+import { createStore } from "solid-js/store";
+import { PLOT_FIELDS } from "../../../../config/project/plot";
 import type {
 	JsonAuthUser,
+	JsonPlot,
 	JsonProject,
 	XAxis,
 } from "../../../../types/bencher";
-import { httpPatch } from "../../../../util/http";
+import { httpGet, httpPatch } from "../../../../util/http";
 import { NotifyKind, pageNotify } from "../../../../util/notify";
+import { init_valid } from "../../../../util/valid";
+import Field, { type FieldHandler } from "../../../field/Field";
+import FieldKind from "../../../field/kind";
+
+// Same cap as the Plots page; a project can have at most 64 pinned plots.
+const MAX_PLOTS = 64;
 
 export interface Props {
 	apiUrl: string;
@@ -14,6 +30,7 @@ export interface Props {
 	project: Accessor<undefined | JsonProject>;
 	isPlotInit: Accessor<boolean>;
 	plot: Accessor<undefined | string>;
+	plot_selected: Resource<JsonPlot[]>;
 	lower_value: Accessor<boolean>;
 	upper_value: Accessor<boolean>;
 	lower_boundary: Accessor<boolean>;
@@ -37,23 +54,129 @@ const UpdateModal = (props: Props) => {
 		}
 	});
 
-	const [submitting, setSubmitting] = createSignal(false);
+	const [bencher_valid] = createResource(init_valid);
 
-	const handleSubmit = () => {
-		const projectUuid = props.project()?.uuid;
-		const plotUuid = props.plot();
+	const [form, setForm] = createStore(initForm());
+	const [submitting, setSubmitting] = createSignal(false);
+	const [valid, setValid] = createSignal(true);
+
+	// The loaded pinned plot provides the current title and window.
+	const plot = createMemo(() => props.plot_selected()?.[0]);
+
+	// The full plots list (rank order) provides the current position and total.
+	const plotsFetcher = createMemo(() => {
+		return {
+			project: props.project()?.uuid,
+			plot: props.plot(),
+			update: props.update(),
+			token: props.user?.token,
+		};
+	});
+	const [plots_list] = createResource<JsonPlot[]>(
+		plotsFetcher,
+		async (fetcher) => {
+			if (!fetcher.project || !fetcher.plot) {
+				return [];
+			}
+			return await httpGet(
+				props.apiUrl,
+				`/v0/projects/${fetcher.project}/plots?per_page=${MAX_PLOTS}`,
+				fetcher.token,
+			)
+				.then((resp) => resp?.data as JsonPlot[])
+				.catch((error) => {
+					console.error(error);
+					Sentry.captureException(error);
+					return [];
+				});
+		},
+	);
+	const position = createMemo(() => {
+		const index = (plots_list() ?? []).findIndex(
+			(list_plot) => list_plot.uuid === props.plot(),
+		);
+		return index >= 0 ? index + 1 : null;
+	});
+	const total = createMemo(() => plots_list()?.length ?? 0);
+
+	// Seed the form with the plot's current title, window, and position.
+	// Reseed whenever fresh data arrives while the modal is closed, and seed
+	// late if the modal was opened before the plot data first arrived.
+	// Never reseed while the modal is open and seeded, to keep in-progress edits.
+	const [seeded, setSeeded] = createSignal(false);
+	createEffect(() => {
+		if (props.update() && seeded()) {
+			return;
+		}
+		const current = plot();
+		const currentPosition = position();
+		if (!current || currentPosition === null) {
+			return;
+		}
+		setForm({
+			title: {
+				value: current.title ?? "",
+				valid: true,
+			},
+			window: {
+				value: current.window,
+				valid: true,
+			},
+			index: {
+				value: currentPosition,
+				valid: true,
+			},
+		});
+		setValid(true);
+		setSeeded(true);
+	});
+
+	const isSendable = (): boolean =>
+		!submitting() &&
+		valid() &&
 		// `isPlotInit` is `true` whenever any of the branches, testbeds,
 		// benchmarks, or measures lists is empty. An empty component list is
 		// rejected by the API, since the plot would never render anything.
-		if (props.isPlotInit() || !projectUuid || !plotUuid) {
+		!props.isPlotInit() &&
+		plot() !== undefined &&
+		position() !== null;
+
+	const handleField: FieldHandler = (key, value, valid) => {
+		setForm({
+			...form,
+			[key]: {
+				value,
+				valid,
+			},
+		});
+
+		setValid(validateForm());
+	};
+
+	const validateForm = () =>
+		(form?.title?.valid !== false &&
+			form?.window?.valid &&
+			form?.index?.valid) ??
+		false;
+
+	const handleSubmit = () => {
+		if (!bencher_valid()) {
+			return;
+		}
+		const projectUuid = props.project()?.uuid;
+		const plotUuid = props.plot();
+		if (!isSendable() || !projectUuid || !plotUuid) {
 			return;
 		}
 
 		setSubmitting(true);
 
-		// Title, window, and position are intentionally omitted so they stay
-		// unchanged. Those are edited from the pinned plot's settings.
+		const title = form?.title?.value?.trim();
 		const updatePlot = {
+			// An empty title clears the current title.
+			title: title ? title : null,
+			index: Number.parseInt(form?.index?.value?.toString()) - 1,
+			window: Number.parseInt(form?.window?.value?.toString()),
 			lower_value: props.lower_value(),
 			upper_value: props.upper_value(),
 			lower_boundary: props.lower_boundary(),
@@ -89,7 +212,13 @@ const UpdateModal = (props: Props) => {
 	};
 
 	return (
-		<div class={`modal ${props.update() && "is-active"}`}>
+		<form
+			class={`modal ${props.update() && "is-active"}`}
+			onSubmit={(e) => {
+				e.preventDefault();
+				handleSubmit();
+			}}
+		>
 			<div
 				class="modal-background"
 				onMouseDown={(e) => {
@@ -120,16 +249,56 @@ const UpdateModal = (props: Props) => {
 						benchmarks, measures, and display settings.
 					</p>
 					<br />
-					<p>
-						The plot's title, window, and position are left unchanged. Edit
-						those from the pinned plot's settings.
-					</p>
+					<Field
+						kind={FieldKind.INPUT}
+						fieldKey="title"
+						label={
+							<>
+								Title <small>(optional)</small>
+							</>
+						}
+						value={form?.title?.value}
+						valid={form?.title?.valid}
+						config={PLOT_FIELDS.title}
+						handleField={handleField}
+					/>
+					<hr />
+					<Field
+						kind={FieldKind.PLOT_WINDOW}
+						fieldKey="window"
+						label={
+							<>
+								Time Window <small>(seconds)</small>
+							</>
+						}
+						value={form?.window?.value}
+						valid={form?.window?.valid}
+						config={{
+							help: PLOT_FIELDS.window.help,
+						}}
+						handleField={handleField}
+					/>
+					<hr />
+					<Field
+						kind={FieldKind.PLOT_RANK}
+						fieldKey="index"
+						label="Move Plot"
+						value={form?.index?.value}
+						valid={form?.index?.valid}
+						config={{
+							bottom: "Move to bottom",
+							top: "Move to top",
+							total: total() > 0 ? total() : undefined,
+							help: PLOT_FIELDS.index.help,
+						}}
+						handleField={handleField}
+					/>
 				</section>
 				<footer class="modal-card-foot">
 					<button
 						class="button is-primary is-fullwidth"
 						type="button"
-						disabled={submitting() || props.isPlotInit()}
+						disabled={!isSendable()}
 						onMouseDown={(e) => {
 							e.preventDefault();
 							handleSubmit();
@@ -139,8 +308,25 @@ const UpdateModal = (props: Props) => {
 					</button>
 				</footer>
 			</div>
-		</div>
+		</form>
 	);
+};
+
+const initForm = () => {
+	return {
+		title: {
+			value: "",
+			valid: null,
+		},
+		window: {
+			value: 2419200,
+			valid: true,
+		},
+		index: {
+			value: 1,
+			valid: true,
+		},
+	};
 };
 
 export default UpdateModal;

--- a/services/console/src/components/console/perf/header/UpdateModal.tsx
+++ b/services/console/src/components/console/perf/header/UpdateModal.tsx
@@ -1,0 +1,142 @@
+import * as Sentry from "@sentry/astro";
+import { type Accessor, createEffect, createSignal } from "solid-js";
+import type {
+	JsonAuthUser,
+	JsonProject,
+	XAxis,
+} from "../../../../types/bencher";
+import { httpPatch } from "../../../../util/http";
+import { NotifyKind, pageNotify } from "../../../../util/notify";
+
+export interface Props {
+	apiUrl: string;
+	user: JsonAuthUser;
+	project: Accessor<undefined | JsonProject>;
+	plot: Accessor<undefined | string>;
+	lower_value: Accessor<boolean>;
+	upper_value: Accessor<boolean>;
+	lower_boundary: Accessor<boolean>;
+	upper_boundary: Accessor<boolean>;
+	x_axis: Accessor<XAxis>;
+	branches: Accessor<string[]>;
+	testbeds: Accessor<string[]>;
+	benchmarks: Accessor<string[]>;
+	measures: Accessor<string[]>;
+	update: Accessor<boolean>;
+	setUpdate: (update: boolean) => void;
+	handleRefresh: () => void;
+}
+
+const UpdateModal = (props: Props) => {
+	createEffect(() => {
+		if (props.update()) {
+			document.documentElement.classList.add("is-clipped");
+		} else {
+			document.documentElement.classList.remove("is-clipped");
+		}
+	});
+
+	const [submitting, setSubmitting] = createSignal(false);
+
+	const handleSubmit = () => {
+		const projectUuid = props.project()?.uuid;
+		const plotUuid = props.plot();
+		if (!projectUuid || !plotUuid) {
+			return;
+		}
+
+		setSubmitting(true);
+
+		// Title, window, and position are intentionally omitted so they stay
+		// unchanged. Those are edited from the pinned plot's settings.
+		const updatePlot = {
+			lower_value: props.lower_value(),
+			upper_value: props.upper_value(),
+			lower_boundary: props.lower_boundary(),
+			upper_boundary: props.upper_boundary(),
+			x_axis: props.x_axis(),
+			branches: props.branches(),
+			testbeds: props.testbeds(),
+			benchmarks: props.benchmarks(),
+			measures: props.measures(),
+		};
+
+		httpPatch(
+			props.apiUrl,
+			`/v0/projects/${projectUuid}/plots/${plotUuid}`,
+			props.user?.token,
+			updatePlot,
+		)
+			.then(() => {
+				setSubmitting(false);
+				props.setUpdate(false);
+				props.handleRefresh();
+				pageNotify(NotifyKind.OK, "Pinned plot updated!");
+			})
+			.catch((error) => {
+				setSubmitting(false);
+				console.error(error);
+				Sentry.captureException(error);
+				pageNotify(
+					NotifyKind.ERROR,
+					`Failed to update plot: ${error?.response?.data?.message}`,
+				);
+			});
+	};
+
+	return (
+		<div class={`modal ${props.update() && "is-active"}`}>
+			<div
+				class="modal-background"
+				onMouseDown={(e) => {
+					e.preventDefault();
+					props.setUpdate(false);
+				}}
+				onKeyDown={(e) => {
+					e.preventDefault();
+					props.setUpdate(false);
+				}}
+			/>
+			<div class="modal-card">
+				<header class="modal-card-head">
+					<p class="modal-card-title">Update pinned plot</p>
+					<button
+						class="delete"
+						type="button"
+						aria-label="close"
+						onMouseDown={(e) => {
+							e.preventDefault();
+							props.setUpdate(false);
+						}}
+					/>
+				</header>
+				<section class="modal-card-body">
+					<p>
+						Update this pinned plot to match your current branches, testbeds,
+						benchmarks, measures, and display settings.
+					</p>
+					<br />
+					<p>
+						The plot's title, window, and position are left unchanged. Edit
+						those from the pinned plot's settings.
+					</p>
+				</section>
+				<footer class="modal-card-foot">
+					<button
+						class="button is-primary is-fullwidth"
+						type="button"
+						disabled={submitting()}
+						onMouseDown={(e) => {
+							e.preventDefault();
+							handleSubmit();
+						}}
+					>
+						Update
+					</button>
+				</footer>
+			</div>
+		</div>
+	);
+};
+
+export default UpdateModal;

--- a/services/console/src/components/console/perf/header/UpdateModal.tsx
+++ b/services/console/src/components/console/perf/header/UpdateModal.tsx
@@ -12,6 +12,7 @@ export interface Props {
 	apiUrl: string;
 	user: JsonAuthUser;
 	project: Accessor<undefined | JsonProject>;
+	isPlotInit: Accessor<boolean>;
 	plot: Accessor<undefined | string>;
 	lower_value: Accessor<boolean>;
 	upper_value: Accessor<boolean>;
@@ -41,7 +42,8 @@ const UpdateModal = (props: Props) => {
 	const handleSubmit = () => {
 		const projectUuid = props.project()?.uuid;
 		const plotUuid = props.plot();
-		if (!projectUuid || !plotUuid) {
+		// An empty component list would leave a pinned plot that renders nothing.
+		if (props.isPlotInit() || !projectUuid || !plotUuid) {
 			return;
 		}
 
@@ -125,7 +127,7 @@ const UpdateModal = (props: Props) => {
 					<button
 						class="button is-primary is-fullwidth"
 						type="button"
-						disabled={submitting()}
+						disabled={submitting() || props.isPlotInit()}
 						onMouseDown={(e) => {
 							e.preventDefault();
 							handleSubmit();

--- a/services/console/src/components/console/perf/header/UpdateModal.tsx
+++ b/services/console/src/components/console/perf/header/UpdateModal.tsx
@@ -42,7 +42,9 @@ const UpdateModal = (props: Props) => {
 	const handleSubmit = () => {
 		const projectUuid = props.project()?.uuid;
 		const plotUuid = props.plot();
-		// An empty component list would leave a pinned plot that renders nothing.
+		// `isPlotInit` is `true` whenever any of the branches, testbeds,
+		// benchmarks, or measures lists is empty. An empty component list is
+		// rejected by the API, since the plot would never render anything.
 		if (props.isPlotInit() || !projectUuid || !plotUuid) {
 			return;
 		}

--- a/services/console/src/components/console/perf/plot/tab/PlotTab.tsx
+++ b/services/console/src/components/console/perf/plot/tab/PlotTab.tsx
@@ -42,6 +42,7 @@ export interface Props {
 	branches_selected: Resource<JsonBranch[]>;
 	testbeds_selected: Resource<JsonTestbed[]>;
 	benchmarks_selected: Resource<JsonBenchmark[]>;
+	plot_selected: Resource<JsonPlot[]>;
 	// Tab data
 	reports_data: Resource<JsonReport>;
 	branches_data: Resource<JsonBranch>;
@@ -83,6 +84,7 @@ export interface Props {
 	handleBranchSelected: (uuid: string) => void;
 	handleTestbedSelected: (uuid: string) => void;
 	handleBenchmarkSelected: (uuid: string) => void;
+	handlePlotSelected: () => void;
 	// Handle checked
 	handleReportChecked: (index: number) => void;
 	handleBranchChecked: (index: undefined | number) => void;
@@ -350,6 +352,7 @@ const PlotTab = (props: Props) => {
 				branches_selected={props.branches_selected}
 				testbeds_selected={props.testbeds_selected}
 				benchmarks_selected={props.benchmarks_selected}
+				plot_selected={props.plot_selected}
 				reports_tab={props.reports_tab}
 				branches_tab={props.branches_tab}
 				testbeds_tab={props.testbeds_tab}
@@ -366,6 +369,7 @@ const PlotTab = (props: Props) => {
 				handleBranchSelected={props.handleBranchSelected}
 				handleTestbedSelected={props.handleTestbedSelected}
 				handleBenchmarkSelected={props.handleBenchmarkSelected}
+				handlePlotSelected={props.handlePlotSelected}
 				handlePage={handlePage}
 				handleChecked={handleChecked}
 				handleSearch={handleSearch as FieldHandler}

--- a/services/console/src/components/console/perf/plot/tab/PlotsTab.tsx
+++ b/services/console/src/components/console/perf/plot/tab/PlotsTab.tsx
@@ -1,4 +1,12 @@
-import { type Accessor, For, Match, Show, Switch, createMemo } from "solid-js";
+import {
+	type Accessor,
+	For,
+	Match,
+	type Resource,
+	Show,
+	Switch,
+	createMemo,
+} from "solid-js";
 import type { PerfTab } from "../../../../../config/types";
 import { fmtDateTime } from "../../../../../config/util";
 import type { JsonPlot } from "../../../../../types/bencher";
@@ -13,14 +21,25 @@ const PlotsTab = (props: {
 	isConsole: boolean;
 	loading: Accessor<boolean>;
 	tab: Accessor<PerfTab>;
+	plot_selected: Resource<JsonPlot[]>;
 	tabList: Accessor<TabList<JsonPlot>>;
 	per_page: Accessor<number>;
 	search: Accessor<undefined | string>;
+	handleSelected: () => void;
 	handleChecked: (index: number, slug?: string) => void;
 	handleSearch: FieldHandler;
 }) => {
 	return (
 		<>
+			<Show when={(props.plot_selected()?.length ?? 0) > 0}>
+				<PlotSelected
+					project_slug={props.project_slug}
+					isConsole={props.isConsole}
+					tab={props.tab}
+					plot_selected={props.plot_selected}
+					handleSelected={props.handleSelected}
+				/>
+			</Show>
 			<div class="panel-block is-block">
 				<Field
 					kind={FieldKind.SEARCH}
@@ -75,6 +94,55 @@ const PlotsTab = (props: {
 	);
 };
 
+const PlotSelected = (props: {
+	project_slug: Accessor<undefined | string>;
+	isConsole: boolean;
+	tab: Accessor<PerfTab>;
+	plot_selected: Resource<JsonPlot[]>;
+	handleSelected: () => void;
+}) => {
+	return (
+		<For each={props.plot_selected()}>
+			{(plot) => (
+				<div class="panel-block is-block">
+					<div class="level">
+						<div class="level-left">
+							<div class="level-item">
+								<div class="columns is-vcentered is-mobile">
+									<div class="column is-narrow">
+										<button
+											class="delete"
+											type="button"
+											title={`Remove ${plotTitle(plot)} from ${props.tab()}`}
+											onMouseDown={(_e) => props.handleSelected()}
+										/>
+									</div>
+									<div class="column">
+										<small style="word-break: break-word;">
+											{plotTitle(plot)}
+										</small>
+									</div>
+								</div>
+							</div>
+						</div>
+						<Show when={props.isConsole}>
+							<div class="level-right">
+								<div class="level-item">
+									<ViewPlotButton
+										project_slug={props.project_slug}
+										tab={props.tab}
+										plot={() => plot}
+									/>
+								</div>
+							</div>
+						</Show>
+					</div>
+				</div>
+			)}
+		</For>
+	);
+};
+
 const PlotRow = (props: {
 	theme: Accessor<Theme>;
 	isConsole: boolean;
@@ -102,8 +170,7 @@ const PlotRow = (props: {
 							</div>
 							<div class="column">
 								<small style="word-break: break-word;">
-									{plot().title ??
-										`Untitled Plot (${fmtDateTime(plot().created)})`}
+									{plotTitle(plot())}
 								</small>
 							</div>
 						</div>
@@ -124,6 +191,9 @@ const PlotRow = (props: {
 		</div>
 	);
 };
+
+const plotTitle = (plot: JsonPlot) =>
+	plot?.title ?? `Untitled Plot (${fmtDateTime(plot?.created)})`;
 
 const ViewPlotButton = (props: {
 	project_slug: Accessor<undefined | string>;

--- a/services/console/src/components/console/perf/plot/tab/Tab.tsx
+++ b/services/console/src/components/console/perf/plot/tab/Tab.tsx
@@ -36,6 +36,7 @@ const Tab = (props: {
 	branches_selected: Resource<JsonBranch[]>;
 	testbeds_selected: Resource<JsonTestbed[]>;
 	benchmarks_selected: Resource<JsonBenchmark[]>;
+	plot_selected: Resource<JsonPlot[]>;
 	// Tabs
 	reports_tab: TabList<JsonReport>;
 	branches_tab: TabList<JsonBranch>;
@@ -54,6 +55,7 @@ const Tab = (props: {
 	handleBranchSelected: (uuid: string) => void;
 	handleTestbedSelected: (uuid: string) => void;
 	handleBenchmarkSelected: (uuid: string) => void;
+	handlePlotSelected: () => void;
 	handlePage: (page: number) => void;
 	handleChecked: (index?: number, slug?: string) => void;
 	handleSearch: FieldHandler;
@@ -187,9 +189,11 @@ const Tab = (props: {
 					isConsole={props.isConsole}
 					loading={props.loading}
 					tab={props.tab}
+					plot_selected={props.plot_selected}
 					tabList={tabList as Accessor<TabList<JsonPlot>>}
 					per_page={props.per_page}
 					search={props.search}
+					handleSelected={props.handlePlotSelected}
 					handleChecked={props.handleChecked}
 					handleSearch={props.handleSearch}
 				/>


### PR DESCRIPTION
## Summary

Today you cannot meaningfully update a pinned plot. The `PATCH /v0/projects/{project}/plots/{plot}` endpoint existed but could only change `title`, `window`, and `index`, so to change what a plot actually shows (branches, testbeds, benchmarks, measures, x-axis, or the value/boundary toggles) you had to open it in the Perf explorer, re-pin a new plot, and delete the old one.

This extends the update path across every layer so an existing pinned plot can be edited in place.

## Changes

**Backend** (all new fields optional; `None` = leave unchanged, so existing `index`/`title`/`window` callers are untouched):
- `bencher_json`: add the value/boundary toggles, `x_axis`, and `branches`/`testbeds`/`benchmarks`/`measures` to `JsonPlotPatch`/`JsonPlotPatchNull` and the hand-written `Deserialize`.
- `bencher_schema`: add `QueryPlot::update`, which resolves the provided component UUIDs scoped to the project, then applies the scalar changeset, any rank move (including redistribution), and each provided component list replacement (delete + re-insert) atomically in a single write transaction via a unit-testable `apply_update` helper. A provided list replaces the current one wholesale.
- Component list validation, shared by `POST` and `PATCH`: a UUID that does not belong to the project is rejected with a `404 Not Found`, an empty list is rejected with a `400 Bad Request` (a plot missing any dimension would never render anything), and duplicate UUIDs are deduped preserving first-occurrence order. Previously `POST /v0/projects/{project}/plots` accepted foreign UUIDs and empty lists.
- `api_projects`: `patch_inner` delegates to `QueryPlot::update`.
- Regenerate `services/api/openapi.json`.

**CLI**: `bencher plot update` gains `--lower-value/--upper-value/--lower-boundary/--upper-boundary`, `--x-axis`, and `--branches/--testbeds/--benchmarks/--measures`.

**Console**: the Perf explorer's edit handlers no longer drop the loaded-plot association, so an "Update Pin" button (new `UpdateModal`) appears whenever a pinned plot is loaded; it saves the current selections back to that plot and presents the plot's current title, time window, and position for editing in place (disabled while any dimension is empty). The Pinned tab shows the loaded plot above its search box with an `x` to deselect it, matching the other dimension tabs. "Clear" still gives a fresh view for creating a brand-new plot.

Also adds the "Less is more / KISS" core axiom to `CLAUDE.md`.

## Testing

- `bencher_json`: 7 deserialization tests (absent vs null title, flags, x-axis, component lists, empty list, duplicate-field error).
- `bencher_schema`: `apply_update` tests (replace only provided components, scalar flags + x-axis) and rank tests (redistribution, rollback with the enclosing transaction).
- `api_projects`: 6 HTTP integration tests (full-config PATCH, unknown component 404, null title clear, index + components combined, empty list 400 on POST and PATCH, duplicate UUID dedupe).
- `cargo clippy --no-deps --all-targets --all-features -- -Dwarnings` clean, `cargo fmt --check` clean, `cargo check --no-default-features` passes.
- Console: Biome clean, `vitest` green; `bencher plot update --help` shows the new flags.


