### PR TITLE
Deploy the prod console to Cloudflare Workers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -270,3 +270,37 @@ jobs:
           RUST_BACKTRACE: full
           BENCHER_USER_AGENT: ${{ secrets.BENCHER_USER_AGENT }} # the secret name predates the x-bencher-agent header it now carries
         run: cargo test-console prod --agent-key "$BENCHER_USER_AGENT" cloud
+
+  # The worker is deployed without a domain, so the prod smoke test still runs
+  # in the Netlify job. It moves here once `bencher.dev` is served by the worker.
+  deploy_console_cloudflare_prod:
+    name: Deploy Console UI to Cloudflare Prod
+    if: ${{ inputs.deploy-prod }}
+    needs: deploy_api_fly_prod
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Download `bencher_valid` Artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.WASM_BENCHER_VALID }}
+          path: ./lib/bencher_valid/pkg
+      - name: Build Console UI
+        working-directory: ./services/console
+        env:
+          SENTRY_UPLOAD: true
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: npm run cloudflare
+      - name: Install Wrangler
+        working-directory: ./services/console
+        env:
+          INPUTS_WRANGLER_VERSION: ${{ inputs.wrangler-version }}
+        run: npm install --save-dev "wrangler@$INPUTS_WRANGLER_VERSION"
+      - name: Deploy Console UI to Cloudflare Prod
+        working-directory: ./services/console
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: npx wrangler deploy --env ""

--- a/services/console/wrangler.jsonc
+++ b/services/console/wrangler.jsonc
@@ -1,10 +1,11 @@
 {
 	// Cloudflare Workers configuration for the console.
 	// Build the site first with `npm run cloudflare`, then run it with `npx wrangler dev`.
+	// The top level deploys with `npx wrangler deploy`.
 	// The `dev` environment deploys with `npx wrangler deploy --env dev`.
 	// https://developers.cloudflare.com/workers/wrangler/configuration/
 	"$schema": "node_modules/wrangler/config-schema.json",
-	"name": "bencher-console",
+	"name": "console",
 	// The Astro Cloudflare adapter writes the server bundle here.
 	// https://docs.astro.build/en/guides/integrations-guide/cloudflare/
 	"main": "./dist/_worker.js/index.js",
@@ -12,11 +13,16 @@
 	// Node.js APIs are used by the server bundle.
 	// https://developers.cloudflare.com/workers/runtime-apis/nodejs/
 	"compatibility_flags": ["nodejs_compat"],
-	// The custom domain of each environment is its only front door,
+	// A custom domain is the only front door for any environment that has one,
 	// so neither the `workers.dev` subdomain nor preview URLs are served.
 	// https://developers.cloudflare.com/workers/configuration/previews/
 	"workers_dev": false,
 	"preview_urls": false,
+	// The top level declares no route and no custom domain, so it deploys
+	// without being served. Wrangler cannot attach `bencher.dev` while another
+	// DNS record still holds it, so the domain is attached by hand at cutover
+	// and declared here in a follow-up change.
+
 	// The prerendered pages and client assets are served from the same directory.
 	// https://developers.cloudflare.com/workers/static-assets/
 	"assets": {
@@ -33,6 +39,12 @@
 	// Every key above is inheritable, so each environment only sets what differs.
 	// Environment variables are not inheritable and must be set for each environment.
 	// https://developers.cloudflare.com/workers/wrangler/environments/
+	// The OAuth settings are feature flags, not credentials.
+	"vars": {
+		"BENCHER_API_URL": "https://api.bencher.dev",
+		"OAUTH_GITHUB": "true",
+		"OAUTH_GOOGLE": "true"
+	},
 	"env": {
 		"dev": {
 			"name": "dev-console",


### PR DESCRIPTION
Every prod deploy now also ships the console to a Cloudflare Worker named `console`, deployed but unreachable: no route, no custom domain, no workers.dev serving. Netlify keeps serving bencher.dev and its deploy job is untouched, so the pipeline stays green before and after this merges. The cutover itself is a later manual step attaching `bencher.dev` to the worker, after which a follow-up declares the domain in config and retires the Netlify job.

## Changes

- `wrangler.jsonc`: the top level is named `console` and gains its own vars (`BENCHER_API_URL=https://api.bencher.dev`, OAuth feature flags). Deliberately no route: wrangler cannot attach `bencher.dev` while another DNS record holds it, so the domain is attached by hand at cutover. The `dev` environment is untouched.
- `deploy.yml`: new `deploy_console_cloudflare_prod` job mirroring the dev job, deploying with `wrangler deploy --env ""` (explicit top-level targeting). No smoke test here yet: the prod smoke test keeps running in the Netlify job, since it tests `https://bencher.dev`, and moves over once the worker serves that hostname.

## Verification

- Credential-stripped dry-runs resolve the top level to worker `console` with exactly the assets binding plus the three vars, and `--env dev` unchanged, proving the rename cannot touch the live `dev-console` worker (its name is pinned explicitly).
- `actionlint` byte-identical to base; `zizmor` adds only a low `adhoc-packages` note identical in class to the two already shipping green.
- A cloud push after this merges runs both prod console jobs in parallel; a failure in the new job cannot affect the Netlify deploy that serves users.