### PR TITLE
Add `cargo ops isolate` subcommand for CPU isolation boot args

### DIFF
--- a/tasks/runner_ops/CLAUDE.md
+++ b/tasks/runner_ops/CLAUDE.md
@@ -51,6 +51,15 @@ cargo ops logs <runner> --follow
 cargo ops provision <runner>
 ```
 
+### CPU isolation boot args
+
+Configure `isolcpus=`/`nohz_full=`/`rcu_nocbs=` kernel boot args for the benchmark cores via a GRUB drop-in (`/etc/default/grub.d/99-bencher-isolation.cfg`), then reboot the server and verify. This clears the runner preflight notice about missing isolation boot args. Idempotent: exits early if the cmdline already has the args (presence-only; it will not re-scope an existing CPU list, even with `--cpus`). The benchmark CPU list defaults to `1-(nproc-1)` (CPU 0 is housekeeping); override with `--cpus`.
+
+```bash
+cargo ops isolate <runner>
+cargo ops isolate <runner> --cpus 1-5
+```
+
 ## How It Works
 
 1. `deploy` downloads the runner binary from a GitHub Actions CI artifact, SSHes into the server, stops the existing service, copies the new binary, configures systemd, and starts the service.

--- a/tasks/runner_ops/src/parser/mod.rs
+++ b/tasks/runner_ops/src/parser/mod.rs
@@ -14,6 +14,8 @@ pub struct TaskRunnerOps {
 pub enum TaskSub {
     /// Full provisioning: install OS, harden, and deploy runner
     Provision(TaskProvision),
+    /// Configure kernel boot args for CPU isolation and reboot
+    Isolate(TaskIsolate),
     /// Download latest runner binary from CI and deploy to server
     Deploy(TaskDeploy),
     /// Show runner binary version
@@ -46,6 +48,28 @@ pub struct TaskProvision {
     /// Path to runner binary to deploy (Linux `x86_64`)
     #[clap(long)]
     pub runner_binary: Option<Utf8PathBuf>,
+}
+
+#[derive(Parser, Debug)]
+pub struct TaskIsolate {
+    /// Runner slug or UUID (for runners.json lookup)
+    pub runner: Option<RunnerResourceId>,
+
+    /// IP address or hostname of the server
+    #[clap(long, required_unless_present = "runner")]
+    pub server: Option<String>,
+
+    /// Path to SSH private key
+    #[clap(long, required_unless_present = "runner")]
+    pub ssh: Option<Utf8PathBuf>,
+
+    /// SSH user
+    #[clap(long)]
+    pub user: Option<String>,
+
+    /// Benchmark CPU list to isolate (e.g. `1-5`; defaults to `1-(nproc-1)`)
+    #[clap(long)]
+    pub cpus: Option<String>,
 }
 
 #[derive(Parser, Debug)]

--- a/tasks/runner_ops/src/task/install_os.rs
+++ b/tasks/runner_ops/src/task/install_os.rs
@@ -1,6 +1,3 @@
-use std::thread;
-use std::time::Duration;
-
 use super::ssh::Ssh;
 
 const AUTOSETUP_CONFIG: &str = "\
@@ -14,9 +11,6 @@ PART /boot ext4 1G
 PART swap swap 4G
 PART / ext4 all
 IMAGE /root/.oldroot/nfs/images/Ubuntu-2404-noble-amd64-base.tar.gz";
-
-const REBOOT_POLL_INTERVAL: Duration = Duration::from_secs(10);
-const REBOOT_TIMEOUT: Duration = Duration::from_mins(5);
 
 pub fn install_os(ssh: &Ssh) -> anyhow::Result<()> {
     // Detect if we're in rescue mode
@@ -34,7 +28,10 @@ pub fn install_os(ssh: &Ssh) -> anyhow::Result<()> {
     ))?;
     ssh.run("/root/.oldroot/nfs/install/installimage -a -c /tmp/autosetup")?;
 
-    // Reboot (will disconnect — ignore connection error)
+    // Capture the rescue system's boot ID to detect the post-install boot
+    let boot_id = ssh.boot_id()?;
+
+    // Reboot (will disconnect; ignore connection error)
     println!("Rebooting server...");
     let _ignored = ssh.run("reboot");
 
@@ -44,37 +41,7 @@ pub fn install_os(ssh: &Ssh) -> anyhow::Result<()> {
     ssh.remove_known_host()?;
 
     // Wait for SSH to come back up
-    wait_for_ssh(ssh)?;
+    ssh.wait_for_reboot(&boot_id)?;
 
     Ok(())
-}
-
-fn wait_for_ssh(ssh: &Ssh) -> anyhow::Result<()> {
-    println!("Waiting for server to come back online...");
-    let mut elapsed = Duration::ZERO;
-    loop {
-        thread::sleep(REBOOT_POLL_INTERVAL);
-        elapsed += REBOOT_POLL_INTERVAL;
-
-        if elapsed > REBOOT_TIMEOUT {
-            anyhow::bail!(
-                "Server did not come back online within {} seconds",
-                REBOOT_TIMEOUT.as_secs()
-            );
-        }
-
-        match ssh.check("true") {
-            Ok(true) => {
-                println!("Server is back online");
-                return Ok(());
-            },
-            _ => {
-                println!(
-                    "Still waiting... ({}/{}s)",
-                    elapsed.as_secs(),
-                    REBOOT_TIMEOUT.as_secs()
-                );
-            },
-        }
-    }
 }

--- a/tasks/runner_ops/src/task/isolate.rs
+++ b/tasks/runner_ops/src/task/isolate.rs
@@ -1,0 +1,210 @@
+use anyhow::Context as _;
+
+use super::merge_ssh;
+use super::ssh::Ssh;
+use super::stop::stop_service;
+use crate::parser::TaskIsolate;
+use crate::parser::server::load_server;
+
+const GRUB_DROP_IN: &str = "/etc/default/grub.d/99-bencher-isolation.cfg";
+
+#[derive(Debug)]
+pub struct Isolate {
+    ssh: Ssh,
+    cpus: Option<String>,
+}
+
+impl TryFrom<TaskIsolate> for Isolate {
+    type Error = anyhow::Error;
+
+    fn try_from(task: TaskIsolate) -> anyhow::Result<Self> {
+        let TaskIsolate {
+            runner,
+            server,
+            ssh,
+            user,
+            cpus,
+        } = task;
+        let file = runner.as_ref().map(load_server).transpose()?.flatten();
+        let (server, ssh, user) = merge_ssh(file.as_ref(), server, ssh, user)?;
+        Ok(Self {
+            ssh: Ssh::new(server, ssh, user),
+            cpus,
+        })
+    }
+}
+
+impl Isolate {
+    pub fn exec(self) -> anyhow::Result<()> {
+        let Self { ssh, cpus } = self;
+
+        let cmdline = ssh.run("cat /proc/cmdline")?;
+        if is_isolated(&cmdline) {
+            println!("CPU isolation boot args already configured");
+            return Ok(());
+        }
+
+        let nproc = ssh
+            .run("nproc")?
+            .trim()
+            .parse()
+            .context("failed to parse `nproc` output")?;
+        let cpus = if let Some(cpus) = cpus {
+            cpus
+        } else {
+            benchmark_cpus(nproc)?
+        };
+        validate_cpu_list(&cpus, nproc)?;
+
+        println!("Configuring CPU isolation boot args for CPUs {cpus}...");
+        let cfg = isolation_cfg(&cpus);
+        ssh.run(&format!(
+            "mkdir -p /etc/default/grub.d && cat > {GRUB_DROP_IN} << 'GRUB_EOF'\n{cfg}\nGRUB_EOF"
+        ))?;
+        ssh.run("update-grub")?;
+
+        let boot_id = ssh.boot_id()?;
+        stop_service(&ssh)?;
+
+        // Reboot (will disconnect; ignore connection error)
+        println!("Rebooting server...");
+        let _ignored = ssh.run("reboot");
+        ssh.wait_for_reboot(&boot_id)?;
+
+        let cmdline = ssh.run("cat /proc/cmdline")?;
+        if !is_isolated(&cmdline) {
+            anyhow::bail!("CPU isolation boot args did not take effect: {cmdline}");
+        }
+        println!("CPU isolation boot args are active");
+
+        if ssh.check("systemctl is-active --quiet bencher-runner")? {
+            println!("Runner is running");
+        } else {
+            println!(
+                "Runner service is not active yet; check `cargo ops logs` or restart it with `cargo ops start`"
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Whether the kernel cmdline already has CPU isolation boot args.
+/// Mirrors the runner preflight check: either arg counts as isolation.
+fn is_isolated(cmdline: &str) -> bool {
+    cmdline.contains("isolcpus=") || cmdline.contains("nohz_full=")
+}
+
+/// Benchmark CPU list: CPU 0 is housekeeping, the rest run benchmarks.
+/// Assumes contiguous logical CPU numbering; pass `--cpus` explicitly for
+/// non-trivial topologies (e.g. SMT sibling layouts).
+fn benchmark_cpus(nproc: u32) -> anyhow::Result<String> {
+    match nproc {
+        0 | 1 => anyhow::bail!("CPU isolation requires at least 2 CPUs, found {nproc}"),
+        2 => Ok("1".to_owned()),
+        _ => Ok(format!("1-{}", nproc - 1)),
+    }
+}
+
+/// Validate a kernel CPU list (comma-separated CPUs or ascending `a-b` ranges)
+/// so typos fail fast instead of after a reboot cycle.
+/// CPU 0 is reserved for housekeeping and values must be below `nproc`.
+fn validate_cpu_list(cpus: &str, nproc: u32) -> anyhow::Result<()> {
+    let parse_cpu = |cpu: &str| {
+        cpu.parse::<u32>()
+            .ok()
+            .filter(|cpu| (1..nproc).contains(cpu))
+    };
+    let valid = !cpus.is_empty()
+        && cpus.split(',').all(|part| {
+            let mut bounds = part.split('-');
+            match (bounds.next(), bounds.next(), bounds.next()) {
+                (Some(cpu), None, None) => parse_cpu(cpu).is_some(),
+                (Some(start), Some(end), None) => matches!(
+                    (parse_cpu(start), parse_cpu(end)),
+                    (Some(start), Some(end)) if start <= end
+                ),
+                _ => false,
+            }
+        });
+    if valid {
+        Ok(())
+    } else {
+        anyhow::bail!("invalid CPU list for {nproc} CPUs: {cpus}")
+    }
+}
+
+/// Build the contents of the GRUB drop-in, appending to the existing cmdline.
+fn isolation_cfg(cpus: &str) -> String {
+    format!(
+        "GRUB_CMDLINE_LINUX_DEFAULT=\"$GRUB_CMDLINE_LINUX_DEFAULT isolcpus={cpus} nohz_full={cpus} rcu_nocbs={cpus}\""
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_isolated_detects_either_arg() {
+        assert!(is_isolated("ro isolcpus=1-5 quiet"));
+        assert!(is_isolated("ro nohz_full=1-5 quiet"));
+        assert!(!is_isolated(
+            "BOOT_IMAGE=/vmlinuz-6.8.0-90-generic ro consoleblank=0"
+        ));
+    }
+
+    #[test]
+    fn benchmark_cpus_range() {
+        assert_eq!(benchmark_cpus(6).unwrap(), "1-5");
+        assert_eq!(benchmark_cpus(12).unwrap(), "1-11");
+    }
+
+    #[test]
+    fn benchmark_cpus_single() {
+        assert_eq!(benchmark_cpus(2).unwrap(), "1");
+    }
+
+    #[test]
+    fn benchmark_cpus_too_few() {
+        benchmark_cpus(0).unwrap_err();
+        benchmark_cpus(1).unwrap_err();
+    }
+
+    #[test]
+    fn validate_cpu_list_ok() {
+        validate_cpu_list("1", 2).unwrap();
+        validate_cpu_list("1-5", 6).unwrap();
+        validate_cpu_list("1,3,5", 6).unwrap();
+        validate_cpu_list("1-5,7", 8).unwrap();
+    }
+
+    #[test]
+    fn validate_cpu_list_invalid() {
+        validate_cpu_list("", 6).unwrap_err();
+        validate_cpu_list("1-", 6).unwrap_err();
+        validate_cpu_list(",1", 6).unwrap_err();
+        validate_cpu_list("1--5", 6).unwrap_err();
+        validate_cpu_list("1 5", 6).unwrap_err();
+        validate_cpu_list("garbage", 6).unwrap_err();
+        validate_cpu_list("1-2-3", 6).unwrap_err();
+        validate_cpu_list("5-1", 6).unwrap_err();
+    }
+
+    #[test]
+    fn validate_cpu_list_out_of_bounds() {
+        // CPU 0 is the housekeeping core
+        validate_cpu_list("0-5", 6).unwrap_err();
+        // Values must be below nproc
+        validate_cpu_list("1-6", 6).unwrap_err();
+        validate_cpu_list("1-9999", 6).unwrap_err();
+    }
+
+    #[test]
+    fn isolation_cfg_appends_all_args() {
+        let cfg = isolation_cfg("1-5");
+        assert_eq!(
+            cfg,
+            "GRUB_CMDLINE_LINUX_DEFAULT=\"$GRUB_CMDLINE_LINUX_DEFAULT isolcpus=1-5 nohz_full=1-5 rcu_nocbs=1-5\""
+        );
+    }
+}

--- a/tasks/runner_ops/src/task/mod.rs
+++ b/tasks/runner_ops/src/task/mod.rs
@@ -3,6 +3,7 @@ mod deploy_setup;
 mod download;
 mod harden;
 mod install_os;
+mod isolate;
 mod logs;
 mod provision;
 pub mod ssh;
@@ -17,6 +18,7 @@ use clap::Parser as _;
 use crate::parser::server::{Server, load_server};
 use crate::parser::{TaskRunnerOps, TaskSub};
 use deploy::Deploy;
+use isolate::Isolate;
 use logs::Logs;
 use provision::Provision;
 use ssh::Ssh;
@@ -37,6 +39,7 @@ pub struct Task {
 #[derive(Debug)]
 enum Sub {
     Provision(Provision),
+    Isolate(Isolate),
     Deploy(Deploy),
     Version(Version),
     Start(Start),
@@ -60,6 +63,7 @@ impl TryFrom<TaskSub> for Sub {
     fn try_from(sub: TaskSub) -> anyhow::Result<Self> {
         Ok(match sub {
             TaskSub::Provision(provision) => Self::Provision(provision.try_into()?),
+            TaskSub::Isolate(isolate) => Self::Isolate(isolate.try_into()?),
             TaskSub::Deploy(deploy) => Self::Deploy(deploy.try_into()?),
             TaskSub::Version(version) => Self::Version(version.try_into()?),
             TaskSub::Start(start) => Self::Start(start.try_into()?),
@@ -83,6 +87,7 @@ impl Sub {
     fn exec(self) -> anyhow::Result<()> {
         match self {
             Self::Provision(provision) => provision.exec(),
+            Self::Isolate(isolate) => isolate.exec(),
             Self::Deploy(deploy) => deploy.exec(),
             Self::Version(version) => version.exec(),
             Self::Start(start) => start.exec(),

--- a/tasks/runner_ops/src/task/ssh.rs
+++ b/tasks/runner_ops/src/task/ssh.rs
@@ -1,6 +1,12 @@
 use std::process::Command;
+use std::thread;
+use std::time::Duration;
 
 use camino::{Utf8Path, Utf8PathBuf};
+
+const REBOOT_POLL_INTERVAL: Duration = Duration::from_secs(10);
+const REBOOT_TIMEOUT: Duration = Duration::from_mins(5);
+const BOOT_ID_CMD: &str = "cat /proc/sys/kernel/random/boot_id";
 
 #[derive(Debug)]
 pub struct Ssh {
@@ -93,6 +99,44 @@ impl Ssh {
             Ok(())
         } else {
             anyhow::bail!("SSH command failed (exit {})", status.code().unwrap_or(-1));
+        }
+    }
+
+    /// Read the kernel boot ID, used to detect when a reboot has completed.
+    pub fn boot_id(&self) -> anyhow::Result<String> {
+        Ok(self.run(BOOT_ID_CMD)?.trim().to_owned())
+    }
+
+    /// Wait for the server to come back online after a reboot.
+    /// A probe only counts once the boot ID differs from `old_boot_id`,
+    /// so a not-yet-rebooted system cannot satisfy the wait.
+    pub fn wait_for_reboot(&self, old_boot_id: &str) -> anyhow::Result<()> {
+        println!("Waiting for server to come back online...");
+        let mut elapsed = Duration::ZERO;
+        loop {
+            thread::sleep(REBOOT_POLL_INTERVAL);
+            elapsed += REBOOT_POLL_INTERVAL;
+
+            if elapsed > REBOOT_TIMEOUT {
+                anyhow::bail!(
+                    "Server did not come back online within {} seconds",
+                    REBOOT_TIMEOUT.as_secs()
+                );
+            }
+
+            match self.run(BOOT_ID_CMD) {
+                Ok(boot_id) if boot_id.trim() != old_boot_id => {
+                    println!("Server is back online");
+                    return Ok(());
+                },
+                _ => {
+                    println!(
+                        "Still waiting... ({}/{}s)",
+                        elapsed.as_secs(),
+                        REBOOT_TIMEOUT.as_secs()
+                    );
+                },
+            }
         }
     }
 


### PR DESCRIPTION
## What

Add a new `cargo ops isolate <runner>` subcommand to the runner ops tooling. It configures the kernel boot args for full CPU isolation on a bare metal runner server (`isolcpus=`, `nohz_full=`, `rcu_nocbs=`), then reboots the server and verifies the args took effect.

- Idempotent: exits early if `/proc/cmdline` already contains `isolcpus=` or `nohz_full=`, mirroring the runner preflight detection
- Benchmark CPU list defaults to `1-(nproc-1)` queried from the server (CPU 0 stays housekeeping); `--cpus` overrides
- Writes a GRUB drop-in at `/etc/default/grub.d/99-bencher-isolation.cfg` that appends to `GRUB_CMDLINE_LINUX_DEFAULT`, then runs `update-grub`
- Stops the runner service, reboots, waits for SSH to come back, and verifies the new cmdline
- Reports whether the runner service came back up after the reboot

## Why

The runner preflight added in #923 warns when the kernel boots without `isolcpus=`/`nohz_full=`. The runtime cpuset partition only partially compensates: tickless cores (`nohz_full`) and RCU callback offload (`rcu_nocbs`) can only be configured at boot. This subcommand makes applying the boot args a repeatable operation instead of a manual SSH session.

## How

- `tasks/runner_ops/src/task/isolate.rs`: new task, with unit tests for the cmdline detection, CPU list derivation, and drop-in contents
- `tasks/runner_ops/src/parser/mod.rs`: new `isolate` subcommand parser
- `tasks/runner_ops/src/task/ssh.rs`: the reboot wait loop moved out of `install_os.rs` into a shared `Ssh::wait_for_reboot()` method
- `tasks/runner_ops/CLAUDE.md`: document the new operation
