### PR TITLE
Sort `cargo ops isolate` GRUB drop-in after provider drop-ins

### DIFF
--- a/tasks/runner_ops/CLAUDE.md
+++ b/tasks/runner_ops/CLAUDE.md
@@ -53,7 +53,7 @@ cargo ops provision <runner>
 
 ### CPU isolation boot args
 
-Configure `isolcpus=`/`nohz_full=`/`rcu_nocbs=` kernel boot args for the benchmark cores via a GRUB drop-in (`/etc/default/grub.d/99-bencher-isolation.cfg`), then reboot the server and verify. This clears the runner preflight notice about missing isolation boot args. Idempotent: exits early if the cmdline already has the args (presence-only; it will not re-scope an existing CPU list, even with `--cpus`). The benchmark CPU list defaults to `1-(nproc-1)` (CPU 0 is housekeeping); override with `--cpus`.
+Configure `isolcpus=`/`nohz_full=`/`rcu_nocbs=` kernel boot args for the benchmark cores via a GRUB drop-in (`/etc/default/grub.d/zz-bencher-isolation.cfg`, named to sort after provider drop-ins that overwrite `GRUB_CMDLINE_LINUX_DEFAULT`), then reboot the server and verify. This clears the runner preflight notice about missing isolation boot args. Idempotent: exits early if the cmdline already has the args (presence-only; it will not re-scope an existing CPU list, even with `--cpus`). The benchmark CPU list defaults to `1-(nproc-1)` (CPU 0 is housekeeping); override with `--cpus`.
 
 ```bash
 cargo ops isolate <runner>

--- a/tasks/runner_ops/src/task/isolate.rs
+++ b/tasks/runner_ops/src/task/isolate.rs
@@ -6,7 +6,10 @@ use super::stop::stop_service;
 use crate::parser::TaskIsolate;
 use crate::parser::server::load_server;
 
-const GRUB_DROP_IN: &str = "/etc/default/grub.d/99-bencher-isolation.cfg";
+// The `zz-` prefix sorts this drop-in after provider drop-ins (e.g. Hetzner's
+// `hetzner.cfg`) that overwrite GRUB_CMDLINE_LINUX_DEFAULT instead of
+// appending; /etc/default/grub.d/*.cfg files are sourced in glob order.
+const GRUB_DROP_IN: &str = "/etc/default/grub.d/zz-bencher-isolation.cfg";
 
 #[derive(Debug)]
 pub struct Isolate {
@@ -62,6 +65,11 @@ impl Isolate {
             "mkdir -p /etc/default/grub.d && cat > {GRUB_DROP_IN} << 'GRUB_EOF'\n{cfg}\nGRUB_EOF"
         ))?;
         ssh.run("update-grub")?;
+        if !ssh.check(&format!("grep -qF 'isolcpus={cpus}' /boot/grub/grub.cfg"))? {
+            anyhow::bail!(
+                "generated GRUB config is missing the isolation args; another /etc/default/grub.d drop-in may be overwriting GRUB_CMDLINE_LINUX_DEFAULT"
+            );
+        }
 
         let boot_id = ssh.boot_id()?;
         stop_service(&ssh)?;


### PR DESCRIPTION
## What

Follow-up to #954, fixing an issue found in field testing of `cargo ops isolate`:

- Rename the GRUB drop-in from `99-bencher-isolation.cfg` to `zz-bencher-isolation.cfg`. Provider images can ship their own `/etc/default/grub.d` drop-in (e.g. Hetzner's `hetzner.cfg`) that overwrites `GRUB_CMDLINE_LINUX_DEFAULT` instead of appending to it. Drop-ins are sourced in glob order, so `99-` sorted before `hetzner.cfg` and our args were silently clobbered; `zz-` sorts last.
- Verify the generated `/boot/grub/grub.cfg` actually contains the isolation args after `update-grub` and before rebooting. A clobbered cmdline now fails fast with a pointer at drop-in ordering, instead of only surfacing after a wasted reboot cycle.

## Why

Without the ordering fix, the command completed `update-grub` successfully but the rebooted kernel came up without any isolation args, and the failure was only detected by the post-reboot cmdline check.

## How

- `tasks/runner_ops/src/task/isolate.rs`: `GRUB_DROP_IN` renamed with a comment explaining the ordering constraint; pre-reboot `grep` check on the generated config
- `tasks/runner_ops/CLAUDE.md`: document the drop-in name and why it sorts last
