### PR TITLE
Authenticate the console smoke test with a secret header

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -156,7 +156,8 @@ jobs:
       - name: Run Console Dev Test
         env:
           RUST_BACKTRACE: full
-        run: cargo test-console dev --user-agent "${{ secrets.BENCHER_USER_AGENT }}" devel
+          BENCHER_USER_AGENT: ${{ secrets.BENCHER_USER_AGENT }} # the secret name predates the x-bencher-agent header it now carries
+        run: cargo test-console dev --agent-key "$BENCHER_USER_AGENT" devel
 
   deploy_api_fly_test:
     name: Deploy API to Fly.io Test
@@ -267,4 +268,5 @@ jobs:
       - name: Run Netlify Test
         env:
           RUST_BACKTRACE: full
-        run: cargo test-console prod --user-agent "${{ secrets.BENCHER_USER_AGENT }}" cloud
+          BENCHER_USER_AGENT: ${{ secrets.BENCHER_USER_AGENT }} # the secret name predates the x-bencher-agent header it now carries
+        run: cargo test-console prod --agent-key "$BENCHER_USER_AGENT" cloud

--- a/tasks/test_console/src/parser/mod.rs
+++ b/tasks/test_console/src/parser/mod.rs
@@ -17,5 +17,5 @@ pub struct TaskTestConsole {
     pub ref_name: String,
 
     #[clap(long)]
-    pub user_agent: Option<String>,
+    pub agent_key: Option<String>,
 }

--- a/tasks/test_console/src/task/test_console.rs
+++ b/tasks/test_console/src/task/test_console.rs
@@ -7,36 +7,39 @@ use crate::{API_VERSION, parser::TaskTestConsole};
 
 const NTFY_URL: &str = "https://ntfy.sh";
 const NTFY_TOPIC: &str = "bencherdev";
+const USER_AGENT: &str = "bencher-test-console";
+// Identifies the deploy smoke test to the console's bot challenge exemption
+const AGENT_HEADER: &str = "x-bencher-agent";
 
 #[derive(Debug)]
 pub struct TestConsole {
     pub dev: bool,
     pub ref_name: String,
-    pub user_agent: Option<String>,
+    pub agent_key: Option<String>,
 }
 
 impl TestConsole {
     pub fn dev(test_console: TaskTestConsole) -> Self {
         let TaskTestConsole {
             ref_name,
-            user_agent,
+            agent_key,
         } = test_console;
         Self {
             dev: true,
             ref_name,
-            user_agent,
+            agent_key,
         }
     }
 
     pub fn prod(test_console: TaskTestConsole) -> Self {
         let TaskTestConsole {
             ref_name,
-            user_agent,
+            agent_key,
         } = test_console;
         Self {
             dev: false,
             ref_name,
-            user_agent,
+            agent_key,
         }
     }
 
@@ -59,7 +62,7 @@ impl TestConsole {
             match test_ui_project(
                 console_url,
                 project_slug,
-                self.user_agent.as_deref(),
+                self.agent_key.as_deref(),
                 find_str,
             )
             .await
@@ -76,7 +79,7 @@ impl TestConsole {
             }
         }
         result?;
-        test_ui_version(console_url, self.user_agent.as_deref()).await?;
+        test_ui_version(console_url, self.agent_key.as_deref()).await?;
 
         let notify = Notify::new(&self.ref_name, console_url);
         notify.send().await?;
@@ -88,35 +91,33 @@ impl TestConsole {
 async fn test_ui_project(
     console_url: &str,
     project_slug: &str,
-    user_agent: Option<&str>,
+    agent_key: Option<&str>,
     find_str: &str,
 ) -> anyhow::Result<()> {
     let url = format!("{console_url}/perf/{project_slug}");
     println!("Testing UI project {project_slug} at {url}");
 
-    fetch_and_check(&url, user_agent, find_str).await
+    fetch_and_check(&url, agent_key, find_str).await
 }
 
-async fn test_ui_version(console_url: &str, user_agent: Option<&str>) -> anyhow::Result<()> {
+async fn test_ui_version(console_url: &str, agent_key: Option<&str>) -> anyhow::Result<()> {
     let url = format!("{console_url}/download");
     println!("Testing UI deploy is version {API_VERSION} at {url}");
 
     let version = format!("Latest Version: <code>v{API_VERSION}</code>");
 
-    fetch_and_check(&url, user_agent, &version).await
+    fetch_and_check(&url, agent_key, &version).await
 }
 
-async fn fetch_and_check(
-    url: &str,
-    user_agent: Option<&str>,
-    find_str: &str,
-) -> anyhow::Result<()> {
-    let client = if let Some(user_agent) = user_agent {
-        reqwest::Client::builder().user_agent(user_agent).build()?
+async fn fetch_and_check(url: &str, agent_key: Option<&str>, find_str: &str) -> anyhow::Result<()> {
+    let client = reqwest::Client::builder().user_agent(USER_AGENT).build()?;
+    let request = client.get(url);
+    let request = if let Some(agent_key) = agent_key {
+        request.header(AGENT_HEADER, agent_key)
     } else {
-        reqwest::Client::new()
+        request
     };
-    let html = client.get(url).send().await?.text().await?;
+    let html = request.send().await?.text().await?;
     if !html.contains(find_str) {
         return Err(anyhow::anyhow!(
             "Failed to find `{find_str}` in HTML from {url}"


### PR DESCRIPTION
The console deploy smoke test authenticates its bot challenge exemption with a dedicated `x-bencher-agent` header instead of a secret User-Agent. User-Agent strings are logged promiscuously (CDN logs, request logging, error tracking), so a secret carried there spreads into far more places than a secret should; a custom header stays out of default logging paths.

## Changes

- `tasks/test_console` takes `--agent-key` and sends the value as the `x-bencher-agent` header on the console requests only. The notification POST is built on a separate client and carries neither the header nor the UA.
- The smoke client now sends a benign static User-Agent (`bencher-test-console`), since sending no UA at all is itself a bot signal.
- `deploy.yml`: both smoke invocations deliver the secret through step-level `env:` instead of inline template interpolation, which also removes the two `template-injection` findings zizmor raised on the old lines. The `BENCHER_USER_AGENT` secret keeps its name and now carries the header value (noted in comments at both call sites).

## Verification

- `cargo fmt`, clippy with workspace flags, and `cargo check` clean for `test_console`; both CLI orderings (`dev --agent-key X devel`, `prod --agent-key X cloud`) parse.
- A keyless run against the live dev console fails loudly on the challenged `/perf` page, and a request with only the static UA is still challenged: the header alone grants the exemption.
- `actionlint` byte-identical to main; `zizmor` strictly improves (two findings removed, none added).

## Deploy sequencing

Before merge: rotate the `BENCHER_USER_AGENT` secret to a fresh value and have both firewall rules live (the old UA rule updated to the new value, plus the new `x-bencher-agent` header rule for both console hostnames). After this merges and a deploy run is green, the UA rule can be removed.
