### PR TITLE
Bump Litestream from 0.5.13 to 0.5.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
     with:
       mold-version: "2.34.1"
       wasm-pack-version: "0.12.1"
-      litestream-version: "0.5.13"
+      litestream-version: "0.5.16"
       cargo-chef-version: "0.1.77"
       sccache-version: "0.16.0"
       is-fork: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
@@ -228,7 +228,7 @@ jobs:
     uses: ./.github/workflows/docker.yml
     with:
       mold-version: "2.34.1"
-      litestream-version: "0.5.13"
+      litestream-version: "0.5.16"
       cargo-chef-version: "0.1.77"
       sccache-version: "0.16.0"
       is-fork: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: ./services/api/Dockerfile
       args:
         MOLD_VERSION: 2.34.1
-        LITESTREAM_VERSION: 0.5.13
+        LITESTREAM_VERSION: 0.5.16
         CARGO_CHEF_VERSION: 0.1.77
         SCCACHE_VERSION: 0.16.0
     image: bencher-api


### PR DESCRIPTION
Upgrades Litestream from 0.5.13 to 0.5.16 (latest) in CI and the local docker-compose.

Motivation: on Bencher Cloud, the hourly level-3 LTX compaction fails every cycle with `write ltx file: extract timestamp from LTX header: EOF` against the R2 replica, even with a verified-clean bucket (only live-lineage snapshot and L0/L1/L2 objects, all individually restorable). The failure is in the 0.5.13 storage read path, the same family as the GCS empty-reader regression fixed upstream in benbjohnson/litestream#807. The 0.5.14 to 0.5.16 releases carry retention and storage-layer fixes; upgrading is the next diagnostic and likely the fix. If the error survives this upgrade, the follow-up is an upstream issue with the captured failure signature.

Replication and restores are healthy on 0.5.13; the compaction failure costs a retry loop (memory spikes and repeated R2 downloads each hour), not data.