### PR TITLE
Generate a final invoice for metered usage on subscription cancel

### DIFF
--- a/plus/bencher_billing/src/biller.rs
+++ b/plus/bencher_billing/src/biller.rs
@@ -982,13 +982,19 @@ impl Biller {
     }
 
     /// Immediately cancel a metered subscription. Used by the admin-only DELETE
-    /// path; the organization downgrades to Free right away.
+    /// path; the organization downgrades to Free right away. `invoice_now`
+    /// generates a final invoice for any un-invoiced metered usage; a bare
+    /// cancel would silently discard all usage accrued since the last invoice.
     pub async fn cancel_metered_subscription(
         &self,
         metered_plan_id: &MeteredPlanId,
     ) -> Result<Subscription, BillingError> {
         let subscription_id: SubscriptionId = metered_plan_id.as_ref().into();
-        self.cancel_subscription(&subscription_id).await
+        CancelSubscription::new(subscription_id)
+            .invoice_now(true)
+            .send(&self.client)
+            .await
+            .map_err(Into::into)
     }
 
     /// Schedule (`true`) or clear (`false`) a metered subscription's
@@ -1074,6 +1080,7 @@ mod tests {
     use literally::hmap;
     use pretty_assertions::assert_eq;
     use stripe_shared::{CustomerId, PaymentMethodId};
+    use stripe_types::Expandable;
 
     use rustls::crypto::aws_lc_rs::default_provider;
 
@@ -1334,12 +1341,24 @@ mod tests {
             .await
             .unwrap();
         assert!(!resumed.cancel_at_period_end);
+        // Snapshot the latest invoice just before cancellation. Only the id is kept
+        // across the awaits below; holding the whole `Subscription` would bloat the
+        // future (`clippy::large_futures`).
+        let pre_cancel_invoice_id = resumed.latest_invoice.map(Expandable::into_id);
 
-        // DELETE path: immediate cancel.
-        biller
+        // DELETE path: immediate cancel. `invoice_now` generates a final invoice
+        // so the usage recorded above is billed instead of discarded.
+        let final_invoice_id = biller
             .cancel_metered_subscription(&subscription_id.parse().unwrap())
             .await
-            .unwrap();
+            .unwrap()
+            .latest_invoice
+            .map(Expandable::into_id)
+            .expect("final invoice for un-invoiced metered usage");
+        // The final invoice must be new: distinct from the pre-cancel one when that
+        // exists, and its mere presence (via `expect` above) proves generation when
+        // no prior invoice existed.
+        assert_ne!(Some(final_invoice_id), pre_cancel_invoice_id);
         let billing = biller
             .get_metered_plan_billing(metered_plan_id)
             .await
@@ -1495,9 +1514,7 @@ mod tests {
             lookup_key: None,
             metadata: HashMap::new(),
             nickname: None,
-            product: stripe_types::Expandable::Id(
-                "prod_test".parse::<stripe_shared::ProductId>().unwrap(),
-            ),
+            product: Expandable::Id("prod_test".parse::<stripe_shared::ProductId>().unwrap()),
             recurring: None,
             tax_behavior: None,
             tiers: None,


### PR DESCRIPTION
## Problem

`Biller::cancel_metered_subscription` sent a bare `CancelSubscription` request. Stripe's `invoice_now` flag defaults to `false`, so an immediate cancel silently discarded any metered usage accrued since the last invoice. The customer was never billed for their final usage on either path that cancels a metered subscription: the admin plan DELETE endpoint and organization deletion.

## Fix

`cancel_metered_subscription` now cancels with `invoice_now(true)`, so Stripe generates a final invoice for any un-invoiced metered usage on the way out.

The licensed cancel path is unchanged: licensed plans bill upfront, so there is no un-invoiced usage to lose. Prorations stay off (`prorate` defaults to `false`) on both paths, so bare metal usage is billed in full and never prorated.

## Tests

The `metered_subscription` lifecycle test records usage before exercising the DELETE path. It now captures the creation-time invoice id and asserts that the cancel returns a subscription whose `latest_invoice` is present and different, verifying that the final invoice was generated. The `resubscribe_has_no_trial` helper cancels with no recorded usage, so the gated Stripe test also covers the nothing-to-bill case.

Only the invoice ids are held across await points in the test; keeping the full `Subscription` objects alive tripped `clippy::large_futures`.
