### PR TITLE
Bump Claude Code review CI to Opus 5

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CLAUDE_MODEL: claude-opus-4-8
+  CLAUDE_MODEL: claude-opus-5
   CLAUDE_MAX_TURNS: 64
 
 jobs:


### PR DESCRIPTION
Update `CLAUDE_MODEL` in the Claude Code Review workflow from `claude-opus-4-8` to `claude-opus-5`.

The `--model` flag on the `claude -p` invocation and the model footer in the PR comment both read from this workflow-level env var, so no other changes are needed.