### PR TITLE
Add Claude Code plugin with Bencher skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "bencher",
+  "owner": { "name": "Bencher" },
+  "description": "Bencher continuous benchmarking CLI",
+  "plugins": [
+    {
+      "name": "bencher",
+      "source": "./",
+      "description": "Bencher continuous benchmarking CLI",
+      "author": { "name": "Bencher" },
+      "homepage": "https://bencher.dev",
+      "repository": "https://github.com/bencherdev/bencher"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bencher",
   "description": "Bencher continuous benchmarking CLI",
-  "version": "0.6.4",
+  "version": "0.6.8",
   "author": { "name": "Bencher" }
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "bencher",
+  "description": "Bencher continuous benchmarking CLI",
+  "version": "0.6.4",
+  "author": { "name": "Bencher" }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ please alert the developer working with you and indicate that this is the case b
 Bencher is a continuous benchmarking platform that detects and prevents performance regressions.
 
 - **Bencher API Server** (`services/api`) - see [`services/api/CLAUDE.md`](services/api/CLAUDE.md)
-- **`bencher` CLI** (`services/cli`) - CLI for the REST API
+- **`bencher` CLI** (`services/cli`) - see [`services/cli/CLAUDE.md`](services/cli/CLAUDE.md)
 - **Bencher Console** (`services/console`) - see [`services/console/CLAUDE.md`](services/console/CLAUDE.md)
 - **Bare Metal `runner`** (`services/runner`) - Bare Metal benchmark runner
 

--- a/scripts/tag.sh
+++ b/scripts/tag.sh
@@ -9,6 +9,9 @@ git add ./services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
 sed -i '' "s/version: [0-9]*\.[0-9]*\.[0-9]*/version: $VERSION/" ./README.md
 git add ./README.md
 
+sed -i '' "s/\"version\": \"[0-9]*\.[0-9]*\.[0-9]*\"/\"version\": \"$VERSION\"/" ./.claude-plugin/plugin.json
+git add ./.claude-plugin/plugin.json
+
 # Generate the API docs from the server and the types for the UI
 cargo gen-types
 git add ./services/api/openapi.json

--- a/services/cli/CLAUDE.md
+++ b/services/cli/CLAUDE.md
@@ -1,0 +1,12 @@
+# Bencher CLI CLAUDE.md
+
+## Skill Sync
+
+When updating the `bencher run` CLI (adding, removing, or renaming flags, adapters, threshold models, or subcommands), also update the Bencher skill files in `skills/bencher/`. The key files to check:
+
+- `skills/bencher/reference.md` - Complete flag and command reference
+- `skills/bencher/local-runs.md` - Adapter table and run examples
+- `skills/bencher/thresholds.md` - Threshold model table and flag docs
+- `skills/bencher/bare-metal.md` - Bare metal flags and examples
+- `skills/bencher/ci.md` - CI integration examples
+- `skills/bencher/SKILL.md` - Auth docs and common options

--- a/services/console/src/chunks/docs-how-to/install-cli/cli-claude-code.mdx
+++ b/services/console/src/chunks/docs-how-to/install-cli/cli-claude-code.mdx
@@ -1,0 +1,4 @@
+```sh
+/plugin marketplace add bencherdev/bencher
+/plugin install bencher
+```

--- a/services/console/src/chunks/docs-how-to/install-cli/cli-claude-code.mdx
+++ b/services/console/src/chunks/docs-how-to/install-cli/cli-claude-code.mdx
@@ -1,4 +1,4 @@
 ```sh
 /plugin marketplace add bencherdev/bencher
-/plugin install bencher
+/plugin install bencher@bencher
 ```

--- a/services/console/src/chunks/docs-how-to/install-cli/de/cli-install-claude-code.mdx
+++ b/services/console/src/chunks/docs-how-to/install-cli/de/cli-install-claude-code.mdx
@@ -1,0 +1,8 @@
+import CliClaudeCode from "../cli-claude-code.mdx";
+
+## Claude Code
+
+Installieren Sie den Bencher-Skill als [Claude Code](https://docs.anthropic.com/en/docs/claude-code) Plugin.
+Nach der Installation verwenden Sie `/bencher` für Anleitungen zu Benchmarking, CI-Setup und Schwellenwert-Konfiguration.
+
+<CliClaudeCode />

--- a/services/console/src/chunks/docs-how-to/install-cli/en/cli-install-claude-code.mdx
+++ b/services/console/src/chunks/docs-how-to/install-cli/en/cli-install-claude-code.mdx
@@ -1,0 +1,8 @@
+import CliClaudeCode from "../cli-claude-code.mdx";
+
+## Claude Code
+
+Install the Bencher skill as a [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugin.
+Once installed, use `/bencher` to get guidance on benchmarking, CI setup, and threshold configuration.
+
+<CliClaudeCode />

--- a/services/console/src/chunks/docs-how-to/install-cli/es/cli-install-claude-code.mdx
+++ b/services/console/src/chunks/docs-how-to/install-cli/es/cli-install-claude-code.mdx
@@ -3,6 +3,6 @@ import CliClaudeCode from "../cli-claude-code.mdx";
 ## Claude Code
 
 Instale el skill de Bencher como un plugin de [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
-Una vez instalado, use `/bencher` para obtener orientacion sobre benchmarking, configuracion de CI y umbrales.
+Una vez instalado, use `/bencher` para obtener orientación sobre benchmarking, configuración de CI y umbrales.
 
 <CliClaudeCode />

--- a/services/console/src/chunks/docs-how-to/install-cli/es/cli-install-claude-code.mdx
+++ b/services/console/src/chunks/docs-how-to/install-cli/es/cli-install-claude-code.mdx
@@ -1,0 +1,8 @@
+import CliClaudeCode from "../cli-claude-code.mdx";
+
+## Claude Code
+
+Instale el skill de Bencher como un plugin de [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
+Una vez instalado, use `/bencher` para obtener orientacion sobre benchmarking, configuracion de CI y umbrales.
+
+<CliClaudeCode />

--- a/services/console/src/chunks/docs-how-to/install-cli/fr/cli-install-claude-code.mdx
+++ b/services/console/src/chunks/docs-how-to/install-cli/fr/cli-install-claude-code.mdx
@@ -3,6 +3,6 @@ import CliClaudeCode from "../cli-claude-code.mdx";
 ## Claude Code
 
 Installez le skill Bencher en tant que plugin [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
-Une fois installe, utilisez `/bencher` pour obtenir des conseils sur le benchmarking, la configuration CI et les seuils.
+Une fois installé, utilisez `/bencher` pour obtenir des conseils sur le benchmarking, la configuration CI et les seuils.
 
 <CliClaudeCode />

--- a/services/console/src/chunks/docs-how-to/install-cli/fr/cli-install-claude-code.mdx
+++ b/services/console/src/chunks/docs-how-to/install-cli/fr/cli-install-claude-code.mdx
@@ -1,0 +1,8 @@
+import CliClaudeCode from "../cli-claude-code.mdx";
+
+## Claude Code
+
+Installez le skill Bencher en tant que plugin [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
+Une fois installe, utilisez `/bencher` pour obtenir des conseils sur le benchmarking, la configuration CI et les seuils.
+
+<CliClaudeCode />

--- a/services/console/src/chunks/docs-how-to/install-cli/ja/cli-install-claude-code.mdx
+++ b/services/console/src/chunks/docs-how-to/install-cli/ja/cli-install-claude-code.mdx
@@ -1,0 +1,8 @@
+import CliClaudeCode from "../cli-claude-code.mdx";
+
+## Claude Code
+
+Bencherスキルを[Claude Code](https://docs.anthropic.com/en/docs/claude-code)プラグインとしてインストールします。
+インストール後、`/bencher`を使用してベンチマーク、CI設定、しきい値構成のガイダンスを取得できます。
+
+<CliClaudeCode />

--- a/services/console/src/chunks/docs-how-to/install-cli/ko/cli-install-claude-code.mdx
+++ b/services/console/src/chunks/docs-how-to/install-cli/ko/cli-install-claude-code.mdx
@@ -1,0 +1,8 @@
+import CliClaudeCode from "../cli-claude-code.mdx";
+
+## Claude Code
+
+Bencher 스킬을 [Claude Code](https://docs.anthropic.com/en/docs/claude-code) 플러그인으로 설치합니다.
+설치 후 `/bencher`를 사용하여 벤치마킹, CI 설정 및 임계값 구성에 대한 안내를 받을 수 있습니다.
+
+<CliClaudeCode />

--- a/services/console/src/chunks/docs-how-to/install-cli/pt/cli-install-claude-code.mdx
+++ b/services/console/src/chunks/docs-how-to/install-cli/pt/cli-install-claude-code.mdx
@@ -1,0 +1,8 @@
+import CliClaudeCode from "../cli-claude-code.mdx";
+
+## Claude Code
+
+Instale o skill do Bencher como um plugin do [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
+Apos a instalacao, use `/bencher` para obter orientacoes sobre benchmarking, configuracao de CI e limites.
+
+<CliClaudeCode />

--- a/services/console/src/chunks/docs-how-to/install-cli/pt/cli-install-claude-code.mdx
+++ b/services/console/src/chunks/docs-how-to/install-cli/pt/cli-install-claude-code.mdx
@@ -3,6 +3,6 @@ import CliClaudeCode from "../cli-claude-code.mdx";
 ## Claude Code
 
 Instale o skill do Bencher como um plugin do [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
-Apos a instalacao, use `/bencher` para obter orientacoes sobre benchmarking, configuracao de CI e limites.
+Após a instalação, use `/bencher` para obter orientações sobre benchmarking, configuração de CI e limites.
 
 <CliClaudeCode />

--- a/services/console/src/chunks/docs-how-to/install-cli/ru/cli-install-claude-code.mdx
+++ b/services/console/src/chunks/docs-how-to/install-cli/ru/cli-install-claude-code.mdx
@@ -1,0 +1,8 @@
+import CliClaudeCode from "../cli-claude-code.mdx";
+
+## Claude Code
+
+Установите навык Bencher как плагин [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
+После установки используйте `/bencher` для получения рекомендаций по бенчмаркингу, настройке CI и конфигурации порогов.
+
+<CliClaudeCode />

--- a/services/console/src/chunks/docs-how-to/install-cli/zh/cli-install-claude-code.mdx
+++ b/services/console/src/chunks/docs-how-to/install-cli/zh/cli-install-claude-code.mdx
@@ -1,0 +1,8 @@
+import CliClaudeCode from "../cli-claude-code.mdx";
+
+## Claude Code
+
+将 Bencher 技能安装为 [Claude Code](https://docs.anthropic.com/en/docs/claude-code) 插件。
+安装后，使用 `/bencher` 获取基准测试、CI 设置和阈值配置的指导。
+
+<CliClaudeCode />

--- a/services/console/src/content/docs-how-to/de/install-cli.mdx
+++ b/services/console/src/content/docs-how-to/de/install-cli.mdx
@@ -3,7 +3,7 @@ title: "CLI installieren"
 description: "Installieren Sie die Bencher CLI zur Verwendung sowohl lokal als auch in kontinuierlichen Benchmarks"
 heading: "So installieren Sie die `bencher` CLI"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-03-13T07:00:00Z"
+modified: "2026-07-18T07:00:00Z"
 sortOrder: 1
 ---
 

--- a/services/console/src/content/docs-how-to/de/install-cli.mdx
+++ b/services/console/src/content/docs-how-to/de/install-cli.mdx
@@ -13,6 +13,7 @@ import CliInstallGitHubActions from "../../../chunks/docs-how-to/install-cli/de/
 import CliInstallSource from "../../../chunks/docs-how-to/install-cli/de/cli-install-source.mdx";
 import CliInstallDocker from "../../../chunks/docs-how-to/install-cli/de/cli-install-docker.mdx";
 import CliInstallNix from "../../../chunks/docs-how-to/install-cli/de/cli-install-nix.mdx";
+import CliInstallClaudeCode from "../../../chunks/docs-how-to/install-cli/de/cli-install-claude-code.mdx";
 import CliPreBuiltBins from "../../../chunks/general/cli-pre-built-bins.mdx";
 import CliPackages from "../../../chunks/general/cli-packages.mdx";
 
@@ -21,6 +22,8 @@ import CliPackages from "../../../chunks/general/cli-packages.mdx";
 <CliInstallScripts />
 
 <CliInstallGitHubActions />
+
+<CliInstallClaudeCode />
 
 <CliInstallDocker />
 

--- a/services/console/src/content/docs-how-to/en/install-cli.mdx
+++ b/services/console/src/content/docs-how-to/en/install-cli.mdx
@@ -3,7 +3,7 @@ title: "Install CLI"
 description: "Install the bencher CLI for use both locally and in continuous benchmarking"
 heading: "How to Install `bencher` CLI"
 published: "2023-08-12T16:07:00Z"
-modified: "2026-03-13T07:00:00Z"
+modified: "2026-07-18T07:00:00Z"
 sortOrder: 1
 ---
 

--- a/services/console/src/content/docs-how-to/en/install-cli.mdx
+++ b/services/console/src/content/docs-how-to/en/install-cli.mdx
@@ -13,6 +13,7 @@ import CliInstallGitHubActions from "../../../chunks/docs-how-to/install-cli/en/
 import CliInstallSource from "../../../chunks/docs-how-to/install-cli/en/cli-install-source.mdx";
 import CliInstallDocker from "../../../chunks/docs-how-to/install-cli/en/cli-install-docker.mdx";
 import CliInstallNix from "../../../chunks/docs-how-to/install-cli/en/cli-install-nix.mdx";
+import CliInstallClaudeCode from "../../../chunks/docs-how-to/install-cli/en/cli-install-claude-code.mdx";
 import CliPreBuiltBins from "../../../chunks/general/cli-pre-built-bins.mdx";
 import CliPackages from "../../../chunks/general/cli-packages.mdx";
 
@@ -21,6 +22,8 @@ import CliPackages from "../../../chunks/general/cli-packages.mdx";
 <CliInstallScripts />
 
 <CliInstallGitHubActions />
+
+<CliInstallClaudeCode />
 
 <CliInstallDocker />
 

--- a/services/console/src/content/docs-how-to/es/install-cli.mdx
+++ b/services/console/src/content/docs-how-to/es/install-cli.mdx
@@ -13,6 +13,7 @@ import CliInstallGitHubActions from "../../../chunks/docs-how-to/install-cli/es/
 import CliInstallSource from "../../../chunks/docs-how-to/install-cli/es/cli-install-source.mdx";
 import CliInstallDocker from "../../../chunks/docs-how-to/install-cli/es/cli-install-docker.mdx";
 import CliInstallNix from "../../../chunks/docs-how-to/install-cli/es/cli-install-nix.mdx";
+import CliInstallClaudeCode from "../../../chunks/docs-how-to/install-cli/es/cli-install-claude-code.mdx";
 import CliPreBuiltBins from "../../../chunks/general/cli-pre-built-bins.mdx";
 import CliPackages from "../../../chunks/general/cli-packages.mdx";
 
@@ -21,6 +22,8 @@ import CliPackages from "../../../chunks/general/cli-packages.mdx";
 <CliInstallScripts />
 
 <CliInstallGitHubActions />
+
+<CliInstallClaudeCode />
 
 <CliInstallDocker />
 

--- a/services/console/src/content/docs-how-to/es/install-cli.mdx
+++ b/services/console/src/content/docs-how-to/es/install-cli.mdx
@@ -3,7 +3,7 @@ title: "Instalar CLI"
 description: "Instalar la CLI de bencher para uso tanto local como en pruebas de rendimiento continuas"
 heading: "Cómo instalar el CLI de `bencher`"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-03-13T07:00:00Z"
+modified: "2026-07-18T07:00:00Z"
 sortOrder: 1
 ---
 

--- a/services/console/src/content/docs-how-to/fr/install-cli.mdx
+++ b/services/console/src/content/docs-how-to/fr/install-cli.mdx
@@ -3,7 +3,7 @@ title: "Installer CLI"
 description: "Installez le CLI bencher pour une utilisation à la fois en local et en benchmarking continu"
 heading: "Comment Installer le CLI `bencher`"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-03-13T07:00:00Z"
+modified: "2026-07-18T07:00:00Z"
 sortOrder: 1
 ---
 

--- a/services/console/src/content/docs-how-to/fr/install-cli.mdx
+++ b/services/console/src/content/docs-how-to/fr/install-cli.mdx
@@ -13,6 +13,7 @@ import CliInstallGitHubActions from "../../../chunks/docs-how-to/install-cli/fr/
 import CliInstallSource from "../../../chunks/docs-how-to/install-cli/fr/cli-install-source.mdx";
 import CliInstallDocker from "../../../chunks/docs-how-to/install-cli/fr/cli-install-docker.mdx";
 import CliInstallNix from "../../../chunks/docs-how-to/install-cli/fr/cli-install-nix.mdx";
+import CliInstallClaudeCode from "../../../chunks/docs-how-to/install-cli/fr/cli-install-claude-code.mdx";
 import CliPreBuiltBins from "../../../chunks/general/cli-pre-built-bins.mdx";
 import CliPackages from "../../../chunks/general/cli-packages.mdx";
 
@@ -21,6 +22,8 @@ import CliPackages from "../../../chunks/general/cli-packages.mdx";
 <CliInstallScripts />
 
 <CliInstallGitHubActions />
+
+<CliInstallClaudeCode />
 
 <CliInstallDocker />
 

--- a/services/console/src/content/docs-how-to/ja/install-cli.mdx
+++ b/services/console/src/content/docs-how-to/ja/install-cli.mdx
@@ -3,7 +3,7 @@ title: "CLIのインストール"
 description: "ベンチャーCLIをローカルと連続ベンチマーキングの両方で使用するためにインストールします"
 heading: "`bencher` CLI のインストール方法"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-03-13T07:00:00Z"
+modified: "2026-07-18T07:00:00Z"
 sortOrder: 1
 ---
 

--- a/services/console/src/content/docs-how-to/ja/install-cli.mdx
+++ b/services/console/src/content/docs-how-to/ja/install-cli.mdx
@@ -13,6 +13,7 @@ import CliInstallGitHubActions from "../../../chunks/docs-how-to/install-cli/ja/
 import CliInstallSource from "../../../chunks/docs-how-to/install-cli/ja/cli-install-source.mdx";
 import CliInstallDocker from "../../../chunks/docs-how-to/install-cli/ja/cli-install-docker.mdx";
 import CliInstallNix from "../../../chunks/docs-how-to/install-cli/ja/cli-install-nix.mdx";
+import CliInstallClaudeCode from "../../../chunks/docs-how-to/install-cli/ja/cli-install-claude-code.mdx";
 import CliPreBuiltBins from "../../../chunks/general/cli-pre-built-bins.mdx";
 import CliPackages from "../../../chunks/general/cli-packages.mdx";
 
@@ -21,6 +22,8 @@ import CliPackages from "../../../chunks/general/cli-packages.mdx";
 <CliInstallScripts />
 
 <CliInstallGitHubActions />
+
+<CliInstallClaudeCode />
 
 <CliInstallDocker />
 

--- a/services/console/src/content/docs-how-to/ko/install-cli.mdx
+++ b/services/console/src/content/docs-how-to/ko/install-cli.mdx
@@ -3,7 +3,7 @@ title: "CLI 설치"
 description: "로컬 및 지속적인 벤치마킹에서 사용할 bencher CLI 설치"
 heading: "`bencher` CLI 설치 방법"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-03-13T07:00:00Z"
+modified: "2026-07-18T07:00:00Z"
 sortOrder: 1
 ---
 

--- a/services/console/src/content/docs-how-to/ko/install-cli.mdx
+++ b/services/console/src/content/docs-how-to/ko/install-cli.mdx
@@ -13,6 +13,7 @@ import CliInstallGitHubActions from "../../../chunks/docs-how-to/install-cli/ko/
 import CliInstallSource from "../../../chunks/docs-how-to/install-cli/ko/cli-install-source.mdx";
 import CliInstallDocker from "../../../chunks/docs-how-to/install-cli/ko/cli-install-docker.mdx";
 import CliInstallNix from "../../../chunks/docs-how-to/install-cli/ko/cli-install-nix.mdx";
+import CliInstallClaudeCode from "../../../chunks/docs-how-to/install-cli/ko/cli-install-claude-code.mdx";
 import CliPreBuiltBins from "../../../chunks/general/cli-pre-built-bins.mdx";
 import CliPackages from "../../../chunks/general/cli-packages.mdx";
 
@@ -21,6 +22,8 @@ import CliPackages from "../../../chunks/general/cli-packages.mdx";
 <CliInstallScripts />
 
 <CliInstallGitHubActions />
+
+<CliInstallClaudeCode />
 
 <CliInstallDocker />
 

--- a/services/console/src/content/docs-how-to/pt/install-cli.mdx
+++ b/services/console/src/content/docs-how-to/pt/install-cli.mdx
@@ -13,6 +13,7 @@ import CliInstallGitHubActions from "../../../chunks/docs-how-to/install-cli/pt/
 import CliInstallSource from "../../../chunks/docs-how-to/install-cli/pt/cli-install-source.mdx";
 import CliInstallDocker from "../../../chunks/docs-how-to/install-cli/pt/cli-install-docker.mdx";
 import CliInstallNix from "../../../chunks/docs-how-to/install-cli/pt/cli-install-nix.mdx";
+import CliInstallClaudeCode from "../../../chunks/docs-how-to/install-cli/pt/cli-install-claude-code.mdx";
 import CliPreBuiltBins from "../../../chunks/general/cli-pre-built-bins.mdx";
 import CliPackages from "../../../chunks/general/cli-packages.mdx";
 
@@ -21,6 +22,8 @@ import CliPackages from "../../../chunks/general/cli-packages.mdx";
 <CliInstallScripts />
 
 <CliInstallGitHubActions />
+
+<CliInstallClaudeCode />
 
 <CliInstallDocker />
 

--- a/services/console/src/content/docs-how-to/pt/install-cli.mdx
+++ b/services/console/src/content/docs-how-to/pt/install-cli.mdx
@@ -3,7 +3,7 @@ title: "Instalar CLI"
 description: "Instale o CLI do bencher para uso local e em benchmarking contínuo"
 heading: "Como instalar o CLI do `bencher`"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-03-13T07:00:00Z"
+modified: "2026-07-18T07:00:00Z"
 sortOrder: 1
 ---
 

--- a/services/console/src/content/docs-how-to/ru/install-cli.mdx
+++ b/services/console/src/content/docs-how-to/ru/install-cli.mdx
@@ -3,7 +3,7 @@ title: "Установка CLI"
 description: "Установите CLI bencher для использования как локально, так и в непрерывном бенчмаркинге"
 heading: "Как установить `bencher` CLI"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-03-13T07:00:00Z"
+modified: "2026-07-18T07:00:00Z"
 sortOrder: 1
 ---
 

--- a/services/console/src/content/docs-how-to/ru/install-cli.mdx
+++ b/services/console/src/content/docs-how-to/ru/install-cli.mdx
@@ -13,6 +13,7 @@ import CliInstallGitHubActions from "../../../chunks/docs-how-to/install-cli/ru/
 import CliInstallSource from "../../../chunks/docs-how-to/install-cli/ru/cli-install-source.mdx";
 import CliInstallDocker from "../../../chunks/docs-how-to/install-cli/ru/cli-install-docker.mdx";
 import CliInstallNix from "../../../chunks/docs-how-to/install-cli/ru/cli-install-nix.mdx";
+import CliInstallClaudeCode from "../../../chunks/docs-how-to/install-cli/ru/cli-install-claude-code.mdx";
 import CliPreBuiltBins from "../../../chunks/general/cli-pre-built-bins.mdx";
 import CliPackages from "../../../chunks/general/cli-packages.mdx";
 
@@ -21,6 +22,8 @@ import CliPackages from "../../../chunks/general/cli-packages.mdx";
 <CliInstallScripts />
 
 <CliInstallGitHubActions />
+
+<CliInstallClaudeCode />
 
 <CliInstallDocker />
 

--- a/services/console/src/content/docs-how-to/zh/install-cli.mdx
+++ b/services/console/src/content/docs-how-to/zh/install-cli.mdx
@@ -3,7 +3,7 @@ title: "安装 CLI"
 description: "安装 bencher CLI 以便在本地和持续性基准测试中使用"
 heading: "如何安装 `bencher` CLI"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-03-13T07:00:00Z"
+modified: "2026-07-18T07:00:00Z"
 sortOrder: 1
 ---
 

--- a/services/console/src/content/docs-how-to/zh/install-cli.mdx
+++ b/services/console/src/content/docs-how-to/zh/install-cli.mdx
@@ -13,6 +13,7 @@ import CliInstallGitHubActions from "../../../chunks/docs-how-to/install-cli/zh/
 import CliInstallSource from "../../../chunks/docs-how-to/install-cli/zh/cli-install-source.mdx";
 import CliInstallDocker from "../../../chunks/docs-how-to/install-cli/zh/cli-install-docker.mdx";
 import CliInstallNix from "../../../chunks/docs-how-to/install-cli/zh/cli-install-nix.mdx";
+import CliInstallClaudeCode from "../../../chunks/docs-how-to/install-cli/zh/cli-install-claude-code.mdx";
 import CliPreBuiltBins from "../../../chunks/general/cli-pre-built-bins.mdx";
 import CliPackages from "../../../chunks/general/cli-packages.mdx";
 
@@ -21,6 +22,8 @@ import CliPackages from "../../../chunks/general/cli-packages.mdx";
 <CliInstallScripts />
 
 <CliInstallGitHubActions />
+
+<CliInstallClaudeCode />
 
 <CliInstallDocker />
 

--- a/skills/bencher/SKILL.md
+++ b/skills/bencher/SKILL.md
@@ -84,10 +84,10 @@ Query existing data:
 
 ```bash
 bencher project view <project>
-bencher branch list --project <project>
-bencher report list --project <project>
-bencher alert list --project <project>
-bencher threshold list --project <project>
+bencher branch list <project>
+bencher report list <project>
+bencher alert list <project>
+bencher threshold list <project>
 ```
 
 Use `--format json` on any command for machine-readable output.

--- a/skills/bencher/SKILL.md
+++ b/skills/bencher/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: bencher
+description: >
+  Guide for using Bencher continuous benchmarking. Use when the user wants to:
+  benchmark code, track performance, detect regressions, set up CI performance
+  checks, run bare metal benchmarks, configure thresholds, or use the bencher CLI.
+  Also use when you see BENCHER_API_KEY, BENCHER_API_TOKEN, bencher CLI usage, bencher.dev
+  URLs, or port 61016 (Bencher self-hosted default) in the project.
+argument-hint: [task]
+---
+
+# Bencher
+
+Bencher is a continuous benchmarking platform that tracks performance over time
+and detects regressions before they reach production.
+
+## Quick Start
+
+Check if the CLI is installed:
+```
+`bencher --version 2>/dev/null || echo "bencher CLI not installed — see https://bencher.dev/docs/how-to/install-cli/"`
+```
+
+Choose your workflow:
+
+| Goal | Workflow |
+|------|---------|
+| Run benchmarks locally | See [local-runs.md](./local-runs.md) |
+| Run benchmarks on dedicated hardware (Bencher Cloud) | See [bare-metal.md](./bare-metal.md) |
+| Set up CI regression detection | See [ci.md](./ci.md) |
+| Configure statistical thresholds | See [thresholds.md](./thresholds.md) |
+| Quick command reference | See [reference.md](./reference.md) |
+
+Simplest possible run (generates mock data to verify setup):
+```bash
+bencher run "bencher mock"
+```
+
+## Authentication
+
+**Preferred (agents and CI):** Project-scoped API key
+```bash
+export BENCHER_API_KEY=bencher_run_...
+# or pass --key bencher_run_...
+```
+
+Project keys are scoped to a single project and can only submit benchmark runs
+and read project data. This is the recommended authentication method.
+
+**Alternative (users):** User-scoped API token
+```bash
+export BENCHER_API_TOKEN=eyJ...
+# or pass --token eyJ...
+```
+
+User tokens grant full access to all projects and operations the user has permission for.
+
+## Common Options
+
+Every `bencher run` accepts these project-scoping options:
+
+| Flag | Env Var | Purpose |
+|------|---------|---------|
+| `--project` | `BENCHER_PROJECT` | Project slug or UUID |
+| `--branch` | `BENCHER_BRANCH` | Branch name/slug/UUID (auto-created if needed) |
+| `--testbed` | `BENCHER_TESTBED` | Testbed name/slug/UUID (auto-created if needed) |
+| `--host` | `BENCHER_HOST` | API host (default: `https://api.bencher.dev`) |
+
+## Reading Project Data
+
+With a project key, you can query existing data:
+
+```bash
+bencher project view <project>
+bencher branch list --project <project>
+bencher report list --project <project>
+bencher alert list --project <project>
+bencher threshold list --project <project>
+```
+
+Use `--format json` on any command for machine-readable output.

--- a/skills/bencher/SKILL.md
+++ b/skills/bencher/SKILL.md
@@ -58,13 +58,15 @@ owning user across everything a session can do (except minting other keys), and 
 create a project on the fly, so `--project` is optional.
 ```bash
 export BENCHER_API_KEY=bencher_user_...
-bencher run --project my-project "cargo bench"
+bencher run "cargo bench"
 ```
 
 **Deprecated, user API token (`--token` / `BENCHER_API_TOKEN`, a JWT):** existing
 tokens still work, but new ones can no longer be created. Use an API key instead.
 
-`--key` and `--token` are mutually exclusive; `--key` takes precedence.
+`--key` and `--token` are mutually exclusive: supplying both is an error, even
+when one comes from an environment variable. When migrating, unset
+`BENCHER_API_TOKEN` before setting `BENCHER_API_KEY`.
 
 ## Common Options
 

--- a/skills/bencher/SKILL.md
+++ b/skills/bencher/SKILL.md
@@ -18,8 +18,8 @@ and detects regressions before they reach production.
 ## Quick Start
 
 Check if the CLI is installed:
-```
-`bencher --version 2>/dev/null || echo "bencher CLI not installed. See https://bencher.dev/docs/how-to/install-cli/"`
+```bash
+bencher --version 2>/dev/null || echo "bencher CLI not installed. See https://bencher.dev/docs/how-to/install-cli/"
 ```
 
 Choose your workflow:
@@ -45,7 +45,7 @@ The prefix selects one of two kinds.
 
 **Project key (`bencher_run_*`), preferred for CI:** scoped to a single existing
 project. Submits runs and reads that project's data; cannot create or claim a project,
-nor perform destructive operations (least privilege).
+nor perform manage-level operations such as renaming resources or managing keys (least privilege).
 ```bash
 export BENCHER_API_KEY=bencher_run_...
 bencher run --project my-project "cargo bench"

--- a/skills/bencher/SKILL.md
+++ b/skills/bencher/SKILL.md
@@ -29,6 +29,7 @@ Choose your workflow:
 | Run benchmarks on dedicated hardware (Bencher Cloud) | See [bare-metal.md](./bare-metal.md) |
 | Set up CI regression detection | See [ci.md](./ci.md) |
 | Configure statistical thresholds | See [thresholds.md](./thresholds.md) |
+| Set up a self-hosted Bencher instance | See [self-hosted.md](./self-hosted.md) |
 | Quick command reference | See [reference.md](./reference.md) |
 
 Simplest possible run (generates mock data to verify setup):

--- a/skills/bencher/SKILL.md
+++ b/skills/bencher/SKILL.md
@@ -4,8 +4,9 @@ description: >
   Guide for using Bencher continuous benchmarking. Use when the user wants to:
   benchmark code, track performance, detect regressions, set up CI performance
   checks, run bare metal benchmarks, configure thresholds, or use the bencher CLI.
-  Also use when you see BENCHER_API_KEY, BENCHER_API_TOKEN, bencher CLI usage, bencher.dev
-  URLs, or port 61016 (Bencher self-hosted default) in the project.
+  Also use when you see BENCHER_API_KEY, BENCHER_API_TOKEN, bencher_run_ or
+  bencher_user_ API keys, bencher CLI usage, bencher.dev URLs, or port 6610
+  (Bencher self-hosted default) in the project.
 argument-hint: [task]
 ---
 
@@ -18,7 +19,7 @@ and detects regressions before they reach production.
 
 Check if the CLI is installed:
 ```
-`bencher --version 2>/dev/null || echo "bencher CLI not installed — see https://bencher.dev/docs/how-to/install-cli/"`
+`bencher --version 2>/dev/null || echo "bencher CLI not installed. See https://bencher.dev/docs/how-to/install-cli/"`
 ```
 
 Choose your workflow:
@@ -39,22 +40,31 @@ bencher run "bencher mock"
 
 ## Authentication
 
-**Preferred (agents and CI):** Project-scoped API key
+Bencher authenticates with an **API key** via `--key` or `BENCHER_API_KEY`.
+The prefix selects one of two kinds.
+
+**Project key (`bencher_run_*`), preferred for CI:** scoped to a single existing
+project. Submits runs and reads that project's data; cannot create or claim a project,
+nor perform destructive operations (least privilege).
 ```bash
 export BENCHER_API_KEY=bencher_run_...
-# or pass --key bencher_run_...
+bencher run --project my-project "cargo bench"
 ```
+The project must be identified by `--project` or derived from a `--image` whose
+repository names the project. A project key cannot create a project on the fly.
 
-Project keys are scoped to a single project and can only submit benchmark runs
-and read project data. This is the recommended authentication method.
-
-**Alternative (users):** User-scoped API token
+**User key (`bencher_user_*`), good for local/interactive use:** authenticates as the
+owning user across everything a session can do (except minting other keys), and can
+create a project on the fly, so `--project` is optional.
 ```bash
-export BENCHER_API_TOKEN=eyJ...
-# or pass --token eyJ...
+export BENCHER_API_KEY=bencher_user_...
+bencher run --project my-project "cargo bench"
 ```
 
-User tokens grant full access to all projects and operations the user has permission for.
+**Deprecated, user API token (`--token` / `BENCHER_API_TOKEN`, a JWT):** existing
+tokens still work, but new ones can no longer be created. Use an API key instead.
+
+`--key` and `--token` are mutually exclusive; `--key` takes precedence.
 
 ## Common Options
 
@@ -69,7 +79,8 @@ Every `bencher run` accepts these project-scoping options:
 
 ## Reading Project Data
 
-With a project key, you can query existing data:
+A project key reads its own project; a user key spans all the user's projects.
+Query existing data:
 
 ```bash
 bencher project view <project>

--- a/skills/bencher/bare-metal.md
+++ b/skills/bencher/bare-metal.md
@@ -90,7 +90,7 @@ bencher run \
 | `--env KEY=VALUE` | Set environment variables (repeatable) |
 | `--job-timeout <secs>` | Maximum execution time |
 | `--job-poll-interval <secs>` | How often to check for completion |
-| `--detach` | Submit without waiting for results |
+| `--detach` | Submit without waiting for results (conflicts with `--job-poll-interval`) |
 
 ## Build Time and File Size Tracking
 

--- a/skills/bencher/bare-metal.md
+++ b/skills/bencher/bare-metal.md
@@ -85,11 +85,20 @@ bencher run \
 |------|---------|
 | `--image <ref>` | OCI image reference (required for bare metal) |
 | `--spec <slug>` | Hardware spec (default: platform-assigned) |
+| `--spec-reset` | Reset testbed spec (use with `--testbed`, conflicts with `--image`) |
 | `--entrypoint <cmd>` | Override container entrypoint |
 | `--env KEY=VALUE` | Set environment variables (repeatable) |
 | `--job-timeout <secs>` | Maximum execution time |
 | `--job-poll-interval <secs>` | How often to check for completion |
 | `--detach` | Submit without waiting for results |
+
+## Build Time and File Size Tracking
+
+Build time and file size tracking work with bare metal runs:
+```bash
+bencher run --image my-bench:latest --build-time "cargo build --release"
+bencher run --image my-bench:latest --file-size /app/target/release/my-binary
+```
 
 ## Fire-and-Forget
 
@@ -113,3 +122,18 @@ bencher run \
 
 Bare metal jobs on Bencher Cloud run without network access by default.
 All dependencies must be baked into the image.
+
+## Self-Hosted Runners
+
+Beyond Bencher Cloud's managed hardware, you can operate your own bare metal runner
+with the self-hosted `runner` binary (distinct from the `bencher runner` management
+subcommands). It has two subcommands:
+
+- `runner up`: long-running agent that polls for and executes Jobs
+- `runner run`: pull an image and execute it once on the local host (for testing)
+
+For registration, specs, sandboxing, and the full workflow, see the public docs:
+
+- Bare Metal overview: https://bencher.dev/docs/explanation/bare-metal/
+- Self-Hosted Runners: https://bencher.dev/docs/explanation/self-hosted-runners/
+- `runner` CLI reference: https://bencher.dev/docs/reference/runner/

--- a/skills/bencher/bare-metal.md
+++ b/skills/bencher/bare-metal.md
@@ -1,0 +1,115 @@
+# Bare Metal Benchmarks (Bencher Plus)
+
+Run benchmarks on dedicated hardware with isolated Firecracker VMs,
+eliminating noisy-neighbor effects from shared CI runners.
+
+## Quick Start
+
+The simplest bare metal run uses the built-in noise measurement tool:
+```bash
+bencher run --image alpine:latest "bencher noise"
+```
+
+This submits a job that runs `bencher noise` inside an Alpine container on
+dedicated hardware and reports back environment noise metrics.
+
+## Available Specs (Bencher Cloud)
+
+See: https://bencher.dev/docs/explanation/testbeds/#--spec-spec
+
+| Name | Slug | OS | Arch | Sandbox | CPU | Memory | Disk | Network |
+|------|------|----|------|---------|-----|--------|------|---------|
+| Intel v1 | `intel-v1` | Linux | x86_64 | Firecracker | 4 | 48.0 GiB | 128.0 GiB | No |
+
+Specify with `--spec`:
+```bash
+bencher run --image my-bench:latest --spec intel-v1 "cargo bench"
+```
+
+## Workflow
+
+1. Build an OCI image containing your benchmark suite
+2. Push it to a container registry (Docker Hub, GHCR, etc.)
+3. Submit with `bencher run --image <ref>`
+
+### Writing a Dockerfile
+
+The image must contain everything needed to run benchmarks.
+The command passed to `bencher run` executes inside the container.
+
+Example for Rust (Criterion):
+```dockerfile
+FROM rust:1.87-slim
+WORKDIR /app
+COPY . .
+RUN cargo build --release --benches
+```
+
+Example for Go:
+```dockerfile
+FROM golang:1.24
+WORKDIR /app
+COPY . .
+RUN go build ./...
+```
+
+Example for Python (pytest-benchmark):
+```dockerfile
+FROM python:3.13-slim
+WORKDIR /app
+COPY . .
+RUN pip install -e ".[bench]"
+```
+
+### Build and Push
+
+```bash
+docker build -t ghcr.io/myorg/my-bench:latest .
+docker push ghcr.io/myorg/my-bench:latest
+```
+
+### Submit
+
+```bash
+bencher run \
+  --project my-project \
+  --branch main \
+  --image ghcr.io/myorg/my-bench:latest \
+  --spec intel-v1 \
+  "cargo bench"
+```
+
+## Key Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--image <ref>` | OCI image reference (required for bare metal) |
+| `--spec <slug>` | Hardware spec (default: platform-assigned) |
+| `--entrypoint <cmd>` | Override container entrypoint |
+| `--env KEY=VALUE` | Set environment variables (repeatable) |
+| `--job-timeout <secs>` | Maximum execution time |
+| `--job-poll-interval <secs>` | How often to check for completion |
+| `--detach` | Submit without waiting for results |
+
+## Fire-and-Forget
+
+Submit the job and exit immediately (useful in CI where you check results later):
+```bash
+bencher run --image my-bench:latest --detach "cargo bench"
+```
+
+## Environment Variables
+
+Pass secrets or config into the container:
+```bash
+bencher run \
+  --image my-bench:latest \
+  --env DATABASE_URL=postgres://... \
+  --env FEATURE_FLAG=true \
+  "pytest benchmarks/"
+```
+
+## Networking
+
+Bare metal jobs on Bencher Cloud run without network access by default.
+All dependencies must be baked into the image.

--- a/skills/bencher/ci.md
+++ b/skills/bencher/ci.md
@@ -82,7 +82,7 @@ benchmark_main:
         --branch main
         --testbed gitlab-ci
         --threshold-measure latency
-        --threshold-test t
+        --threshold-test t_test
         --threshold-upper-boundary 0.99
         --error-on-alert
         "cargo bench"
@@ -110,10 +110,13 @@ benchmark_mr:
         "cargo bench")
     - |
       curl --request POST \
-        --header "PRIVATE-TOKEN: $CI_JOB_TOKEN" \
+        --header "PRIVATE-TOKEN: $GITLAB_ACCESS_TOKEN" \
         --data-urlencode "body=$REPORT" \
         "https://gitlab.com/api/v4/projects/$CI_PROJECT_ID/merge_requests/$CI_MERGE_REQUEST_IID/notes"
 ```
+
+`$GITLAB_ACCESS_TOKEN` is a project access token with the `api` scope, stored as a
+masked CI/CD variable. The built-in `CI_JOB_TOKEN` cannot post MR notes.
 
 ## Generic CI (Any Platform)
 

--- a/skills/bencher/ci.md
+++ b/skills/bencher/ci.md
@@ -1,5 +1,9 @@
 # CI Integration
 
+In CI, set `BENCHER_API_KEY` to a **project** API key (`bencher_run_*`) for least
+privilege. Create one with `bencher project key create <project> --name ci` (or in the
+Console) and store it as a CI secret.
+
 ## GitHub Actions (Native)
 
 Bencher has native GitHub Actions support for posting benchmark results
@@ -15,7 +19,7 @@ as PR comments.
       --branch main \
       --testbed github-actions \
       --threshold-measure latency \
-      --threshold-test t \
+      --threshold-test t_test \
       --threshold-upper-boundary 0.99 \
       --error-on-alert \
       "cargo bench"

--- a/skills/bencher/ci.md
+++ b/skills/bencher/ci.md
@@ -1,0 +1,151 @@
+# CI Integration
+
+## GitHub Actions (Native)
+
+Bencher has native GitHub Actions support for posting benchmark results
+as PR comments.
+
+### Target Branch (runs on push to main)
+
+```yaml
+- uses: bencherdev/bencher@main
+- run: |
+    bencher run \
+      --project my-project \
+      --branch main \
+      --testbed github-actions \
+      --threshold-measure latency \
+      --threshold-test t \
+      --threshold-upper-boundary 0.99 \
+      --error-on-alert \
+      "cargo bench"
+  env:
+    BENCHER_API_KEY: ${{ secrets.BENCHER_API_KEY }}
+```
+
+### Pull Request (runs on PR)
+
+```yaml
+- uses: bencherdev/bencher@main
+- run: |
+    bencher run \
+      --project my-project \
+      --branch "${{ github.head_ref }}" \
+      --start-point "${{ github.base_ref }}" \
+      --start-point-hash "${{ github.event.pull_request.base.sha }}" \
+      --start-point-clone-thresholds \
+      --start-point-reset \
+      --testbed github-actions \
+      --error-on-alert \
+      --github-actions "${{ secrets.GITHUB_TOKEN }}" \
+      "cargo bench"
+  env:
+    BENCHER_API_KEY: ${{ secrets.BENCHER_API_KEY }}
+```
+
+### PR Comment Options
+
+| Flag | Purpose |
+|------|---------|
+| `--github-actions <token>` | Enable PR comments (pass `${{ secrets.GITHUB_TOKEN }}`) |
+| `--ci-only-thresholds` | Only post if a threshold exists for the branch/testbed/measure |
+| `--ci-only-on-alert` | Only post when an alert is generated |
+| `--ci-public-links` | Use public URLs (no login required to view) |
+| `--ci-id <id>` | Custom identifier for the CI comment |
+| `--ci-number <n>` | Issue/PR number to post on |
+
+### On-the-Fly Project Creation
+
+For repos that want benchmarks without pre-creating the Bencher project:
+```bash
+bencher run --ci-on-the-fly "cargo bench"
+```
+
+## GitLab CI/CD
+
+GitLab uses `--format html` to capture a report, then posts it as an MR note.
+
+### Target Branch Job
+
+```yaml
+benchmark_main:
+  stage: benchmark
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+  script:
+    - bencher run
+        --project my-project
+        --branch main
+        --testbed gitlab-ci
+        --threshold-measure latency
+        --threshold-test t
+        --threshold-upper-boundary 0.99
+        --error-on-alert
+        "cargo bench"
+```
+
+### Merge Request Job
+
+```yaml
+benchmark_mr:
+  stage: benchmark
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  script:
+    - |
+      REPORT=$(bencher run \
+        --project my-project \
+        --branch "$CI_COMMIT_REF_NAME" \
+        --start-point "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" \
+        --start-point-hash "$CI_MERGE_REQUEST_TARGET_BRANCH_SHA" \
+        --start-point-clone-thresholds \
+        --start-point-reset \
+        --testbed gitlab-ci \
+        --error-on-alert \
+        --format html \
+        "cargo bench")
+    - |
+      curl --request POST \
+        --header "PRIVATE-TOKEN: $CI_JOB_TOKEN" \
+        --data-urlencode "body=$REPORT" \
+        "https://gitlab.com/api/v4/projects/$CI_PROJECT_ID/merge_requests/$CI_MERGE_REQUEST_IID/notes"
+```
+
+## Generic CI (Any Platform)
+
+The pattern works on any CI platform:
+
+1. Run benchmarks on the target branch (push to main) with thresholds
+2. Run benchmarks on PRs/MRs using `--start-point` to inherit thresholds
+3. Use `--format html` and post results via the platform's API
+
+Key environment variables to map from your CI platform:
+- Current branch name -> `--branch`
+- Target/base branch name -> `--start-point`
+- Target/base branch commit hash -> `--start-point-hash`
+
+## Branch Management for PRs
+
+When benchmarking a PR/MR branch:
+```bash
+--branch feature-branch \
+--start-point main \
+--start-point-hash abc123... \
+--start-point-clone-thresholds \
+--start-point-reset
+```
+
+- `--start-point-clone-thresholds`: Copy threshold configuration from the base branch
+- `--start-point-reset`: Reset the branch head so only PR data is included
+
+## Branch Cleanup
+
+Archive stale branches (e.g., when a PR is closed):
+```bash
+bencher archive --project my-project --branch old-feature-branch
+```
+
+Unarchive if needed:
+```bash
+bencher unarchive --project my-project --branch old-feature-branch
+```

--- a/skills/bencher/local-runs.md
+++ b/skills/bencher/local-runs.md
@@ -29,6 +29,7 @@ If auto-detection fails, specify the adapter explicitly with `--adapter`:
 | `java_jmh` | Java | JMH |
 | `js_benchmark` | JavaScript | Benchmark.js |
 | `js_time` | JavaScript | console.time / console.timeEnd |
+| `js_vitest` | JavaScript | Vitest |
 | `python_asv` | Python | ASV |
 | `python_pytest` | Python | pytest-benchmark |
 | `ruby_benchmark` | Ruby | Benchmark module |

--- a/skills/bencher/local-runs.md
+++ b/skills/bencher/local-runs.md
@@ -35,7 +35,7 @@ If auto-detection fails, specify the adapter explicitly with `--adapter`:
 | `rust_bench` | Rust | libtest bench (nightly) |
 | `rust_criterion` | Rust | Criterion.rs |
 | `rust_iai` | Rust | Iai |
-| `rust_iai_callgrind` | Rust | Iai-Callgrind |
+| `rust_gungraun` | Rust | Gungraun (alias: `rust_iai_callgrind`) |
 | `shell_hyperfine` | Shell | Hyperfine |
 
 Example:

--- a/skills/bencher/local-runs.md
+++ b/skills/bencher/local-runs.md
@@ -1,0 +1,122 @@
+# Local Benchmark Runs
+
+## Basic Usage
+
+Run a benchmark command and submit results:
+```bash
+bencher run "cargo bench"
+```
+
+The default adapter (`magic`) auto-detects the output format.
+To verify your setup without a real benchmark harness:
+```bash
+bencher run "bencher mock"
+```
+
+## Adapters
+
+If auto-detection fails, specify the adapter explicitly with `--adapter`:
+
+| Adapter | Language | Tool |
+|---------|----------|------|
+| `magic` | Any | Auto-detect (default) |
+| `json` | Any | Bencher Metric Format (BMF) JSON |
+| `c_sharp_dot_net` | C# | BenchmarkDotNet |
+| `cpp_catch2` | C++ | Catch2 |
+| `cpp_google` | C++ | Google Benchmark |
+| `dart_benchmark_harness` | Dart | benchmark_harness |
+| `go_bench` | Go | `go test -bench` |
+| `java_jmh` | Java | JMH |
+| `js_benchmark` | JavaScript | Benchmark.js |
+| `js_time` | JavaScript | console.time / console.timeEnd |
+| `python_asv` | Python | ASV |
+| `python_pytest` | Python | pytest-benchmark |
+| `ruby_benchmark` | Ruby | Benchmark module |
+| `rust_bench` | Rust | libtest bench (nightly) |
+| `rust_criterion` | Rust | Criterion.rs |
+| `rust_iai` | Rust | Iai |
+| `rust_iai_callgrind` | Rust | Iai-Callgrind |
+| `shell_hyperfine` | Shell | Hyperfine |
+
+Example:
+```bash
+bencher run --adapter rust_criterion "cargo bench"
+```
+
+## Multiple Iterations
+
+Run the benchmark multiple times and aggregate results:
+```bash
+bencher run --iter 5 --fold mean "cargo bench"
+```
+
+`--fold` options: `mean`, `median`, `min`, `max`
+
+## File-Based Input
+
+If your benchmark writes output to a file instead of stdout:
+```bash
+bencher run --file results.json "cargo bench -- --output results.json"
+```
+
+Multiple files:
+```bash
+bencher run --file results1.json --file results2.json "run-benchmarks.sh"
+```
+
+## Build Time Tracking
+
+Track how long compilation takes:
+```bash
+bencher run --build-time "cargo build --release"
+```
+
+Cannot be combined with `--file`.
+
+## File Size Tracking
+
+Track the size of a binary or artifact:
+```bash
+bencher run --file-size target/release/my-binary
+```
+
+Multiple paths:
+```bash
+bencher run --file-size target/release/binary1 --file-size target/release/binary2
+```
+
+Cannot be combined with `--file`.
+
+## Shell vs Exec Mode
+
+By default, commands run through the shell (`/bin/sh -c "..."`).
+
+To run as a direct executable (no shell interpretation):
+```bash
+bencher run --exec cargo bench -- --output-format json
+```
+
+Customize the shell:
+```bash
+bencher run --shell /bin/bash --flag -c "cargo bench"
+```
+
+## Output Formats
+
+| Format | Flag | Use Case |
+|--------|------|----------|
+| `human` | `--format human` | Terminal display (default) |
+| `json` | `--format json` | Programmatic consumption |
+| `html` | `--format html` | CI comment posting (GitLab, etc.) |
+
+Suppress progress output and only print the final report:
+```bash
+bencher run --quiet --format json "cargo bench"
+```
+
+## Dry Run
+
+Validate everything without saving data:
+```bash
+bencher run --dry-run "cargo bench"
+```

--- a/skills/bencher/reference.md
+++ b/skills/bencher/reference.md
@@ -34,8 +34,12 @@
 |------|---------|
 | `--threshold-measure <measure>` | Measure for threshold |
 | `--threshold-test <model>` | Statistical test model |
+| `--threshold-min-sample-size <n>` | Minimum historical sample size |
+| `--threshold-max-sample-size <n>` | Maximum historical sample size |
+| `--threshold-window <secs>` | Time window in seconds |
 | `--threshold-upper-boundary <val>` | Upper boundary value |
 | `--threshold-lower-boundary <val>` | Lower boundary value |
+| `--thresholds-reset` | Reset all unspecified thresholds |
 | `--error-on-alert` / `--err` | Exit non-zero on alert |
 
 ### Command Execution
@@ -75,6 +79,7 @@
 |------|---------|
 | `--image <ref>` | OCI image reference |
 | `--spec <slug>` | Hardware spec |
+| `--spec-reset` | Reset testbed spec (requires `--testbed`, conflicts with `--image`) |
 | `--entrypoint <cmd>` | Container entrypoint override |
 | `--env KEY=VALUE` | Environment variable (repeatable) |
 | `--job-timeout <secs>` | Maximum execution time |
@@ -86,11 +91,15 @@
 | Flag | Env Var | Default | Purpose |
 |------|---------|---------|---------|
 | `--host <url>` | `BENCHER_HOST` | `https://api.bencher.dev` | API host |
-| `--token <jwt>` | `BENCHER_API_TOKEN` | | User API token |
-| `--key <key>` | `BENCHER_API_KEY` | | Project API key (preferred) |
-| `--timeout <secs>` | | 15 | Request timeout |
-| `--attempts <n>` | | 10 | Request attempts |
-| `--retry-after <secs>` | | 1 | Initial backoff time |
+| `--token <jwt>` | `BENCHER_API_TOKEN` | | User API token (JWT). Deprecated; use `--key` |
+| `--key <key>` | `BENCHER_API_KEY` | | Bencher API key: user (`bencher_user_*`) or project (`bencher_run_*`); project keys need `--project` or `--image` |
+| `--insecure-host` | | | Allow insecure HTTPS connections |
+| `--native-tls` | | | Use platform native TLS certificates |
+| `--timeout <secs>` | | 15 | Request timeout (1-900) |
+| `--attempts <n>` | | 35 | Request attempts |
+| `--retry-after <secs>` | | 1 | Initial backoff time (1-900) |
+| `--max-retry-after <secs>` | | 30 | Max backoff time (1-900) |
+| `--strict` | | | Strictly parse JSON responses |
 
 ## Adapters
 
@@ -112,7 +121,7 @@
 | `rust_bench` | Rust | libtest bench (nightly) |
 | `rust_criterion` | Rust | Criterion.rs |
 | `rust_iai` | Rust | Iai |
-| `rust_iai_callgrind` | Rust | Iai-Callgrind |
+| `rust_gungraun` | Rust | Gungraun (alias: `rust_iai_callgrind`) |
 | `shell_hyperfine` | Shell | Hyperfine |
 
 ## Threshold Models
@@ -121,8 +130,8 @@
 |-------|------|----------|------------|
 | Static | `static` | Fixed value | `lower_boundary`, `upper_boundary` |
 | Percentage | `percentage` | % change from mean | `upper_boundary` (e.g., 0.10 = 10%) |
-| z-score | `z` | Normal, large samples | `upper_boundary` (cumulative %) |
-| Student's t | `t` | Normal, small samples | `upper_boundary` (cumulative %) |
+| z-score | `z_score` (alias: `z`) | Normal, large samples | `upper_boundary` (cumulative %) |
+| Student's t | `t_test` (alias: `t`) | Normal, small samples | `upper_boundary` (cumulative %) |
 | Log Normal | `log_normal` | Right-skewed (latency) | `upper_boundary` (cumulative %) |
 | IQR | `iqr` | Outlier-robust | `upper_boundary` (IQR multiplier) |
 | Delta IQR | `delta_iqr` | Change-based IQR | `upper_boundary` (delta multiplier) |
@@ -131,14 +140,51 @@
 
 | Variable | Purpose |
 |----------|---------|
-| `BENCHER_API_KEY` | Project-scoped API key (preferred for agents/CI) |
-| `BENCHER_API_TOKEN` | User-scoped API token |
+| `BENCHER_API_KEY` | Bencher API key: user (`bencher_user_*`) or project (`bencher_run_*`) |
+| `BENCHER_API_TOKEN` | User API token (JWT). Deprecated; use `BENCHER_API_KEY` |
 | `BENCHER_HOST` | API host URL |
 | `BENCHER_PROJECT` | Default project |
 | `BENCHER_BRANCH` | Default branch |
 | `BENCHER_TESTBED` | Default testbed |
 | `BENCHER_ADAPTER` | Default adapter |
 | `BENCHER_CMD` | Default benchmark command |
+
+## Key & Token Management
+
+```bash
+# User API keys (bencher_user_*)
+bencher user key list <user>
+bencher user key create <user> --name <name> [--ttl <seconds>]
+bencher user key view <user> <uuid>
+bencher user key update <user> <uuid> --name <name>
+bencher user key revoke <user> <uuid>
+
+# Project API keys (bencher_run_*) - preferred for `bencher run` in CI
+bencher project key list <project>
+bencher project key create <project> --name <name> [--ttl <seconds>]
+bencher project key view <project> <uuid>
+bencher project key update <project> <uuid> --name <name>
+bencher project key revoke <project> <uuid>
+
+# User API tokens (deprecated: existing tokens only, none can be created)
+bencher token list <user>
+bencher token view <user> <uuid>
+bencher token update <user> <uuid> --name <name>
+bencher token revoke <user> <uuid>
+```
+
+The plaintext key is returned only once, at creation time. Aliases: `add` (create),
+`get` (view), `edit` (update), `rm` (revoke), `ls` (list).
+
+## Utility Commands
+
+```bash
+# Generate mock benchmark data (verify setup)
+bencher mock
+
+# Measure environment noise
+bencher noise
+```
 
 ## Common Resource Commands
 
@@ -158,6 +204,14 @@ bencher testbed list --project <project>
 bencher testbed view --project <project> <testbed>
 bencher testbed create --project <project> --name <name>
 
+# Benchmarks
+bencher benchmark list --project <project>
+bencher benchmark view --project <project> <benchmark>
+
+# Measures
+bencher measure list --project <project>
+bencher measure view --project <project> <measure>
+
 # Reports
 bencher report list --project <project>
 bencher report view --project <project> <report>
@@ -169,6 +223,25 @@ bencher alert view --project <project> <alert>
 # Thresholds
 bencher threshold list --project <project>
 bencher threshold view --project <project> <threshold>
+
+# Metrics
+bencher metric list --project <project>
+
+# Plots
+bencher plot list --project <project>
+bencher plot view --project <project> <plot>
+
+# Jobs (Bencher Plus)
+bencher job list --project <project>
+bencher job view --project <project> <job>
+
+# Runners (Bencher Plus)
+bencher runner list
+bencher runner view <runner>
+
+# Specs (Bencher Plus)
+bencher spec list
+bencher spec view <spec>
 
 # Archive/Unarchive (branches, testbeds, benchmarks, measures)
 bencher archive --project <project> --branch <branch>

--- a/skills/bencher/reference.md
+++ b/skills/bencher/reference.md
@@ -1,0 +1,179 @@
+# Bencher CLI Reference
+
+## `bencher run` Flags
+
+### Project and Branch
+
+| Flag | Env Var | Default | Purpose |
+|------|---------|---------|---------|
+| `--project <slug>` | `BENCHER_PROJECT` | | Project slug or UUID |
+| `--ci-on-the-fly` | | | Auto-create project in CI |
+| `--branch <name>` | `BENCHER_BRANCH` | | Branch name/slug/UUID (auto-created) |
+| `--hash <hash>` | | HEAD | Git commit hash |
+| `--start-point <branch>` | | | Base branch for new branch |
+| `--start-point-hash <hash>` | | | Full git hash for start point |
+| `--start-point-max-versions <n>` | | 255 | Historical versions to include |
+| `--start-point-clone-thresholds` | | | Clone thresholds from start point |
+| `--start-point-reset` | | | Reset branch head to empty |
+
+### Benchmark Configuration
+
+| Flag | Env Var | Default | Purpose |
+|------|---------|---------|---------|
+| `--testbed <name>` | `BENCHER_TESTBED` | | Testbed name/slug/UUID (auto-created) |
+| `--adapter <name>` | `BENCHER_ADAPTER` | `magic` | Benchmark harness adapter |
+| `--average <type>` | | | Suggested central tendency |
+| `--iter <n>` | | 1 | Number of run iterations |
+| `--fold <fn>` | | | Aggregate function (requires `--iter`) |
+| `--backdate <epoch>` | | | Backdate report (seconds since epoch) |
+| `--allow-failure` | | | Allow benchmark command failure |
+
+### Thresholds
+
+| Flag | Purpose |
+|------|---------|
+| `--threshold-measure <measure>` | Measure for threshold |
+| `--threshold-test <model>` | Statistical test model |
+| `--threshold-upper-boundary <val>` | Upper boundary value |
+| `--threshold-lower-boundary <val>` | Lower boundary value |
+| `--error-on-alert` / `--err` | Exit non-zero on alert |
+
+### Command Execution
+
+| Flag | Env Var | Purpose |
+|------|---------|---------|
+| `--build-time` | | Track build time |
+| `--file <path>` | | Read output from file (repeatable) |
+| `--file-size <path>` | | Track file size (repeatable) |
+| `--shell <path>` | | Shell command path |
+| `--flag <flag>` | | Shell command flag |
+| `--exec` | | Run as executable, not shell command |
+| (trailing args) | `BENCHER_CMD` | Benchmark command |
+
+### Output
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--format <fmt>` | `human` | Output format: human, json, html |
+| `--quiet` / `-q` | | Only output final report |
+| `--dry-run` | | Validate without saving |
+
+### CI Integration
+
+| Flag | Purpose |
+|------|---------|
+| `--github-actions <token>` | GitHub Actions PR comments |
+| `--ci-only-thresholds` | Post only if threshold exists |
+| `--ci-only-on-alert` | Post only on alert |
+| `--ci-public-links` | Use public URLs |
+| `--ci-id <id>` | Custom CI comment identifier |
+| `--ci-number <n>` | Issue/PR number |
+
+### Bare Metal (Bencher Plus)
+
+| Flag | Purpose |
+|------|---------|
+| `--image <ref>` | OCI image reference |
+| `--spec <slug>` | Hardware spec |
+| `--entrypoint <cmd>` | Container entrypoint override |
+| `--env KEY=VALUE` | Environment variable (repeatable) |
+| `--job-timeout <secs>` | Maximum execution time |
+| `--job-poll-interval <secs>` | Poll interval |
+| `--detach` | Submit without waiting |
+
+### Backend
+
+| Flag | Env Var | Default | Purpose |
+|------|---------|---------|---------|
+| `--host <url>` | `BENCHER_HOST` | `https://api.bencher.dev` | API host |
+| `--token <jwt>` | `BENCHER_API_TOKEN` | | User API token |
+| `--key <key>` | `BENCHER_API_KEY` | | Project API key (preferred) |
+| `--timeout <secs>` | | 15 | Request timeout |
+| `--attempts <n>` | | 10 | Request attempts |
+| `--retry-after <secs>` | | 1 | Initial backoff time |
+
+## Adapters
+
+| Adapter | Language | Tool |
+|---------|----------|------|
+| `magic` | Any | Auto-detect |
+| `json` | Any | Bencher Metric Format (BMF) |
+| `c_sharp_dot_net` | C# | BenchmarkDotNet |
+| `cpp_catch2` | C++ | Catch2 |
+| `cpp_google` | C++ | Google Benchmark |
+| `dart_benchmark_harness` | Dart | benchmark_harness |
+| `go_bench` | Go | `go test -bench` |
+| `java_jmh` | Java | JMH |
+| `js_benchmark` | JavaScript | Benchmark.js |
+| `js_time` | JavaScript | console.time/timeEnd |
+| `python_asv` | Python | ASV |
+| `python_pytest` | Python | pytest-benchmark |
+| `ruby_benchmark` | Ruby | Benchmark module |
+| `rust_bench` | Rust | libtest bench (nightly) |
+| `rust_criterion` | Rust | Criterion.rs |
+| `rust_iai` | Rust | Iai |
+| `rust_iai_callgrind` | Rust | Iai-Callgrind |
+| `shell_hyperfine` | Shell | Hyperfine |
+
+## Threshold Models
+
+| Model | Slug | Use Case | Key Params |
+|-------|------|----------|------------|
+| Static | `static` | Fixed value | `lower_boundary`, `upper_boundary` |
+| Percentage | `percentage` | % change from mean | `upper_boundary` (e.g., 0.10 = 10%) |
+| z-score | `z` | Normal, large samples | `upper_boundary` (cumulative %) |
+| Student's t | `t` | Normal, small samples | `upper_boundary` (cumulative %) |
+| Log Normal | `log_normal` | Right-skewed (latency) | `upper_boundary` (cumulative %) |
+| IQR | `iqr` | Outlier-robust | `upper_boundary` (IQR multiplier) |
+| Delta IQR | `delta_iqr` | Change-based IQR | `upper_boundary` (delta multiplier) |
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `BENCHER_API_KEY` | Project-scoped API key (preferred for agents/CI) |
+| `BENCHER_API_TOKEN` | User-scoped API token |
+| `BENCHER_HOST` | API host URL |
+| `BENCHER_PROJECT` | Default project |
+| `BENCHER_BRANCH` | Default branch |
+| `BENCHER_TESTBED` | Default testbed |
+| `BENCHER_ADAPTER` | Default adapter |
+| `BENCHER_CMD` | Default benchmark command |
+
+## Common Resource Commands
+
+```bash
+# Projects
+bencher project list
+bencher project view <project>
+bencher project create --org <org> --name <name>
+
+# Branches
+bencher branch list --project <project>
+bencher branch view --project <project> <branch>
+bencher branch create --project <project> --name <name>
+
+# Testbeds
+bencher testbed list --project <project>
+bencher testbed view --project <project> <testbed>
+bencher testbed create --project <project> --name <name>
+
+# Reports
+bencher report list --project <project>
+bencher report view --project <project> <report>
+
+# Alerts
+bencher alert list --project <project>
+bencher alert view --project <project> <alert>
+
+# Thresholds
+bencher threshold list --project <project>
+bencher threshold view --project <project> <threshold>
+
+# Archive/Unarchive (branches, testbeds, benchmarks, measures)
+bencher archive --project <project> --branch <branch>
+bencher unarchive --project <project> --branch <branch>
+
+# Performance query
+bencher perf --project <project> --branch <branch> --testbed <testbed> --benchmark <benchmark> --measure <measure>
+```

--- a/skills/bencher/reference.md
+++ b/skills/bencher/reference.md
@@ -84,7 +84,7 @@
 | `--env KEY=VALUE` | Environment variable (repeatable) |
 | `--job-timeout <secs>` | Maximum execution time |
 | `--job-poll-interval <secs>` | Poll interval |
-| `--detach` | Submit without waiting |
+| `--detach` | Submit without waiting (conflicts with `--job-poll-interval`) |
 
 ### Backend
 

--- a/skills/bencher/reference.md
+++ b/skills/bencher/reference.md
@@ -115,6 +115,7 @@
 | `java_jmh` | Java | JMH |
 | `js_benchmark` | JavaScript | Benchmark.js |
 | `js_time` | JavaScript | console.time/timeEnd |
+| `js_vitest` | JavaScript | Vitest |
 | `python_asv` | Python | ASV |
 | `python_pytest` | Python | pytest-benchmark |
 | `ruby_benchmark` | Ruby | Benchmark module |
@@ -190,50 +191,50 @@ bencher noise
 
 ```bash
 # Projects
-bencher project list
+bencher project list [organization]
 bencher project view <project>
-bencher project create --org <org> --name <name>
+bencher project create <organization> --name <name>
 
 # Branches
-bencher branch list --project <project>
-bencher branch view --project <project> <branch>
-bencher branch create --project <project> --name <name>
+bencher branch list <project>
+bencher branch view <project> <branch>
+bencher branch create <project> --name <name>
 
 # Testbeds
-bencher testbed list --project <project>
-bencher testbed view --project <project> <testbed>
-bencher testbed create --project <project> --name <name>
+bencher testbed list <project>
+bencher testbed view <project> <testbed>
+bencher testbed create <project> --name <name>
 
 # Benchmarks
-bencher benchmark list --project <project>
-bencher benchmark view --project <project> <benchmark>
+bencher benchmark list <project>
+bencher benchmark view <project> <benchmark>
 
 # Measures
-bencher measure list --project <project>
-bencher measure view --project <project> <measure>
+bencher measure list <project>
+bencher measure view <project> <measure>
 
 # Reports
-bencher report list --project <project>
-bencher report view --project <project> <report>
+bencher report list <project>
+bencher report view <project> <report>
 
 # Alerts
-bencher alert list --project <project>
-bencher alert view --project <project> <alert>
+bencher alert list <project>
+bencher alert view <project> <alert>
 
 # Thresholds
-bencher threshold list --project <project>
-bencher threshold view --project <project> <threshold>
+bencher threshold list <project>
+bencher threshold view <project> <threshold>
 
-# Metrics
-bencher metric list --project <project>
+# Metrics (view only, no list)
+bencher metric view <project> <metric>
 
 # Plots
-bencher plot list --project <project>
-bencher plot view --project <project> <plot>
+bencher plot list <project>
+bencher plot view <project> <plot>
 
 # Jobs (Bencher Plus)
-bencher job list --project <project>
-bencher job view --project <project> <job>
+bencher job list <project>
+bencher job view <project> <job>
 
 # Runners (Bencher Plus)
 bencher runner list
@@ -247,6 +248,6 @@ bencher spec view <spec>
 bencher archive --project <project> --branch <branch>
 bencher unarchive --project <project> --branch <branch>
 
-# Performance query
-bencher perf --project <project> --branch <branch> --testbed <testbed> --benchmark <benchmark> --measure <measure>
+# Performance query (all flags are repeatable and take UUIDs only)
+bencher perf <project> --branches <branch-uuid> --testbeds <testbed-uuid> --benchmarks <benchmark-uuid> --measures <measure-uuid>
 ```

--- a/skills/bencher/self-hosted.md
+++ b/skills/bencher/self-hosted.md
@@ -1,0 +1,104 @@
+# Self-Hosted Bencher
+
+Run your own Bencher instance using Docker Compose via the CLI.
+
+## Quick Start
+
+```bash
+bencher up --detach
+```
+
+This starts the API server (port 61016) and Console (port 3000) in the background.
+
+Open `http://localhost:3000` to access the console and create your first account.
+
+## Point the CLI at Your Instance
+
+```bash
+export BENCHER_HOST=http://localhost:61016
+```
+
+Or pass `--host http://localhost:61016` on each command.
+
+All `bencher run` and resource commands respect `BENCHER_HOST`.
+
+## Container Management
+
+### Start
+
+```bash
+# Start all services in background
+bencher up --detach
+
+# Start only the API
+bencher up api --detach
+
+# Pin to a specific version
+bencher up --tag v0.6.4
+
+# Custom ports
+bencher up --api-port 8080 --console-port 8081
+```
+
+### Logs
+
+```bash
+# All services
+bencher logs
+
+# API only
+bencher logs api
+```
+
+### Stop
+
+```bash
+# Stop all
+bencher down
+
+# Stop only the console
+bencher down console
+```
+
+## Configuration
+
+### Environment Variables
+
+Pass environment variables to containers:
+```bash
+bencher up --api-env SECRET_KEY=mykey --api-env DATABASE_URL=sqlite:///data/bencher.db
+```
+
+### Volumes
+
+Mount host paths into containers:
+```bash
+bencher up --api-volume /host/data:/data
+```
+
+## Services
+
+| Service | Default Port | Purpose |
+|---------|-------------|---------|
+| `api` | 61016 | REST API server |
+| `console` | 3000 | Web UI |
+| `all` | Both | Default: starts everything |
+
+## Initial Setup
+
+After `bencher up`:
+
+1. Open `http://localhost:3000`
+2. Create your admin account through the console
+3. Create an organization and project
+4. Generate an API token (or project key) for CLI/CI use
+
+Or via CLI:
+```bash
+bencher auth signup --name "Admin" --email admin@example.com --host http://localhost:61016
+```
+
+## Full Documentation
+
+See https://bencher.dev/docs/tutorial/self-hosted/ for the complete self-hosted tutorial
+including production deployment, backups, and upgrades.

--- a/skills/bencher/self-hosted.md
+++ b/skills/bencher/self-hosted.md
@@ -93,9 +93,9 @@ After `bencher up`:
 3. Create an organization and project
 4. Generate a project API key (or user API key) for CLI/CI use
 
-Or via CLI:
+Or via CLI (the email is a positional argument and `--i-agree` is required):
 ```bash
-bencher auth signup --name "Admin" --email admin@example.com --host http://localhost:6610
+bencher auth signup --name "Admin" --i-agree admin@example.com --host http://localhost:6610
 ```
 
 ## Full Documentation

--- a/skills/bencher/self-hosted.md
+++ b/skills/bencher/self-hosted.md
@@ -64,10 +64,14 @@ bencher down console
 
 ### Environment Variables
 
-Pass environment variables to containers:
+Pass environment variables to containers. The API server is configured via
+`BENCHER_CONFIG` (a JSON string) or `BENCHER_CONFIG_PATH` (a path to a JSON
+file inside the container), not individual settings variables:
 ```bash
-bencher up --api-env SECRET_KEY=mykey --api-env DATABASE_URL=sqlite:///data/bencher.db
+bencher up --api-env BENCHER_CONFIG="$(cat bencher.json)"
 ```
+
+See https://bencher.dev/docs/reference/server-config/ for the config JSON schema.
 
 ### Volumes
 

--- a/skills/bencher/self-hosted.md
+++ b/skills/bencher/self-hosted.md
@@ -8,17 +8,17 @@ Run your own Bencher instance using Docker Compose via the CLI.
 bencher up --detach
 ```
 
-This starts the API server (port 61016) and Console (port 3000) in the background.
+This starts the API server (port 6610) and Console (port 3000) in the background.
 
 Open `http://localhost:3000` to access the console and create your first account.
 
 ## Point the CLI at Your Instance
 
 ```bash
-export BENCHER_HOST=http://localhost:61016
+export BENCHER_HOST=http://localhost:6610
 ```
 
-Or pass `--host http://localhost:61016` on each command.
+Or pass `--host http://localhost:6610` on each command.
 
 All `bencher run` and resource commands respect `BENCHER_HOST`.
 
@@ -34,7 +34,7 @@ bencher up --detach
 bencher up api --detach
 
 # Pin to a specific version
-bencher up --tag v0.6.4
+bencher up --tag v0.6.8
 
 # Custom ports
 bencher up --api-port 8080 --console-port 8081
@@ -80,7 +80,7 @@ bencher up --api-volume /host/data:/data
 
 | Service | Default Port | Purpose |
 |---------|-------------|---------|
-| `api` | 61016 | REST API server |
+| `api` | 6610 | REST API server |
 | `console` | 3000 | Web UI |
 | `all` | Both | Default: starts everything |
 
@@ -91,11 +91,11 @@ After `bencher up`:
 1. Open `http://localhost:3000`
 2. Create your admin account through the console
 3. Create an organization and project
-4. Generate an API token (or project key) for CLI/CI use
+4. Generate a project API key (or user API key) for CLI/CI use
 
 Or via CLI:
 ```bash
-bencher auth signup --name "Admin" --email admin@example.com --host http://localhost:61016
+bencher auth signup --name "Admin" --email admin@example.com --host http://localhost:6610
 ```
 
 ## Full Documentation

--- a/skills/bencher/self-hosted.md
+++ b/skills/bencher/self-hosted.md
@@ -33,8 +33,8 @@ bencher up --detach
 # Start only the API
 bencher up api --detach
 
-# Pin to a specific version
-bencher up --tag v0.6.8
+# Pin to a specific version tag (defaults to the CLI's own version)
+bencher up --tag vX.Y.Z
 
 # Custom ports
 bencher up --api-port 8080 --console-port 8081

--- a/skills/bencher/thresholds.md
+++ b/skills/bencher/thresholds.md
@@ -99,18 +99,18 @@ but may include stale data from before an intentional performance change.
 
 ```bash
 # List thresholds for a project
-bencher threshold list --project my-project
+bencher threshold list my-project
 
 # View a specific threshold
-bencher threshold view --project my-project <threshold-uuid>
+bencher threshold view my-project <threshold-uuid>
 
 # Create a threshold outside of bencher run
-bencher threshold create --project my-project \
+bencher threshold create my-project \
   --branch main --testbed localhost --measure latency \
   --test t --upper-boundary 0.99
 
 # Delete a threshold
-bencher threshold delete --project my-project <threshold-uuid>
+bencher threshold delete my-project <threshold-uuid>
 ```
 
 ## Multiple Measures

--- a/skills/bencher/thresholds.md
+++ b/skills/bencher/thresholds.md
@@ -10,7 +10,7 @@ The simplest way to configure thresholds is inline with `bencher run`:
 ```bash
 bencher run \
   --threshold-measure latency \
-  --threshold-test t \
+  --threshold-test t_test \
   --threshold-upper-boundary 0.99 \
   "cargo bench"
 ```
@@ -24,7 +24,7 @@ Add `--error-on-alert` (alias `--err`) to exit non-zero when an alert fires:
 ```bash
 bencher run \
   --threshold-measure latency \
-  --threshold-test t \
+  --threshold-test t_test \
   --threshold-upper-boundary 0.99 \
   --error-on-alert \
   "cargo bench"
@@ -36,16 +36,16 @@ bencher run \
 |-------|------|----------|------------|
 | Static | `static` | Fixed-value thresholds | `lower_boundary`, `upper_boundary` (absolute values) |
 | Percentage | `percentage` | Percentage change from mean | `upper_boundary` (e.g., 0.10 = 10% regression) |
-| z-score | `z` | Normal distribution, large samples (>30) | `upper_boundary` (cumulative percentage, e.g., 0.99) |
-| Student's t-test | `t` | Normal distribution, small samples (<30) | `upper_boundary` (cumulative percentage, e.g., 0.99) |
+| z-score | `z_score` (alias: `z`) | Normal distribution, large samples (>30) | `upper_boundary` (cumulative percentage, e.g., 0.99) |
+| Student's t-test | `t_test` (alias: `t`) | Normal distribution, small samples (<30) | `upper_boundary` (cumulative percentage, e.g., 0.99) |
 | Log Normal | `log_normal` | Log-normal distributions (common in latency) | `upper_boundary` (cumulative percentage) |
 | Interquartile Range | `iqr` | Skewed data, outlier-robust | `upper_boundary` (IQR multiplier, e.g., 3.0) |
 | Delta IQR | `delta_iqr` | Change-based IQR | `upper_boundary` (delta IQR multiplier) |
 
 ## Choosing a Model
 
-- **Latency benchmarks:** Use `t` (small sample) or `log_normal` (right-skewed data)
-- **Throughput benchmarks:** Use `t` or `z` (often normally distributed)
+- **Latency benchmarks:** Use `t_test` (small sample) or `log_normal` (right-skewed data)
+- **Throughput benchmarks:** Use `t_test` or `z_score` (often normally distributed)
 - **Known fixed limits:** Use `static` with exact boundary values
 - **Noisy environments:** Use `iqr` or `delta_iqr` (outlier-robust)
 - **Percentage-based checks:** Use `percentage` (e.g., "alert if >10% slower")
@@ -62,13 +62,35 @@ Thresholds can have a lower boundary, upper boundary, or both:
 --threshold-measure throughput --threshold-test t --threshold-lower-boundary 0.99
 
 # Alert on any change (both)
---threshold-measure latency --threshold-test t \
+--threshold-measure latency --threshold-test t_test \
   --threshold-lower-boundary 0.95 --threshold-upper-boundary 0.95
 ```
 
-## Sample Size and Window
+## Sample Size, Window, and Reset
 
 Thresholds use historical data from the same branch, testbed, and measure.
+
+Control the historical data used:
+```bash
+bencher run \
+  --threshold-measure latency \
+  --threshold-test t_test \
+  --threshold-min-sample-size 2 \
+  --threshold-max-sample-size 64 \
+  --threshold-window 2592000 \
+  --threshold-upper-boundary 0.99 \
+  "cargo bench"
+```
+
+| Flag | Purpose |
+|------|---------|
+| `--threshold-min-sample-size <n>` | Minimum historical samples required |
+| `--threshold-max-sample-size <n>` | Maximum historical samples to consider |
+| `--threshold-window <secs>` | Time window in seconds for historical data |
+| `--thresholds-reset` | Reset all unspecified thresholds for the branch and testbed |
+
+Use `_` as a value to explicitly ignore a parameter (leave it unset).
+
 The `--start-point-max-versions` flag controls how much history is available
 (default: 255 versions). More history gives better statistical confidence
 but may include stale data from before an intentional performance change.
@@ -98,10 +120,10 @@ add multiple threshold flag groups:
 ```bash
 bencher run \
   --threshold-measure latency \
-  --threshold-test t \
+  --threshold-test t_test \
   --threshold-upper-boundary 0.99 \
   --threshold-measure throughput \
-  --threshold-test t \
+  --threshold-test t_test \
   --threshold-lower-boundary 0.95 \
   "cargo bench"
 ```

--- a/skills/bencher/thresholds.md
+++ b/skills/bencher/thresholds.md
@@ -1,0 +1,107 @@
+# Thresholds and Alerts
+
+Thresholds define statistical boundaries for benchmark results.
+When a new result exceeds the boundary, Bencher generates an alert,
+signaling a potential performance regression.
+
+## Inline Threshold Creation
+
+The simplest way to configure thresholds is inline with `bencher run`:
+```bash
+bencher run \
+  --threshold-measure latency \
+  --threshold-test t \
+  --threshold-upper-boundary 0.99 \
+  "cargo bench"
+```
+
+This creates (or updates) a threshold for the `latency` measure using a
+Student's t-test with a 99% confidence upper boundary.
+
+## Fail CI on Alert
+
+Add `--error-on-alert` (alias `--err`) to exit non-zero when an alert fires:
+```bash
+bencher run \
+  --threshold-measure latency \
+  --threshold-test t \
+  --threshold-upper-boundary 0.99 \
+  --error-on-alert \
+  "cargo bench"
+```
+
+## Statistical Models
+
+| Model | Slug | Best For | Key Params |
+|-------|------|----------|------------|
+| Static | `static` | Fixed-value thresholds | `lower_boundary`, `upper_boundary` (absolute values) |
+| Percentage | `percentage` | Percentage change from mean | `upper_boundary` (e.g., 0.10 = 10% regression) |
+| z-score | `z` | Normal distribution, large samples (>30) | `upper_boundary` (cumulative percentage, e.g., 0.99) |
+| Student's t-test | `t` | Normal distribution, small samples (<30) | `upper_boundary` (cumulative percentage, e.g., 0.99) |
+| Log Normal | `log_normal` | Log-normal distributions (common in latency) | `upper_boundary` (cumulative percentage) |
+| Interquartile Range | `iqr` | Skewed data, outlier-robust | `upper_boundary` (IQR multiplier, e.g., 3.0) |
+| Delta IQR | `delta_iqr` | Change-based IQR | `upper_boundary` (delta IQR multiplier) |
+
+## Choosing a Model
+
+- **Latency benchmarks:** Use `t` (small sample) or `log_normal` (right-skewed data)
+- **Throughput benchmarks:** Use `t` or `z` (often normally distributed)
+- **Known fixed limits:** Use `static` with exact boundary values
+- **Noisy environments:** Use `iqr` or `delta_iqr` (outlier-robust)
+- **Percentage-based checks:** Use `percentage` (e.g., "alert if >10% slower")
+
+## Boundary Configuration
+
+Thresholds can have a lower boundary, upper boundary, or both:
+
+```bash
+# Alert if latency increases (upper only, most common)
+--threshold-measure latency --threshold-test t --threshold-upper-boundary 0.99
+
+# Alert if throughput decreases (lower only)
+--threshold-measure throughput --threshold-test t --threshold-lower-boundary 0.99
+
+# Alert on any change (both)
+--threshold-measure latency --threshold-test t \
+  --threshold-lower-boundary 0.95 --threshold-upper-boundary 0.95
+```
+
+## Sample Size and Window
+
+Thresholds use historical data from the same branch, testbed, and measure.
+The `--start-point-max-versions` flag controls how much history is available
+(default: 255 versions). More history gives better statistical confidence
+but may include stale data from before an intentional performance change.
+
+## Managing Thresholds via CLI
+
+```bash
+# List thresholds for a project
+bencher threshold list --project my-project
+
+# View a specific threshold
+bencher threshold view --project my-project <threshold-uuid>
+
+# Create a threshold outside of bencher run
+bencher threshold create --project my-project \
+  --branch main --testbed localhost --measure latency \
+  --test t --upper-boundary 0.99
+
+# Delete a threshold
+bencher threshold delete --project my-project <threshold-uuid>
+```
+
+## Multiple Measures
+
+If your benchmark produces multiple measures (e.g., latency and throughput),
+add multiple threshold flag groups:
+```bash
+bencher run \
+  --threshold-measure latency \
+  --threshold-test t \
+  --threshold-upper-boundary 0.99 \
+  --threshold-measure throughput \
+  --threshold-test t \
+  --threshold-lower-boundary 0.95 \
+  "cargo bench"
+```


### PR DESCRIPTION
## What

Make the Bencher repo installable as a Claude Code plugin:

- `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` manifests, with the plugin version kept in sync by `scripts/tag.sh`
- A `bencher` skill (`skills/bencher/`) covering local runs, CI integration, thresholds, bare metal, self-hosted setup, and a full CLI command reference
- A "Claude Code" install section in the install CLI docs for all 9 languages
- A skill sync rule in `services/cli/CLAUDE.md` so future CLI changes keep the skill files up to date

## Notes

- The skill command examples were verified against the CLI parsers: positional project arguments, `bencher perf` flag names, and the adapter list (including `js_vitest`)
- The GitLab CI example posts MR notes with a project access token, since the built-in `CI_JOB_TOKEN` cannot post notes