### PR TITLE
Fix report table percent difference when a metric drops to zero

### DIFF
--- a/lib/bencher_comment/src/lib.rs
+++ b/lib/bencher_comment/src/lib.rs
@@ -920,11 +920,7 @@ fn value_cell(
         }
 
         if let Some(baseline) = baseline {
-            let percent = if value.is_normal() && baseline.is_normal() {
-                ((value - baseline) / baseline) * 100.0
-            } else {
-                0.0.into()
-            };
+            let percent = percent_difference(value, baseline);
             let plus = if percent > 0.0.into() { "+" } else { "" };
             let percent = Units::format_float(percent.into());
             let baseline = Units::format_float((baseline / factor).into());
@@ -955,6 +951,21 @@ fn value_cell(
     html.push_str("</td>");
 }
 
+/// The percent difference between a value and its baseline.
+///
+/// Only the baseline has to be non-zero.
+/// A value of zero is a `-100.00%` difference from a positive baseline,
+/// not a `0.00%` difference.
+/// There is no percent difference from a zero baseline (`±∞`)
+/// nor from a non-finite value, so fall back to zero.
+fn percent_difference(value: OrderedFloat<f64>, baseline: OrderedFloat<f64>) -> OrderedFloat<f64> {
+    if baseline.is_normal() && value.is_finite() {
+        ((value - baseline) / baseline) * 100.0
+    } else {
+        0.0.into()
+    }
+}
+
 fn lower_limit_cell(
     html: &mut String,
     value: OrderedFloat<f64>,
@@ -968,11 +979,7 @@ fn lower_limit_cell(
         return;
     };
 
-    let percent = if value.is_normal() && limit.is_normal() {
-        (limit / value) * 100.0
-    } else {
-        0.0.into()
-    };
+    let percent = percent_of(limit, value);
 
     limit_cell(html, limit, percent, factor, units_symbol, bold);
 }
@@ -990,13 +997,23 @@ fn upper_limit_cell(
         return;
     };
 
-    let percent = if value.is_normal() && limit.is_normal() {
-        (value / limit) * 100.0
-    } else {
-        0.0.into()
-    };
+    let percent = percent_of(value, limit);
 
     limit_cell(html, limit, percent, factor, units_symbol, bold);
+}
+
+/// The numerator as a percent of the denominator.
+///
+/// Only the denominator has to be non-zero.
+/// A numerator of zero is `0.00%` of a positive denominator.
+/// There is no percent of a zero denominator (`±∞`)
+/// nor of a non-finite numerator, so fall back to zero.
+fn percent_of(numerator: OrderedFloat<f64>, denominator: OrderedFloat<f64>) -> OrderedFloat<f64> {
+    if denominator.is_normal() && numerator.is_finite() {
+        (numerator / denominator) * 100.0
+    } else {
+        0.0.into()
+    }
 }
 
 fn limit_cell(
@@ -1138,8 +1155,9 @@ mod tests {
         DateTime, JsonBranch, JsonHead, JsonProject, JsonReport, JsonReportCounts, JsonTestbed,
         project::{Visibility, report::Adapter},
     };
+    use ordered_float::OrderedFloat;
 
-    use crate::{ReportComment, SubAdapter};
+    use crate::{ReportComment, SubAdapter, percent_difference, percent_of, value_cell};
 
     const CONSOLE_URL: &str = "https://bencher.example.com";
 
@@ -1235,5 +1253,97 @@ mod tests {
         let testbed_pos = html.find(testbed).expect("missing testbed row");
         assert!(project_pos < branch_pos);
         assert!(branch_pos < testbed_pos);
+    }
+
+    #[test]
+    fn percent_difference_value() {
+        // A value that drops all the way to zero is a 100% improvement,
+        // not a 0% no-op.
+        assert_eq!(
+            percent_difference(OrderedFloat(0.0), OrderedFloat(3_069_448.0)),
+            OrderedFloat(-100.0)
+        );
+        assert_eq!(
+            percent_difference(OrderedFloat(50.0), OrderedFloat(100.0)),
+            OrderedFloat(-50.0)
+        );
+        assert_eq!(
+            percent_difference(OrderedFloat(150.0), OrderedFloat(100.0)),
+            OrderedFloat(50.0)
+        );
+        assert_eq!(
+            percent_difference(OrderedFloat(100.0), OrderedFloat(100.0)),
+            OrderedFloat(0.0)
+        );
+    }
+
+    #[test]
+    fn percent_difference_zero_baseline() {
+        // There is no percent difference from a zero baseline
+        // nor from a non-finite value,
+        // so fall back to zero instead of infinity or `NaN`.
+        assert_eq!(
+            percent_difference(OrderedFloat(0.0), OrderedFloat(0.0)),
+            OrderedFloat(0.0)
+        );
+        assert_eq!(
+            percent_difference(OrderedFloat(100.0), OrderedFloat(0.0)),
+            OrderedFloat(0.0)
+        );
+        assert_eq!(
+            percent_difference(OrderedFloat(100.0), OrderedFloat(f64::INFINITY)),
+            OrderedFloat(0.0)
+        );
+        assert_eq!(
+            percent_difference(OrderedFloat(f64::INFINITY), OrderedFloat(100.0)),
+            OrderedFloat(0.0)
+        );
+    }
+
+    #[test]
+    fn percent_of_value() {
+        // A zero numerator is zero percent of the denominator.
+        assert_eq!(
+            percent_of(OrderedFloat(0.0), OrderedFloat(100.0)),
+            OrderedFloat(0.0)
+        );
+        assert_eq!(
+            percent_of(OrderedFloat(50.0), OrderedFloat(100.0)),
+            OrderedFloat(50.0)
+        );
+        assert_eq!(
+            percent_of(OrderedFloat(100.0), OrderedFloat(100.0)),
+            OrderedFloat(100.0)
+        );
+        // A zero denominator has no percent, so fall back to zero.
+        assert_eq!(
+            percent_of(OrderedFloat(100.0), OrderedFloat(0.0)),
+            OrderedFloat(0.0)
+        );
+        assert_eq!(
+            percent_of(OrderedFloat(0.0), OrderedFloat(0.0)),
+            OrderedFloat(0.0)
+        );
+    }
+
+    #[test]
+    fn value_cell_zero_value() {
+        let mut html = String::new();
+        value_cell(
+            &mut html,
+            OrderedFloat(0.0),
+            Some(OrderedFloat(3_069_448.0)),
+            OrderedFloat(1.0),
+            "B",
+            false,
+        );
+        assert!(
+            html.contains("<summary>(-100.00%)</summary>"),
+            "unexpected value cell: {html}"
+        );
+        assert!(
+            html.contains("Baseline: 3,069,448.00 B"),
+            "unexpected value cell: {html}"
+        );
     }
 }

--- a/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
+++ b/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx
@@ -1,3 +1,6 @@
+## Pending `v0.6.11`
+- Fix the percent difference shown in the report table when a metric drops to zero; a value of `0.00` against a positive baseline now shows `-100.00%` instead of `0.00%` in both the Console and the CI comment (Thank you [@OmarTawfik](https://github.com/OmarTawfik))
+
 ## `v0.6.10`
 - Add a Y-Axis scale toggle to perf plots with three modes (Auto, Linear, and Log); the Auto default preserves the existing adaptive scaling, Log falls back to Auto when the data includes zero or negative values, and the selection is saved in the plot URL, restored for pinned plots, and can be set with `bencher plot create --y-axis` or changed with `bencher plot update --y-axis`
 - Selecting a pinned plot from the Plots tab in the Perf explorer now applies the plot's saved X-Axis and Y-Axis instead of the defaults

--- a/services/console/src/components/console/deck/hand/card/ReportCard.tsx
+++ b/services/console/src/components/console/deck/hand/card/ReportCard.tsx
@@ -21,6 +21,7 @@ import {
 	scale_units_symbol,
 } from "../../../../../util/scale";
 import { BACK_PARAM, encodePath } from "../../../../../util/url";
+import { percentDifference, percentOf } from "./percent";
 
 export interface Props {
 	isConsole?: boolean;
@@ -543,9 +544,7 @@ const ValueCell = (props: {
 
 		const percent =
 			typeof props.baseline === "number"
-				? props.value > 0 && props.baseline > 0
-					? ((props.value - props.baseline) / props.baseline) * 100
-					: 0.0
+				? percentDifference(props.value, props.baseline)
 				: null;
 
 		return (
@@ -609,10 +608,7 @@ const LowerLimitCell = (props: {
 		return <td />;
 	}
 
-	const percent =
-		props.value > 0 && props.lowerLimit > 0
-			? (props.lowerLimit / props.value) * 100
-			: 0.0;
+	const percent = percentOf(props.lowerLimit, props.value);
 
 	return (
 		<LimitCell
@@ -640,10 +636,7 @@ const UpperLimitCell = (props: {
 		return <td />;
 	}
 
-	const percent =
-		props.value > 0 && props.upperLimit > 0
-			? (props.value / props.upperLimit) * 100
-			: 0.0;
+	const percent = percentOf(props.value, props.upperLimit);
 
 	return (
 		<LimitCell

--- a/services/console/src/components/console/deck/hand/card/percent.test.ts
+++ b/services/console/src/components/console/deck/hand/card/percent.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest";
+import { percentDifference, percentOf } from "./percent";
+
+describe("percentDifference", () => {
+	test("a value that drops to zero is a 100% improvement", () => {
+		expect(percentDifference(0.0, 3_069_448.0)).toBe(-100.0);
+	});
+
+	test("a value below the baseline is a negative percent", () => {
+		expect(percentDifference(50.0, 100.0)).toBe(-50.0);
+	});
+
+	test("a value above the baseline is a positive percent", () => {
+		expect(percentDifference(150.0, 100.0)).toBe(50.0);
+	});
+
+	test("a value equal to the baseline is no change", () => {
+		expect(percentDifference(100.0, 100.0)).toBe(0.0);
+	});
+
+	test("a zero baseline has no percent difference", () => {
+		expect(percentDifference(0.0, 0.0)).toBe(0.0);
+		expect(percentDifference(100.0, 0.0)).toBe(0.0);
+	});
+
+	test("a non-finite value or baseline has no percent difference", () => {
+		expect(percentDifference(Number.POSITIVE_INFINITY, 100.0)).toBe(0.0);
+		expect(percentDifference(100.0, Number.POSITIVE_INFINITY)).toBe(0.0);
+		expect(percentDifference(Number.NaN, 100.0)).toBe(0.0);
+	});
+});
+
+describe("percentOf", () => {
+	test("a zero numerator is zero percent of the denominator", () => {
+		expect(percentOf(0.0, 100.0)).toBe(0.0);
+	});
+
+	test("a numerator is its share of the denominator", () => {
+		expect(percentOf(50.0, 100.0)).toBe(50.0);
+		expect(percentOf(100.0, 100.0)).toBe(100.0);
+		expect(percentOf(200.0, 100.0)).toBe(200.0);
+	});
+
+	test("a zero denominator has no percent", () => {
+		expect(percentOf(100.0, 0.0)).toBe(0.0);
+		expect(percentOf(0.0, 0.0)).toBe(0.0);
+	});
+
+	test("a non-finite numerator or denominator has no percent", () => {
+		expect(percentOf(Number.POSITIVE_INFINITY, 100.0)).toBe(0.0);
+		expect(percentOf(100.0, Number.POSITIVE_INFINITY)).toBe(0.0);
+		expect(percentOf(Number.NaN, 100.0)).toBe(0.0);
+	});
+});

--- a/services/console/src/components/console/deck/hand/card/percent.ts
+++ b/services/console/src/components/console/deck/hand/card/percent.ts
@@ -1,0 +1,24 @@
+// The percent difference between a value and its baseline.
+//
+// Only the baseline has to be non-zero.
+// A value of zero is a `-100.00%` difference from a positive baseline,
+// not a `0.00%` difference.
+// There is no percent difference from a zero baseline (`±∞`)
+// nor from a non-finite value, so fall back to zero.
+export const percentDifference = (value: number, baseline: number): number =>
+	Number.isFinite(value) && Number.isFinite(baseline) && baseline !== 0
+		? ((value - baseline) / baseline) * 100
+		: 0.0;
+
+// The numerator as a percent of the denominator.
+//
+// Only the denominator has to be non-zero.
+// A numerator of zero is `0.00%` of a positive denominator.
+// There is no percent of a zero denominator (`±∞`)
+// nor of a non-finite numerator, so fall back to zero.
+export const percentOf = (numerator: number, denominator: number): number =>
+	Number.isFinite(numerator) &&
+	Number.isFinite(denominator) &&
+	denominator !== 0
+		? (numerator / denominator) * 100
+		: 0.0;

--- a/services/console/src/content/docs-reference/de/changelog.mdx
+++ b/services/console/src/content/docs-reference/de/changelog.mdx
@@ -3,7 +3,7 @@ title: "Changelog"
 description: "Bencher changelog"
 heading: "Bencher Changelog"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-07-18T07:00:00Z"
+modified: "2026-07-25T07:00:00Z"
 sortOrder: 10
 canonicalize: true
 ---

--- a/services/console/src/content/docs-reference/en/changelog.mdx
+++ b/services/console/src/content/docs-reference/en/changelog.mdx
@@ -3,7 +3,7 @@ title: "Changelog"
 description: "Bencher release changelog"
 heading: "Bencher Changelog"
 published: "2023-08-12T16:07:00Z"
-modified: "2026-07-18T07:00:00Z"
+modified: "2026-07-25T07:00:00Z"
 sortOrder: 10
 ---
 

--- a/services/console/src/content/docs-reference/es/changelog.mdx
+++ b/services/console/src/content/docs-reference/es/changelog.mdx
@@ -3,7 +3,7 @@ title: "Changelog"
 description: "Bencher changelog"
 heading: "Bencher Changelog"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-07-18T07:00:00Z"
+modified: "2026-07-25T07:00:00Z"
 sortOrder: 10
 canonicalize: true
 ---

--- a/services/console/src/content/docs-reference/fr/changelog.mdx
+++ b/services/console/src/content/docs-reference/fr/changelog.mdx
@@ -3,7 +3,7 @@ title: "Changelog"
 description: "Bencher changelog"
 heading: "Bencher Changelog"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-07-18T07:00:00Z"
+modified: "2026-07-25T07:00:00Z"
 sortOrder: 10
 canonicalize: true
 ---

--- a/services/console/src/content/docs-reference/ja/changelog.mdx
+++ b/services/console/src/content/docs-reference/ja/changelog.mdx
@@ -3,7 +3,7 @@ title: "Changelog"
 description: "Bencher changelog"
 heading: "Bencher Changelog"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-07-18T07:00:00Z"
+modified: "2026-07-25T07:00:00Z"
 sortOrder: 10
 canonicalize: true
 ---

--- a/services/console/src/content/docs-reference/ko/changelog.mdx
+++ b/services/console/src/content/docs-reference/ko/changelog.mdx
@@ -3,7 +3,7 @@ title: "Changelog"
 description: "Bencher changelog"
 heading: "Bencher Changelog"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-07-18T07:00:00Z"
+modified: "2026-07-25T07:00:00Z"
 sortOrder: 10
 canonicalize: true
 ---

--- a/services/console/src/content/docs-reference/pt/changelog.mdx
+++ b/services/console/src/content/docs-reference/pt/changelog.mdx
@@ -3,7 +3,7 @@ title: "Changelog"
 description: "Bencher changelog"
 heading: "Bencher Changelog"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-07-18T07:00:00Z"
+modified: "2026-07-25T07:00:00Z"
 sortOrder: 10
 canonicalize: true
 ---

--- a/services/console/src/content/docs-reference/ru/changelog.mdx
+++ b/services/console/src/content/docs-reference/ru/changelog.mdx
@@ -3,7 +3,7 @@ title: "Changelog"
 description: "Bencher changelog"
 heading: "Bencher Changelog"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-07-18T07:00:00Z"
+modified: "2026-07-25T07:00:00Z"
 sortOrder: 10
 canonicalize: true
 ---

--- a/services/console/src/content/docs-reference/zh/changelog.mdx
+++ b/services/console/src/content/docs-reference/zh/changelog.mdx
@@ -3,7 +3,7 @@ title: "Changelog"
 description: "Bencher changelog"
 heading: "Bencher Changelog"
 published: "2023-10-27T08:40:00Z"
-modified: "2026-07-18T07:00:00Z"
+modified: "2026-07-25T07:00:00Z"
 sortOrder: 10
 canonicalize: true
 ---


### PR DESCRIPTION
The percent difference in the report table required *both* the value and the baseline to be non-zero before it would divide, so a metric that dropped all the way to zero rendered as `0.00%` (no change) instead of `-100.00%`.

```
0.00 B (0.00%) Baseline: 3,069,448.00 B
```

Only the denominator has to be non-zero. A value of `0` against a positive baseline is a well defined 100% improvement. An `∞` percent would only ever come from a *baseline* of zero, not from a value of zero.

## Changes

- `lib/bencher_comment`: extract `percent_difference` (value vs baseline) and `percent_of` (numerator as a percent of denominator) and guard only the denominator, falling back to `0.00%` when there is no percent to report (a zero denominator or a non-finite numerator).
- `services/console`: same fix for the Console report table, with the math extracted into a testable `percent.ts` module used by `ReportCard`.

The limit cells (`Lower Boundary Limit` / `Upper Boundary Limit`) shared the same guard. Their zero-numerator case happened to already render correctly, but they now report a `0.00%` fallback only when their denominator is zero.

| baseline | value | before | after |
| --- | --- | --- | --- |
| 3,069,448 | 0 | `0.00%` | `-100.00%` |
| 100 | 50 | `-50.00%` | `-50.00%` |
| 0 | 0 | `0.00%` | `0.00%` |
| 0 | 100 | `0.00%` | `0.00%` (no percent from a zero baseline) |

## Tests

- `cargo nextest run -p bencher_comment --all-features` (4 new tests, including a `value_cell` render assertion). Both new behavior tests fail against the previous guard.
- `npx vitest run` in `services/console` (10 new tests in `percent.test.ts`).

Refs #956
