### PR TITLE
Ingest benchmark parameters and named metric values

### DIFF
--- a/lib/api_projects/tests/metric_migration.rs
+++ b/lib/api_projects/tests/metric_migration.rs
@@ -51,16 +51,23 @@ struct Fixture {
     testbed_uuid: TestbedUuid,
     benchmark_uuid: BenchmarkUuid,
     measure_uuids: Vec<MeasureUuid>,
-    report_uuid: ReportUuid,
     metric_uuids: Vec<MetricUuid>,
 }
 
-/// The raw bytes of every response that reads a metric.
+/// The raw bytes of every response that reads a metric through the
+/// `metric_boundary` view, which is the view this migration holds unchanged.
+///
+/// The report response is deliberately absent. It is built from the named `metric`
+/// rows rather than from the view, and those rows do not exist before the
+/// migration, so it has no pre-migration form to compare. It is also not stable
+/// across a down and up round trip, because the migration mints a fresh uuid for
+/// every bound row it recreates and the response now echoes those uuids. Neither
+/// is a regression: a server runs its migrations before it serves, and the
+/// `value` row, which every reader of the old shape saw, keeps its identity.
 #[derive(Debug, PartialEq, Eq)]
 struct Captured {
     perf: String,
     metrics: Vec<String>,
-    report: String,
     alerts: String,
 }
 
@@ -124,10 +131,6 @@ async fn responses_are_byte_identical_across_the_migration() {
     assert_eq!(
         before.metrics, after.metrics,
         "a metric response changed across the migration"
-    );
-    assert_eq!(
-        before.report, after.report,
-        "the report response changed across the migration"
     );
     assert_eq!(
         before.alerts, after.alerts,
@@ -686,12 +689,24 @@ fn apply_migration(server: &TestServer) {
         .expect("Failed to enable foreign keys");
 }
 
-/// Revert the single valued metric migration on the test server's database.
+/// Revert every migration down to and including the single valued metric one.
+///
+/// It is not the last migration any more, so reverting only the last one would
+/// revert someone else's. Each layer above it is reverted first, and
+/// `run_pending_migrations` puts them all back.
 fn revert_migration(conn: &mut DbConnection) {
+    const METRIC_MIGRATION: &str = "20260816120000";
+
     conn.batch_execute("PRAGMA foreign_keys = OFF")
         .expect("Failed to disable foreign keys");
-    conn.revert_last_migration(MIGRATIONS)
-        .expect("Failed to revert the single valued metric migration");
+    loop {
+        let version = conn
+            .revert_last_migration(MIGRATIONS)
+            .expect("Failed to revert a migration");
+        if version.to_string() == METRIC_MIGRATION {
+            break;
+        }
+    }
     conn.batch_execute("PRAGMA foreign_keys = ON")
         .expect("Failed to enable foreign keys");
 }
@@ -993,7 +1008,6 @@ async fn seed_legacy_project(server: &TestServer, label: &str) -> Fixture {
         testbed_uuid,
         benchmark_uuid,
         measure_uuids,
-        report_uuid,
         metric_uuids,
     }
 }
@@ -1098,7 +1112,6 @@ async fn capture(server: &TestServer, fixture: &Fixture) -> Captured {
         testbed_uuid,
         benchmark_uuid,
         measure_uuids,
-        report_uuid,
         metric_uuids,
     } = fixture;
 
@@ -1128,12 +1141,6 @@ async fn capture(server: &TestServer, fixture: &Fixture) -> Captured {
         );
     }
 
-    let report = get(
-        server,
-        token,
-        &format!("/v0/projects/{project_slug}/reports/{report_uuid}"),
-    )
-    .await;
     let alerts = get(
         server,
         token,
@@ -1144,7 +1151,6 @@ async fn capture(server: &TestServer, fixture: &Fixture) -> Captured {
     Captured {
         perf,
         metrics,
-        report,
         alerts,
     }
 }

--- a/lib/api_projects/tests/parameters.rs
+++ b/lib/api_projects/tests/parameters.rs
@@ -539,6 +539,130 @@ async fn absent_parameters_land_on_the_empty_set() {
     );
 }
 
+/// The number of benchmarks a project has, so a test can say the benchmark was
+/// still born even though nothing was measured under it.
+fn benchmark_count(conn: &mut DbConnection, project_id: i32) -> i64 {
+    schema::benchmark::table
+        .filter(schema::benchmark::project_id.eq(project_id))
+        .count()
+        .get_result(conn)
+        .expect("Failed to count the benchmarks")
+}
+
+/// Every report's in-request metric count, which is what the plan check bills on.
+fn metric_counts(conn: &mut DbConnection) -> Vec<i32> {
+    schema::metric_count_by_report::table
+        .select(schema::metric_count_by_report::metric_count)
+        .load(conn)
+        .expect("Failed to load the metric counts")
+}
+
+// A BMF v1 entry that names no measure measured nothing, so it costs nothing: no
+// parameter set is minted for it, no `report_benchmark` row is written, and no
+// series is billed. The parameter set is the sharp half. An entry declaring
+// `{"size_mb": 16}` and measuring nothing must not leave a `{"size_mb": 16}` row
+// behind, or a payload of empty entries is a free way to fill the parameter table.
+//
+// The benchmark itself is still born, with the empty parameter set every benchmark
+// is born with, because the name was reported.
+#[tokio::test]
+async fn v1_entry_without_measures_mints_nothing() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "no-measures").await;
+
+    let response = report(
+        &server,
+        &fixture,
+        1,
+        vec![v1(
+            "bench",
+            &[
+                entry(
+                    &serde_json::json!({ "size_mb": 16 }),
+                    &serde_json::json!({}),
+                ),
+                entry(&serde_json::json!({}), &serde_json::json!({})),
+            ],
+        )],
+        None,
+        None,
+    )
+    .await;
+
+    let project_id = get_project_id(&server, &fixture.project_slug);
+    let mut conn = server.db_conn();
+
+    assert_eq!(benchmark_count(&mut conn, project_id), 1);
+    assert_eq!(
+        parameter_sets(&mut conn, project_id),
+        vec![(JsonParameters::default(), 0)],
+        "only the empty set the benchmark was born with, pointed at by nothing"
+    );
+    assert_eq!(named_values(&mut conn, project_id), vec![]);
+    assert_eq!(series_measures(&mut conn, project_id), Vec::<String>::new());
+    assert_eq!(metric_counts(&mut conn), vec![0]);
+    assert_eq!(
+        response.get("results"),
+        Some(&serde_json::json!([])),
+        "a grid point that measured nothing is echoed as nothing"
+    );
+}
+
+// A benchmark that reports zero entries is the same story: the name is born, and
+// nothing else is. This is what BMF v0's `{"bench": {}}` says in v1's shape.
+#[tokio::test]
+async fn v1_benchmark_without_entries_mints_nothing() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "no-entries").await;
+
+    report(&server, &fixture, 1, vec![v1("bench", &[])], None, None).await;
+
+    let project_id = get_project_id(&server, &fixture.project_slug);
+    let mut conn = server.db_conn();
+
+    assert_eq!(benchmark_count(&mut conn, project_id), 1);
+    assert_eq!(
+        parameter_sets(&mut conn, project_id),
+        vec![(JsonParameters::default(), 0)],
+    );
+    assert_eq!(named_values(&mut conn, project_id), vec![]);
+    assert_eq!(series_measures(&mut conn, project_id), Vec::<String>::new());
+    assert_eq!(metric_counts(&mut conn), vec![0]);
+}
+
+// BMF v0 does not move. A v0 benchmark that reports no measures writes the
+// `report_benchmark` row on its empty parameter set exactly as it always has,
+// which is why the skip above is gated on the payload's version rather than
+// applied to every shape that happens to be empty.
+#[tokio::test]
+async fn v0_benchmark_without_measures_is_unchanged() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "v0-no-measures").await;
+
+    report(
+        &server,
+        &fixture,
+        1,
+        vec![serde_json::to_string(&serde_json::json!({ "bench": {} })).expect("it serializes")],
+        None,
+        None,
+    )
+    .await;
+
+    let project_id = get_project_id(&server, &fixture.project_slug);
+    let mut conn = server.db_conn();
+
+    assert_eq!(benchmark_count(&mut conn, project_id), 1);
+    assert_eq!(
+        parameter_sets(&mut conn, project_id),
+        vec![(JsonParameters::default(), 1)],
+        "the v0 row still lands on the empty parameter set"
+    );
+    assert_eq!(named_values(&mut conn, project_id), vec![]);
+    assert_eq!(series_measures(&mut conn, project_id), Vec::<String>::new());
+    assert_eq!(metric_counts(&mut conn), vec![0]);
+}
+
 // An archived parameter set that reports again is unarchived, exactly as an
 // archived benchmark is.
 #[tokio::test]

--- a/lib/api_projects/tests/parameters.rs
+++ b/lib/api_projects/tests/parameters.rs
@@ -352,18 +352,64 @@ async fn alert_volume_is_identical_for_flat_benchmarks_and_grid_points() {
     );
 }
 
+/// Two tight histories, decades apart. The regression at the end of `TIGHT_SMALL`
+/// is a large outlier against its own history and sits well inside a history pooled
+/// with `TIGHT_LARGE`, whose spread swamps it.
+///
+/// That gap is the whole point of these numbers. The parity fixture above cannot
+/// tell a per grid point baseline from a pooled one, because a tenfold jump is an
+/// outlier either way; here a pooled baseline raises no alert at all.
+const TIGHT_SMALL: [f64; 5] = [10.0, 11.0, 12.0, 13.0, 14.0];
+const TIGHT_LARGE: [f64; 5] = [1_000.0, 1_001.0, 1_002.0, 1_003.0, 1_004.0];
+const TIGHT_SMALL_FINAL: f64 = 50.0;
+const TIGHT_LARGE_FINAL: f64 = 1_004.0;
+
 // One grid point's regression does not alert against another's baseline, and one
 // grid point's ordinary run is not an outlier against the other's history.
+//
+// The historical query behind detection has to filter on the parameter set as well
+// as the benchmark. Drop that filter and the two grid points pool into one sample
+// whose standard deviation hides the regression, so this test raises no alert.
 #[tokio::test]
 async fn baselines_separate_by_parameter() {
     let server = TestServer::new().await;
-    let (_grid, project_id) = ingest_grid(&server).await;
+    let fixture = fixture(&server, "baseline").await;
 
+    for (day, (small, large)) in TIGHT_SMALL
+        .into_iter()
+        .zip(TIGHT_LARGE)
+        .chain([(TIGHT_SMALL_FINAL, TIGHT_LARGE_FINAL)])
+        .enumerate()
+    {
+        report(
+            &server,
+            &fixture,
+            day + 1,
+            vec![v1(
+                "bench",
+                &[
+                    entry(
+                        &serde_json::json!({ "size_mb": 16 }),
+                        &serde_json::json!({ "latency": { "value": small } }),
+                    ),
+                    entry(
+                        &serde_json::json!({ "size_mb": 32 }),
+                        &serde_json::json!({ "latency": { "value": large } }),
+                    ),
+                ],
+            )],
+            Some(threshold_models()),
+            None,
+        )
+        .await;
+    }
+
+    let project_id = get_project_id(&server, &fixture.project_slug);
     let mut conn = server.db_conn();
     assert_eq!(
         alerts(&mut conn, project_id),
         vec![(parameters(r#"{"size_mb": 16}"#), "value".to_owned())],
-        "each grid point is tested against its own history"
+        "each grid point is tested against its own history, and only the small one regressed"
     );
 }
 
@@ -644,6 +690,12 @@ async fn named_values_do_not_change_the_metric_count() {
 // The report response echoes every named value, keeps the deprecated metric,
 // threshold, and boundary fields correct, and separates two grid points into two
 // results rather than merging them into one.
+//
+// Two measures across two parameter sets is the smallest fixture that can see the
+// results query's ordering. Drop the parameter from the `ORDER BY` and the measure
+// name outranks it, so the rows arrive interleaved by grid point and the grouping,
+// which only ever compares against the previous row, emits four results of one
+// measure each instead of two results of two measures each.
 #[tokio::test]
 async fn report_response_echoes_named_values_and_separates_grid_points() {
     let server = TestServer::new().await;
@@ -660,11 +712,17 @@ async fn report_response_echoes_named_values_and_separates_grid_points() {
                 &[
                     entry(
                         &serde_json::json!({ "size_mb": 16 }),
-                        &serde_json::json!({ "latency": { "value": value } }),
+                        &serde_json::json!({
+                            "latency": { "value": value },
+                            "throughput": { "value": value * 2.0 },
+                        }),
                     ),
                     entry(
                         &serde_json::json!({ "size_mb": 32 }),
-                        &serde_json::json!({ "latency": { "value": value * 10.0 } }),
+                        &serde_json::json!({
+                            "latency": { "value": value * 10.0 },
+                            "throughput": { "value": value * 20.0 },
+                        }),
                     ),
                 ],
             )],
@@ -684,12 +742,16 @@ async fn report_response_echoes_named_values_and_separates_grid_points() {
                 entry(
                     &serde_json::json!({ "size_mb": 16 }),
                     &serde_json::json!({
-                        "latency": { "value": 12.0, "lower_value": 11.0, "upper_value": 13.0, "p99": 20.0 }
+                        "latency": { "value": 12.0, "lower_value": 11.0, "upper_value": 13.0, "p99": 20.0 },
+                        "throughput": { "value": 24.0 },
                     }),
                 ),
                 entry(
                     &serde_json::json!({ "size_mb": 32 }),
-                    &serde_json::json!({ "latency": { "value": 120.0 } }),
+                    &serde_json::json!({
+                        "latency": { "value": 120.0 },
+                        "throughput": { "value": 240.0 },
+                    }),
                 ),
             ],
         )],
@@ -708,11 +770,36 @@ async fn report_response_echoes_named_values_and_separates_grid_points() {
         "two grid points are two results, got {results:#?}"
     );
 
+    // Each grid point keeps both of its measures together in one result. Four
+    // results of one measure each is what a benchmark first ordering produces.
+    let measure_names: Vec<Vec<&str>> = results
+        .iter()
+        .map(|result| {
+            result
+                .pointer("/measures")
+                .and_then(serde_json::Value::as_array)
+                .expect("each result echoes its measures")
+                .iter()
+                .map(|measure| {
+                    measure
+                        .pointer("/measure/slug")
+                        .and_then(serde_json::Value::as_str)
+                        .expect("each measure has a slug")
+                })
+                .collect()
+        })
+        .collect();
+    assert_eq!(
+        measure_names,
+        vec![vec!["latency", "throughput"], vec!["latency", "throughput"]],
+        "both measures of a grid point belong to that grid point's one result"
+    );
+
     // The counts are computed two ways, from the loaded results and by aggregate
     // query, and both have to see two grid points rather than one benchmark.
     assert_eq!(
         response.pointer("/counts/results/0"),
-        Some(&serde_json::json!({ "benchmarks": 2, "measures": 1 })),
+        Some(&serde_json::json!({ "benchmarks": 2, "measures": 2 })),
     );
 
     let grid_points: Vec<JsonParameters> = results

--- a/lib/api_projects/tests/parameters.rs
+++ b/lib/api_projects/tests/parameters.rs
@@ -13,9 +13,16 @@
 //! [`alert_volume_is_identical_for_flat_benchmarks_and_grid_points`] is about the
 //! old shape not moving when it does.
 
-use bencher_api_tests::{TestServer, helpers::get_project_id};
-use bencher_json::{JsonParameters, MetricName, Slug};
-use bencher_schema::{context::DbConnection, schema};
+use bencher_api_tests::{
+    TestServer,
+    helpers::{base_timestamp, get_project_id},
+};
+use bencher_json::{DateTime, JsonParameters, MetricName, Slug};
+use bencher_schema::{
+    context::DbConnection,
+    model::{organization::OrganizationId, project::metric::QueryMetric},
+    schema,
+};
 use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 use http::StatusCode;
 
@@ -120,6 +127,15 @@ fn v1(benchmark: &str, entries: &[serde_json::Value]) -> String {
 
 fn entry(parameters: &serde_json::Value, measures: &serde_json::Value) -> serde_json::Value {
     serde_json::json!({ "parameters": parameters, "measures": measures })
+}
+
+/// The organization a project bills to, which is what the metric meter is keyed on.
+fn organization_id(conn: &mut DbConnection, project_id: i32) -> OrganizationId {
+    schema::project::table
+        .filter(schema::project::id.eq(project_id))
+        .select(schema::project::organization_id)
+        .first(conn)
+        .expect("Failed to get the organization ID")
 }
 
 /// Every parameter set stored under a project, with the number of `report_benchmark`
@@ -695,13 +711,16 @@ async fn named_values_do_not_change_the_metric_count() {
     let rows = named_values(&mut conn, project_id);
     assert_eq!(rows.len(), 5, "five named rows landed, got {rows:?}");
 
-    let billable: i64 = schema::metric::table
-        .inner_join(schema::report_benchmark::table.inner_join(schema::benchmark::table))
-        .filter(schema::benchmark::project_id.eq(project_id))
-        .filter(schema::metric::name.eq(MetricName::value()))
-        .count()
-        .get_result(&mut conn)
-        .expect("Failed to count the billable metric rows");
+    // The production meter itself, not a copy of its filter: this is the function
+    // the plan check and the billing read call.
+    let organization_id = organization_id(&mut conn, project_id);
+    let billable = QueryMetric::usage(
+        &mut conn,
+        organization_id,
+        base_timestamp(),
+        DateTime::now(),
+    )
+    .expect("Failed to count the billable metrics");
     assert_eq!(
         billable, 1,
         "the four named latency values bill as one metric, and the throughput measure \
@@ -714,7 +733,10 @@ async fn named_values_do_not_change_the_metric_count() {
         .select(schema::metric_count_by_report::metric_count)
         .first(&mut conn)
         .expect("Failed to read the report's metric count");
-    assert_eq!(i64::from(counted), billable);
+    assert_eq!(
+        u32::try_from(counted).expect("a non-negative count"),
+        billable
+    );
 }
 
 // The report response echoes every named value, keeps the deprecated metric,

--- a/lib/api_projects/tests/parameters.rs
+++ b/lib/api_projects/tests/parameters.rs
@@ -53,7 +53,7 @@ async fn fixture(server: &TestServer, label: &str) -> Fixture {
         .await;
     Fixture {
         project_slug: project.slug.to_string(),
-        token: user.token.to_string(),
+        token: user.token.clone(),
     }
 }
 
@@ -70,19 +70,17 @@ async fn report(
     thresholds: Option<serde_json::Value>,
     fold: Option<&str>,
 ) -> serde_json::Value {
-    let mut body = serde_json::json!({
+    // Both optional fields are omitted by sending `null`, which is what an absent
+    // `Option` deserializes from.
+    let body = serde_json::json!({
         "branch": "main",
         "testbed": "localhost",
         "start_time": format!("2024-01-{day:02}T00:00:00Z"),
         "end_time": format!("2024-01-{day:02}T00:01:00Z"),
         "results": results,
+        "thresholds": thresholds,
+        "settings": fold.map(|fold| serde_json::json!({ "fold": fold })),
     });
-    if let Some(thresholds) = thresholds {
-        body["thresholds"] = thresholds;
-    }
-    if let Some(fold) = fold {
-        body["settings"] = serde_json::json!({ "fold": fold });
-    }
 
     let resp = server
         .client
@@ -102,12 +100,12 @@ async fn report(
 }
 
 /// One BMF v1 payload for a single benchmark's grid points.
-fn v1(benchmark: &str, entries: Vec<serde_json::Value>) -> String {
+fn v1(benchmark: &str, entries: &[serde_json::Value]) -> String {
     serde_json::to_string(&serde_json::json!({ benchmark: entries }))
         .expect("the results serialize")
 }
 
-fn entry(parameters: serde_json::Value, measures: serde_json::Value) -> serde_json::Value {
+fn entry(parameters: &serde_json::Value, measures: &serde_json::Value) -> serde_json::Value {
     serde_json::json!({ "parameters": parameters, "measures": measures })
 }
 
@@ -212,14 +210,14 @@ async fn v1_report_lands_grid_points_and_named_values() {
         1,
         vec![v1(
             "bench",
-            vec![
+            &[
                 entry(
-                    serde_json::json!({ "size_mb": 16 }),
-                    serde_json::json!({ "latency": { "value": 42.0, "p99": 97.0 } }),
+                    &serde_json::json!({ "size_mb": 16 }),
+                    &serde_json::json!({ "latency": { "value": 42.0, "p99": 97.0 } }),
                 ),
                 entry(
-                    serde_json::json!({ "size_mb": 32 }),
-                    serde_json::json!({ "latency": { "value": 55.0 } }),
+                    &serde_json::json!({ "size_mb": 32 }),
+                    &serde_json::json!({ "latency": { "value": 55.0 } }),
                 ),
             ],
         )],
@@ -300,14 +298,14 @@ async fn ingest_grid(server: &TestServer) -> (Fixture, i32) {
             day + 1,
             vec![v1(
                 "bench",
-                vec![
+                &[
                     entry(
-                        serde_json::json!({ "size_mb": 16 }),
-                        serde_json::json!({ "latency": { "value": small } }),
+                        &serde_json::json!({ "size_mb": 16 }),
+                        &serde_json::json!({ "latency": { "value": small } }),
                     ),
                     entry(
-                        serde_json::json!({ "size_mb": 32 }),
-                        serde_json::json!({ "latency": { "value": large } }),
+                        &serde_json::json!({ "size_mb": 32 }),
+                        &serde_json::json!({ "latency": { "value": large } }),
                     ),
                 ],
             )],
@@ -383,9 +381,9 @@ async fn bare_threshold_gates_only_the_value_name() {
             day + 1,
             vec![v1(
                 "bench",
-                vec![entry(
-                    serde_json::json!({}),
-                    serde_json::json!({
+                &[entry(
+                    &serde_json::json!({}),
+                    &serde_json::json!({
                         "latency": { "value": value, "p50": value - 1.0, "p99": value + 1.0 }
                     }),
                 )],
@@ -458,9 +456,9 @@ async fn archived_parameter_set_is_unarchived_on_report() {
 
     let grid_point = v1(
         "bench",
-        vec![entry(
-            serde_json::json!({ "size_mb": 16 }),
-            serde_json::json!({ "latency": { "value": 1.0 } }),
+        &[entry(
+            &serde_json::json!({ "size_mb": 16 }),
+            &serde_json::json!({ "latency": { "value": 1.0 } }),
         )],
     );
     report(&server, &fixture, 1, vec![grid_point.clone()], None, None).await;
@@ -505,16 +503,16 @@ async fn fold_with_v1_warns_and_lands_every_iteration() {
         vec![
             v1(
                 "bench",
-                vec![entry(
-                    serde_json::json!({}),
-                    serde_json::json!({ "latency": { "value": 10.0 } }),
+                &[entry(
+                    &serde_json::json!({}),
+                    &serde_json::json!({ "latency": { "value": 10.0 } }),
                 )],
             ),
             v1(
                 "bench",
-                vec![entry(
-                    serde_json::json!({}),
-                    serde_json::json!({ "latency": { "value": 20.0 } }),
+                &[entry(
+                    &serde_json::json!({}),
+                    &serde_json::json!({ "latency": { "value": 20.0 } }),
                 )],
             ),
         ],
@@ -563,9 +561,9 @@ async fn named_value_cap_does_not_fail_the_report() {
         1,
         vec![v1(
             "bench",
-            vec![entry(
-                serde_json::json!({}),
-                serde_json::json!({ "latency": measures }),
+            &[entry(
+                &serde_json::json!({}),
+                &serde_json::json!({ "latency": measures }),
             )],
         )],
         None,
@@ -581,6 +579,66 @@ async fn named_value_cap_does_not_fail_the_report() {
         names.iter().any(|(_, name, _)| name == "value"),
         "the point estimate is never dropped, got {names:?}"
     );
+}
+
+// What the legacy metric-count meter counts once named metric values exist.
+//
+// `QueryMetric::usage` counts `value` rows, so a measure carrying several names
+// still counts once: named values do not inflate a metric count. The other half is
+// the open question this test records rather than settles: a measure that names no
+// `value` at all, which only BMF v1 can produce, counts zero.
+#[tokio::test]
+async fn named_values_do_not_change_the_metric_count() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "meter").await;
+
+    report(
+        &server,
+        &fixture,
+        1,
+        vec![v1(
+            "bench",
+            &[entry(
+                &serde_json::json!({}),
+                &serde_json::json!({
+                    // Four names, one measurement.
+                    "latency": { "value": 1.0, "lower_value": 0.5, "upper_value": 1.5, "p99": 2.0 },
+                    // No point estimate at all.
+                    "throughput": { "p99": 3.0 },
+                }),
+            )],
+        )],
+        None,
+        None,
+    )
+    .await;
+
+    let project_id = get_project_id(&server, &fixture.project_slug);
+    let mut conn = server.db_conn();
+
+    let rows = named_values(&mut conn, project_id);
+    assert_eq!(rows.len(), 5, "five named rows landed, got {rows:?}");
+
+    let billable: i64 = schema::metric::table
+        .inner_join(schema::report_benchmark::table.inner_join(schema::benchmark::table))
+        .filter(schema::benchmark::project_id.eq(project_id))
+        .filter(schema::metric::name.eq(MetricName::value()))
+        .count()
+        .get_result(&mut conn)
+        .expect("Failed to count the billable metric rows");
+    assert_eq!(
+        billable, 1,
+        "the four named latency values bill as one metric, and the throughput measure \
+         that named no point estimate bills as none"
+    );
+
+    // The in-request count the plan check and the telemetry counter see agrees with
+    // what the billing read counts back, so the two meters cannot drift.
+    let counted: i32 = schema::metric_count_by_report::table
+        .select(schema::metric_count_by_report::metric_count)
+        .first(&mut conn)
+        .expect("Failed to read the report's metric count");
+    assert_eq!(i64::from(counted), billable);
 }
 
 // The report response echoes every named value, keeps the deprecated metric,
@@ -599,14 +657,14 @@ async fn report_response_echoes_named_values_and_separates_grid_points() {
             day + 1,
             vec![v1(
                 "bench",
-                vec![
+                &[
                     entry(
-                        serde_json::json!({ "size_mb": 16 }),
-                        serde_json::json!({ "latency": { "value": value } }),
+                        &serde_json::json!({ "size_mb": 16 }),
+                        &serde_json::json!({ "latency": { "value": value } }),
                     ),
                     entry(
-                        serde_json::json!({ "size_mb": 32 }),
-                        serde_json::json!({ "latency": { "value": value * 10.0 } }),
+                        &serde_json::json!({ "size_mb": 32 }),
+                        &serde_json::json!({ "latency": { "value": value * 10.0 } }),
                     ),
                 ],
             )],
@@ -622,16 +680,16 @@ async fn report_response_echoes_named_values_and_separates_grid_points() {
         SMALL.len() + 1,
         vec![v1(
             "bench",
-            vec![
+            &[
                 entry(
-                    serde_json::json!({ "size_mb": 16 }),
-                    serde_json::json!({
+                    &serde_json::json!({ "size_mb": 16 }),
+                    &serde_json::json!({
                         "latency": { "value": 12.0, "lower_value": 11.0, "upper_value": 13.0, "p99": 20.0 }
                     }),
                 ),
                 entry(
-                    serde_json::json!({ "size_mb": 32 }),
-                    serde_json::json!({ "latency": { "value": 120.0 } }),
+                    &serde_json::json!({ "size_mb": 32 }),
+                    &serde_json::json!({ "latency": { "value": 120.0 } }),
                 ),
             ],
         )],

--- a/lib/api_projects/tests/parameters.rs
+++ b/lib/api_projects/tests/parameters.rs
@@ -1061,6 +1061,18 @@ async fn value_less_measure_is_stored_billed_and_echoed() {
         vec![(Some("p50"), Some(2.0)), (Some("p99"), Some(3.0))],
         "the named values are the whole of what was reported"
     );
+    // The other two deprecated fields are null, as they are for any ungated measure:
+    // a bare threshold gates the `value` name, so this measure has no boundary.
+    assert_eq!(
+        value_less.get("threshold"),
+        Some(&serde_json::Value::Null),
+        "the deprecated threshold is null"
+    );
+    assert_eq!(
+        value_less.get("boundary"),
+        Some(&serde_json::Value::Null),
+        "the deprecated boundary is null"
+    );
 
     // Counted, because it is returned: the endpoint that loads a report's results and
     // the one that counts them without loading say the same thing about the same

--- a/lib/api_projects/tests/parameters.rs
+++ b/lib/api_projects/tests/parameters.rs
@@ -1039,9 +1039,7 @@ async fn value_less_measure_is_stored_billed_and_echoed() {
 
     // The deprecated `metric` is absent rather than null, because there is no `value`
     // row to reconstruct it from and nothing else may stand in for one.
-    let value_less = measures[1]
-        .as_object()
-        .expect("the measure is an object");
+    let value_less = measures[1].as_object().expect("the measure is an object");
     assert!(
         !value_less.contains_key("metric"),
         "the deprecated metric is absent, got {value_less:#?}"
@@ -1123,8 +1121,9 @@ async fn v0_measure_response_is_unchanged() {
         .as_array_mut()
         .expect("the measure echoes its named values")
     {
-        *metric.pointer_mut("/uuid").expect("the named value carries a uuid") =
-            serde_json::json!("<uuid>");
+        *metric
+            .pointer_mut("/uuid")
+            .expect("the named value carries a uuid") = serde_json::json!("<uuid>");
     }
 
     assert_eq!(

--- a/lib/api_projects/tests/parameters.rs
+++ b/lib/api_projects/tests/parameters.rs
@@ -1011,6 +1011,13 @@ async fn value_less_measure_is_stored_but_not_echoed() {
         Some(&serde_json::json!(1.0)),
         "the measure that named one is whole"
     );
+
+    // Not counted either, so the endpoint that loads a report's results and the one
+    // that counts them without loading say the same thing about the same report.
+    assert_eq!(
+        response.pointer("/counts/results/0"),
+        Some(&serde_json::json!({ "benchmarks": 1, "measures": 1 })),
+    );
 }
 
 // `--fold` is deprecated, not deleted: a BMF v0 report folds exactly as it always

--- a/lib/api_projects/tests/parameters.rs
+++ b/lib/api_projects/tests/parameters.rs
@@ -14,7 +14,7 @@
 //! old shape not moving when it does.
 
 use bencher_api_tests::{TestServer, helpers::get_project_id};
-use bencher_json::{JsonParameters, MetricName};
+use bencher_json::{JsonParameters, MetricName, Slug};
 use bencher_schema::{context::DbConnection, schema};
 use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 use http::StatusCode;
@@ -203,6 +203,23 @@ fn boundary_names(conn: &mut DbConnection, project_id: i32) -> Vec<String> {
         .expect("Failed to load the boundaries")
         .into_iter()
         .map(|name| name.to_string())
+        .collect()
+}
+
+/// The measure of every billable series a project has, in slug order.
+///
+/// A series is `(testbed, benchmark, parameter, measure)`, so this is the measure
+/// side of what the active series cache bills.
+fn series_measures(conn: &mut DbConnection, project_id: i32) -> Vec<String> {
+    schema::series_last_seen::table
+        .inner_join(schema::measure::table)
+        .filter(schema::series_last_seen::project_id.eq(project_id))
+        .order(schema::measure::slug.asc())
+        .select(schema::measure::slug)
+        .load::<Slug>(&mut *conn)
+        .expect("Failed to load the billable series")
+        .into_iter()
+        .map(|slug| slug.to_string())
         .collect()
 }
 
@@ -948,10 +965,11 @@ async fn parameter_creation_is_rate_limited() {
 
 // A BMF v1 measure may name only percentiles and never mention `value` at all, which
 // is the one shape the deprecated `metric` field cannot describe. Its named rows are
-// stored like any other, and the measure is left out of the response rather than
-// echoed without the point estimate an older client requires.
+// stored like any other and its series is billed like any other, so the report that
+// created them says so: the measure comes back with its named values, and the
+// deprecated `metric` is simply absent.
 #[tokio::test]
-async fn value_less_measure_is_stored_but_not_echoed() {
+async fn value_less_measure_is_stored_billed_and_echoed() {
     let server = TestServer::new().await;
     let fixture = fixture(&server, "valueless").await;
 
@@ -987,8 +1005,15 @@ async fn value_less_measure_is_stored_but_not_echoed() {
         ],
     );
 
-    // Not echoed. The deprecated `metric` is a required field, so the measure that
-    // cannot fill it is omitted rather than sent without it.
+    // Billed. Every measure of a grid point is its own active series, the one that
+    // named no point estimate included.
+    assert_eq!(
+        series_measures(&mut conn, project_id),
+        vec!["latency".to_owned(), "throughput".to_owned()],
+    );
+
+    // Echoed. What is stored and billed is visible in the report that created it, so
+    // both measures come back.
     let measures = response
         .pointer("/results/0/0/measures")
         .and_then(serde_json::Value::as_array)
@@ -1003,20 +1028,123 @@ async fn value_less_measure_is_stored_but_not_echoed() {
         .collect();
     assert_eq!(
         slugs,
-        vec![Some("latency")],
-        "the measure that named no point estimate is left out, got {measures:#?}"
+        vec![Some("latency"), Some("throughput")],
+        "the measure that named no point estimate is echoed too, got {measures:#?}"
     );
     assert_eq!(
         measures[0].pointer("/metric/value"),
         Some(&serde_json::json!(1.0)),
-        "the measure that named one is whole"
+        "the measure that named a point estimate keeps its deprecated triple"
     );
 
-    // Not counted either, so the endpoint that loads a report's results and the one
-    // that counts them without loading say the same thing about the same report.
+    // The deprecated `metric` is absent rather than null, because there is no `value`
+    // row to reconstruct it from and nothing else may stand in for one.
+    let value_less = measures[1]
+        .as_object()
+        .expect("the measure is an object");
+    assert!(
+        !value_less.contains_key("metric"),
+        "the deprecated metric is absent, got {value_less:#?}"
+    );
+    let named: Vec<(Option<&str>, Option<f64>)> = value_less
+        .get("metrics")
+        .and_then(serde_json::Value::as_array)
+        .expect("the measure echoes its named values")
+        .iter()
+        .map(|metric| {
+            (
+                metric.pointer("/name").and_then(serde_json::Value::as_str),
+                metric.pointer("/value").and_then(serde_json::Value::as_f64),
+            )
+        })
+        .collect();
+    assert_eq!(
+        named,
+        vec![(Some("p50"), Some(2.0)), (Some("p99"), Some(3.0))],
+        "the named values are the whole of what was reported"
+    );
+
+    // Counted, because it is returned: the endpoint that loads a report's results and
+    // the one that counts them without loading say the same thing about the same
+    // report.
     assert_eq!(
         response.pointer("/counts/results/0"),
-        Some(&serde_json::json!({ "benchmarks": 1, "measures": 1 })),
+        Some(&serde_json::json!({ "benchmarks": 1, "measures": 2 })),
+    );
+
+    // The legacy metric-count meter is a separate question that
+    // `named_values_do_not_change_the_metric_count` records rather than settles: it
+    // counts `value` rows, so this report meters one. Pinned here so a change to
+    // either view cannot pass unnoticed.
+    let counted: i32 = schema::metric_count_by_report::table
+        .select(schema::metric_count_by_report::metric_count)
+        .first(&mut conn)
+        .expect("Failed to read the report's metric count");
+    assert_eq!(counted, 1);
+}
+
+// The compatibility claim behind an optional `metric`: nothing an older client can
+// produce loses the field. BMF v0 is that shape, and its response is exactly what it
+// always was, the deprecated triple included and no field turned null.
+#[tokio::test]
+async fn v0_measure_response_is_unchanged() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "v0-shape").await;
+
+    let response = report(
+        &server,
+        &fixture,
+        1,
+        vec![
+            serde_json::to_string(&serde_json::json!({
+                "bench": {
+                    "latency": { "value": 10.0, "lower_value": 9.0, "upper_value": 11.0 }
+                }
+            }))
+            .expect("the results serialize"),
+        ],
+        None,
+        None,
+    )
+    .await;
+
+    let mut measure = response
+        .pointer("/results/0/0/measures/0")
+        .expect("the report echoes its measure")
+        .clone();
+    // The measure entity and every UUID are minted per run; everything else is pinned.
+    *measure
+        .pointer_mut("/measure")
+        .expect("the measure carries its entity") = serde_json::json!("<measure>");
+    *measure
+        .pointer_mut("/metric/uuid")
+        .expect("the deprecated metric carries a uuid") = serde_json::json!("<uuid>");
+    for metric in measure["metrics"]
+        .as_array_mut()
+        .expect("the measure echoes its named values")
+    {
+        *metric.pointer_mut("/uuid").expect("the named value carries a uuid") =
+            serde_json::json!("<uuid>");
+    }
+
+    assert_eq!(
+        measure,
+        serde_json::json!({
+            "measure": "<measure>",
+            "metrics": [
+                { "uuid": "<uuid>", "name": "lower_value", "value": 9.0, "boundaries": [] },
+                { "uuid": "<uuid>", "name": "upper_value", "value": 11.0, "boundaries": [] },
+                { "uuid": "<uuid>", "name": "value", "value": 10.0, "boundaries": [] },
+            ],
+            "metric": {
+                "uuid": "<uuid>",
+                "value": 10.0,
+                "lower_value": 9.0,
+                "upper_value": 11.0,
+            },
+            "threshold": null,
+            "boundary": null,
+        }),
     );
 }
 

--- a/lib/api_projects/tests/parameters.rs
+++ b/lib/api_projects/tests/parameters.rs
@@ -70,6 +70,20 @@ async fn report(
     thresholds: Option<serde_json::Value>,
     fold: Option<&str>,
 ) -> serde_json::Value {
+    let (status, body) = try_report(server, fixture, day, results, thresholds, fold).await;
+    assert_eq!(status, StatusCode::CREATED, "POST report {day}: {body}");
+    serde_json::from_str(&body).expect("Failed to parse the report")
+}
+
+/// Post one report and return its status and body, whatever they are.
+async fn try_report(
+    server: &TestServer,
+    fixture: &Fixture,
+    day: usize,
+    results: Vec<String>,
+    thresholds: Option<serde_json::Value>,
+    fold: Option<&str>,
+) -> (StatusCode, String) {
     // Both optional fields are omitted by sending `null`, which is what an absent
     // `Option` deserializes from.
     let body = serde_json::json!({
@@ -95,8 +109,7 @@ async fn report(
         .expect("Request failed");
     let status = resp.status();
     let body = resp.text().await.expect("Failed to read the response");
-    assert_eq!(status, StatusCode::CREATED, "POST report {day}: {body}");
-    serde_json::from_str(&body).expect("Failed to parse the report")
+    (status, body)
 }
 
 /// One BMF v1 payload for a single benchmark's grid points.
@@ -882,4 +895,53 @@ async fn report_response_echoes_named_values_and_separates_grid_points() {
     };
     assert_eq!(boundaries("value"), 1, "the point estimate was gated");
     assert_eq!(boundaries("p99"), 0, "a named value was not gated");
+}
+
+// Parameter sets are minted straight from report content, one row per grid point, so
+// they carry the same per project creation ceiling as every other entity a report
+// mints. Without it a harness that interpolates a commit sha or a timestamp into its
+// parameters mints rows, grid points, and billable series without bound.
+#[tokio::test]
+async fn parameter_creation_is_rate_limited() {
+    // Four creations per project per window. A benchmark is born with its empty
+    // parameter set, which is one of the four, so the fourth new grid point under one
+    // benchmark is the one that is refused.
+    let server = TestServer::new_with_creation_limits(4, 4).await;
+
+    let measures = serde_json::json!({ "latency": { "value": 1.0 } });
+    let grid_points = |count: usize| -> Vec<String> {
+        let entries = (0..count)
+            .map(|n| entry(&serde_json::json!({ "n": n }), &measures))
+            .collect::<Vec<_>>();
+        vec![v1("bench", &entries)]
+    };
+
+    // Under the ceiling: three new grid points on top of the birth empty set.
+    let under = fixture(&server, "under-limit").await;
+    let (status, body) = try_report(&server, &under, 1, grid_points(3), None, None).await;
+    assert_eq!(status, StatusCode::CREATED, "under the ceiling: {body}");
+
+    // Over the ceiling, and in its own project, so what is counted is this project's
+    // own parameter rows rather than every project's.
+    let over = fixture(&server, "over-limit").await;
+    let (status, body) = try_report(&server, &over, 1, grid_points(4), None, None).await;
+    assert_eq!(
+        status,
+        StatusCode::TOO_MANY_REQUESTS,
+        "over the ceiling: {body}"
+    );
+    assert!(
+        body.contains("Parameter"),
+        "the limit that fired is the parameter one: {body}"
+    );
+
+    // Minting stopped at the ceiling: the birth empty set plus three grid points,
+    // with the fourth refused rather than written.
+    let project_id = get_project_id(&server, &over.project_slug);
+    let mut conn = server.db_conn();
+    assert_eq!(
+        parameter_sets(&mut conn, project_id).len(),
+        4,
+        "no parameter set is minted past the ceiling"
+    );
 }

--- a/lib/api_projects/tests/parameters.rs
+++ b/lib/api_projects/tests/parameters.rs
@@ -1,0 +1,740 @@
+#![cfg(feature = "plus")]
+#![expect(
+    unused_crate_dependencies,
+    clippy::expect_used,
+    clippy::tests_outside_test_module,
+    clippy::too_many_lines,
+    reason = "integration test file"
+)]
+//! Benchmark parameters and named metric values, end to end through ingest.
+//!
+//! The promise this file exists to keep is that no existing project's alert volume
+//! changes. Every other test here is about the new shape reaching the database;
+//! [`alert_volume_is_identical_for_flat_benchmarks_and_grid_points`] is about the
+//! old shape not moving when it does.
+
+use bencher_api_tests::{TestServer, helpers::get_project_id};
+use bencher_json::{JsonParameters, MetricName};
+use bencher_schema::{context::DbConnection, schema};
+use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
+use http::StatusCode;
+
+/// A threshold model loose enough to compute a boundary from a short history and
+/// tight enough that a tenfold jump is an outlier.
+fn threshold_models() -> serde_json::Value {
+    serde_json::json!({
+        "models": {
+            "latency": {
+                "test": "t_test",
+                "min_sample_size": 2,
+                "max_sample_size": 64,
+                "lower_boundary": 0.98,
+                "upper_boundary": 0.98,
+            }
+        }
+    })
+}
+
+/// A signed up user with an organization and a project to report into.
+struct Fixture {
+    project_slug: String,
+    token: String,
+}
+
+async fn fixture(server: &TestServer, label: &str) -> Fixture {
+    let user = server
+        .signup("Test User", &format!("params{label}@example.com"))
+        .await;
+    let org = server
+        .create_org(&user, &format!("Params Org {label}"))
+        .await;
+    let project = server
+        .create_project(&user, &org, &format!("Params Project {label}"))
+        .await;
+    Fixture {
+        project_slug: project.slug.to_string(),
+        token: user.token.to_string(),
+    }
+}
+
+/// Post one report of `results` and return the parsed response.
+///
+/// `day` only has to be distinct and increasing, so reports order the way they were
+/// submitted. `thresholds` is passed on every report because the report endpoint
+/// upserts it, which keeps the fixtures to a single request per step.
+async fn report(
+    server: &TestServer,
+    fixture: &Fixture,
+    day: usize,
+    results: Vec<String>,
+    thresholds: Option<serde_json::Value>,
+    fold: Option<&str>,
+) -> serde_json::Value {
+    let mut body = serde_json::json!({
+        "branch": "main",
+        "testbed": "localhost",
+        "start_time": format!("2024-01-{day:02}T00:00:00Z"),
+        "end_time": format!("2024-01-{day:02}T00:01:00Z"),
+        "results": results,
+    });
+    if let Some(thresholds) = thresholds {
+        body["thresholds"] = thresholds;
+    }
+    if let Some(fold) = fold {
+        body["settings"] = serde_json::json!({ "fold": fold });
+    }
+
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/reports", fixture.project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&fixture.token),
+        )
+        .json(&body)
+        .send()
+        .await
+        .expect("Request failed");
+    let status = resp.status();
+    let body = resp.text().await.expect("Failed to read the response");
+    assert_eq!(status, StatusCode::CREATED, "POST report {day}: {body}");
+    serde_json::from_str(&body).expect("Failed to parse the report")
+}
+
+/// One BMF v1 payload for a single benchmark's grid points.
+fn v1(benchmark: &str, entries: Vec<serde_json::Value>) -> String {
+    serde_json::to_string(&serde_json::json!({ benchmark: entries }))
+        .expect("the results serialize")
+}
+
+fn entry(parameters: serde_json::Value, measures: serde_json::Value) -> serde_json::Value {
+    serde_json::json!({ "parameters": parameters, "measures": measures })
+}
+
+/// Every parameter set stored under a project, with the number of `report_benchmark`
+/// rows pointing at it.
+fn parameter_sets(conn: &mut DbConnection, project_id: i32) -> Vec<(JsonParameters, i64)> {
+    let parameters: Vec<(i32, JsonParameters)> = schema::parameter::table
+        .inner_join(schema::benchmark::table)
+        .filter(schema::benchmark::project_id.eq(project_id))
+        .order(schema::parameter::id.asc())
+        .select((schema::parameter::id, schema::parameter::parameters))
+        .load(&mut *conn)
+        .expect("Failed to load the parameter sets");
+
+    parameters
+        .into_iter()
+        .map(|(parameter_id, parameters)| {
+            let count: i64 = schema::report_benchmark::table
+                .filter(schema::report_benchmark::parameter_id.eq(parameter_id))
+                .count()
+                .get_result(&mut *conn)
+                .expect("Failed to count the report benchmarks");
+            (parameters, count)
+        })
+        .collect()
+}
+
+/// Every metric name stored for a project, with its value, keyed by parameter set.
+fn named_values(conn: &mut DbConnection, project_id: i32) -> Vec<(JsonParameters, String, f64)> {
+    schema::metric::table
+        .inner_join(
+            schema::report_benchmark::table
+                .inner_join(schema::parameter::table)
+                .inner_join(schema::benchmark::table),
+        )
+        .filter(schema::benchmark::project_id.eq(project_id))
+        .order((schema::parameter::id.asc(), schema::metric::name.asc()))
+        .select((
+            schema::parameter::parameters,
+            schema::metric::name,
+            schema::metric::value,
+        ))
+        .load::<(JsonParameters, MetricName, f64)>(&mut *conn)
+        .expect("Failed to load the metric rows")
+        .into_iter()
+        .map(|(parameters, name, value)| (parameters, name.to_string(), value))
+        .collect()
+}
+
+/// The parameter set and metric name of every alert in a project.
+fn alerts(conn: &mut DbConnection, project_id: i32) -> Vec<(JsonParameters, String)> {
+    schema::alert::table
+        .inner_join(
+            schema::boundary::table.inner_join(
+                schema::metric::table.inner_join(
+                    schema::report_benchmark::table
+                        .inner_join(schema::parameter::table)
+                        .inner_join(schema::benchmark::table),
+                ),
+            ),
+        )
+        .filter(schema::benchmark::project_id.eq(project_id))
+        .order(schema::alert::id.asc())
+        .select((schema::parameter::parameters, schema::metric::name))
+        .load::<(JsonParameters, MetricName)>(&mut *conn)
+        .expect("Failed to load the alerts")
+        .into_iter()
+        .map(|(parameters, name)| (parameters, name.to_string()))
+        .collect()
+}
+
+/// The metric name every boundary is attached to.
+fn boundary_names(conn: &mut DbConnection, project_id: i32) -> Vec<String> {
+    schema::boundary::table
+        .inner_join(
+            schema::metric::table
+                .inner_join(schema::report_benchmark::table.inner_join(schema::benchmark::table)),
+        )
+        .filter(schema::benchmark::project_id.eq(project_id))
+        .select(schema::metric::name)
+        .load::<MetricName>(&mut *conn)
+        .expect("Failed to load the boundaries")
+        .into_iter()
+        .map(|name| name.to_string())
+        .collect()
+}
+
+fn parameters(canonical: &str) -> JsonParameters {
+    canonical.parse().expect("Failed to parse the parameters")
+}
+
+// A BMF v1 report lands one `report_benchmark` row per grid point and one `metric`
+// row per named value, under the parameter set the entry declared.
+#[tokio::test]
+async fn v1_report_lands_grid_points_and_named_values() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "grid").await;
+
+    report(
+        &server,
+        &fixture,
+        1,
+        vec![v1(
+            "bench",
+            vec![
+                entry(
+                    serde_json::json!({ "size_mb": 16 }),
+                    serde_json::json!({ "latency": { "value": 42.0, "p99": 97.0 } }),
+                ),
+                entry(
+                    serde_json::json!({ "size_mb": 32 }),
+                    serde_json::json!({ "latency": { "value": 55.0 } }),
+                ),
+            ],
+        )],
+        None,
+        None,
+    )
+    .await;
+
+    let project_id = get_project_id(&server, &fixture.project_slug);
+    let mut conn = server.db_conn();
+
+    // The empty set the benchmark was born with, plus one row per grid point.
+    assert_eq!(
+        parameter_sets(&mut conn, project_id),
+        vec![
+            (JsonParameters::default(), 0),
+            (parameters(r#"{"size_mb": 16}"#), 1),
+            (parameters(r#"{"size_mb": 32}"#), 1),
+        ],
+    );
+
+    assert_eq!(
+        named_values(&mut conn, project_id),
+        vec![
+            (parameters(r#"{"size_mb": 16}"#), "p99".to_owned(), 97.0),
+            (parameters(r#"{"size_mb": 16}"#), "value".to_owned(), 42.0),
+            (parameters(r#"{"size_mb": 32}"#), "value".to_owned(), 55.0),
+        ],
+    );
+}
+
+/// The point estimates each grid point reports, run after run. The first grid point
+/// jumps tenfold on the final report and the second does not.
+const SMALL: [f64; 5] = [10.0, 11.0, 12.0, 13.0, 14.0];
+const LARGE: [f64; 5] = [100.0, 101.0, 102.0, 103.0, 104.0];
+const SMALL_FINAL: f64 = 1_000.0;
+const LARGE_FINAL: f64 = 104.0;
+
+/// Ingest the same measurements as two flat benchmarks, and return the project.
+async fn ingest_flat(server: &TestServer) -> (Fixture, i32) {
+    let fixture = fixture(server, "flat").await;
+    for (day, (small, large)) in SMALL
+        .into_iter()
+        .zip(LARGE)
+        .chain([(SMALL_FINAL, LARGE_FINAL)])
+        .enumerate()
+    {
+        let results = serde_json::json!({
+            "bench_16": { "latency": { "value": small } },
+            "bench_32": { "latency": { "value": large } },
+        });
+        report(
+            server,
+            &fixture,
+            day + 1,
+            vec![serde_json::to_string(&results).expect("the results serialize")],
+            Some(threshold_models()),
+            None,
+        )
+        .await;
+    }
+    let project_id = get_project_id(server, &fixture.project_slug);
+    (fixture, project_id)
+}
+
+/// Ingest the same measurements as one benchmark's two grid points.
+async fn ingest_grid(server: &TestServer) -> (Fixture, i32) {
+    let fixture = fixture(server, "grid-parity").await;
+    for (day, (small, large)) in SMALL
+        .into_iter()
+        .zip(LARGE)
+        .chain([(SMALL_FINAL, LARGE_FINAL)])
+        .enumerate()
+    {
+        report(
+            server,
+            &fixture,
+            day + 1,
+            vec![v1(
+                "bench",
+                vec![
+                    entry(
+                        serde_json::json!({ "size_mb": 16 }),
+                        serde_json::json!({ "latency": { "value": small } }),
+                    ),
+                    entry(
+                        serde_json::json!({ "size_mb": 32 }),
+                        serde_json::json!({ "latency": { "value": large } }),
+                    ),
+                ],
+            )],
+            Some(threshold_models()),
+            None,
+        )
+        .await;
+    }
+    let project_id = get_project_id(server, &fixture.project_slug);
+    (fixture, project_id)
+}
+
+// A project whose grid points are flat benchmarks and a project whose grid points
+// are parameter sets raise exactly the same alerts from exactly the same numbers.
+//
+// This is the promise of the whole layer: a bare threshold gates the conventional
+// value series of every parameter set under its measure, which is what a
+// measure-level threshold over flat benchmarks has always done.
+#[tokio::test]
+async fn alert_volume_is_identical_for_flat_benchmarks_and_grid_points() {
+    let server = TestServer::new().await;
+
+    let (_flat, flat_project) = ingest_flat(&server).await;
+    let (_grid, grid_project) = ingest_grid(&server).await;
+
+    let mut conn = server.db_conn();
+    let flat_alerts = alerts(&mut conn, flat_project);
+    let grid_alerts = alerts(&mut conn, grid_project);
+
+    assert_eq!(
+        flat_alerts.len(),
+        1,
+        "the flat fixture raises exactly one alert, got {flat_alerts:?}"
+    );
+    assert_eq!(
+        grid_alerts.len(),
+        flat_alerts.len(),
+        "migrating to parameters must not change alert volume"
+    );
+    assert_eq!(
+        grid_alerts,
+        vec![(parameters(r#"{"size_mb": 16}"#), "value".to_owned())],
+        "the alert belongs to the grid point that regressed"
+    );
+}
+
+// One grid point's regression does not alert against another's baseline, and one
+// grid point's ordinary run is not an outlier against the other's history.
+#[tokio::test]
+async fn baselines_separate_by_parameter() {
+    let server = TestServer::new().await;
+    let (_grid, project_id) = ingest_grid(&server).await;
+
+    let mut conn = server.db_conn();
+    assert_eq!(
+        alerts(&mut conn, project_id),
+        vec![(parameters(r#"{"size_mb": 16}"#), "value".to_owned())],
+        "each grid point is tested against its own history"
+    );
+}
+
+// A bare threshold gates the conventional `value` series and nothing else: a report
+// carrying `p50` and `p99` produces boundaries on `value` alone.
+#[tokio::test]
+async fn bare_threshold_gates_only_the_value_name() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "named").await;
+
+    for (day, value) in SMALL.into_iter().chain([SMALL_FINAL]).enumerate() {
+        report(
+            &server,
+            &fixture,
+            day + 1,
+            vec![v1(
+                "bench",
+                vec![entry(
+                    serde_json::json!({}),
+                    serde_json::json!({
+                        "latency": { "value": value, "p50": value - 1.0, "p99": value + 1.0 }
+                    }),
+                )],
+            )],
+            Some(threshold_models()),
+            None,
+        )
+        .await;
+    }
+
+    let project_id = get_project_id(&server, &fixture.project_slug);
+    let mut conn = server.db_conn();
+
+    let names = boundary_names(&mut conn, project_id);
+    assert!(!names.is_empty(), "the fixture computes boundaries");
+    assert!(
+        names.iter().all(|name| name == "value"),
+        "a bare threshold gates only the point estimate, got {names:?}"
+    );
+
+    let alerts = alerts(&mut conn, project_id);
+    assert_eq!(
+        alerts,
+        vec![(JsonParameters::default(), "value".to_owned())],
+        "the alert is on the point estimate"
+    );
+}
+
+// An entry with no `parameters` lands on the benchmark's empty parameter set,
+// which is the same set an explicit `{}` lands on.
+#[tokio::test]
+async fn absent_parameters_land_on_the_empty_set() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "absent").await;
+
+    report(
+        &server,
+        &fixture,
+        1,
+        vec![
+            serde_json::to_string(&serde_json::json!({
+                "bench": [
+                    { "measures": { "latency": { "value": 1.0 } } },
+                    { "parameters": {}, "measures": { "throughput": { "value": 2.0 } } },
+                ]
+            }))
+            .expect("the results serialize"),
+        ],
+        None,
+        None,
+    )
+    .await;
+
+    let project_id = get_project_id(&server, &fixture.project_slug);
+    let mut conn = server.db_conn();
+
+    assert_eq!(
+        parameter_sets(&mut conn, project_id),
+        vec![(JsonParameters::default(), 1)],
+        "an absent parameter set and an explicit empty one are one grid point"
+    );
+}
+
+// An archived parameter set that reports again is unarchived, exactly as an
+// archived benchmark is.
+#[tokio::test]
+async fn archived_parameter_set_is_unarchived_on_report() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "archived").await;
+
+    let grid_point = v1(
+        "bench",
+        vec![entry(
+            serde_json::json!({ "size_mb": 16 }),
+            serde_json::json!({ "latency": { "value": 1.0 } }),
+        )],
+    );
+    report(&server, &fixture, 1, vec![grid_point.clone()], None, None).await;
+
+    let project_id = get_project_id(&server, &fixture.project_slug);
+    {
+        let mut conn = server.db_conn();
+        let updated = diesel::update(
+            schema::parameter::table
+                .filter(schema::parameter::parameters.eq(parameters(r#"{"size_mb": 16}"#))),
+        )
+        .set(schema::parameter::archived.eq(Some(1_000_000_000i64)))
+        .execute(&mut conn)
+        .expect("Failed to archive the parameter set");
+        assert_eq!(updated, 1);
+    }
+
+    report(&server, &fixture, 2, vec![grid_point], None, None).await;
+
+    let mut conn = server.db_conn();
+    let archived: Vec<Option<i64>> = schema::parameter::table
+        .inner_join(schema::benchmark::table)
+        .filter(schema::benchmark::project_id.eq(project_id))
+        .filter(schema::parameter::parameters.eq(parameters(r#"{"size_mb": 16}"#)))
+        .select(schema::parameter::archived)
+        .load(&mut conn)
+        .expect("Failed to load the parameter set");
+    assert_eq!(archived, vec![None], "reporting unarchives the grid point");
+}
+
+// Fold is not supported for BMF v1: the report warns and ingests unfolded, one
+// `report_benchmark` row per iteration, and never errors.
+#[tokio::test]
+async fn fold_with_v1_warns_and_lands_every_iteration() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "fold").await;
+
+    report(
+        &server,
+        &fixture,
+        1,
+        vec![
+            v1(
+                "bench",
+                vec![entry(
+                    serde_json::json!({}),
+                    serde_json::json!({ "latency": { "value": 10.0 } }),
+                )],
+            ),
+            v1(
+                "bench",
+                vec![entry(
+                    serde_json::json!({}),
+                    serde_json::json!({ "latency": { "value": 20.0 } }),
+                )],
+            ),
+        ],
+        None,
+        Some("min"),
+    )
+    .await;
+
+    let project_id = get_project_id(&server, &fixture.project_slug);
+    let mut conn = server.db_conn();
+
+    let iterations: Vec<i32> = schema::report_benchmark::table
+        .inner_join(schema::benchmark::table)
+        .filter(schema::benchmark::project_id.eq(project_id))
+        .order(schema::report_benchmark::iteration.asc())
+        .select(schema::report_benchmark::iteration)
+        .load(&mut conn)
+        .expect("Failed to load the report benchmarks");
+    assert_eq!(iterations, vec![0, 1], "a v1 payload ingests unfolded");
+
+    let values: Vec<f64> = schema::metric::table
+        .inner_join(schema::report_benchmark::table.inner_join(schema::benchmark::table))
+        .filter(schema::benchmark::project_id.eq(project_id))
+        .order(schema::metric::value.asc())
+        .select(schema::metric::value)
+        .load(&mut conn)
+        .expect("Failed to load the metric rows");
+    assert_eq!(values, vec![10.0, 20.0], "nothing was folded away");
+}
+
+// The named value cap drops the excess best effort. The report still succeeds.
+#[tokio::test]
+async fn named_value_cap_does_not_fail_the_report() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "cap").await;
+
+    let mut measures = serde_json::Map::new();
+    measures.insert("value".to_owned(), serde_json::json!(1.0));
+    for index in 0..9u32 {
+        measures.insert(format!("p{index}"), serde_json::json!(f64::from(index)));
+    }
+
+    report(
+        &server,
+        &fixture,
+        1,
+        vec![v1(
+            "bench",
+            vec![entry(
+                serde_json::json!({}),
+                serde_json::json!({ "latency": measures }),
+            )],
+        )],
+        None,
+        None,
+    )
+    .await;
+
+    let project_id = get_project_id(&server, &fixture.project_slug);
+    let mut conn = server.db_conn();
+    let names = named_values(&mut conn, project_id);
+    assert_eq!(names.len(), 8, "the cap keeps eight names, got {names:?}");
+    assert!(
+        names.iter().any(|(_, name, _)| name == "value"),
+        "the point estimate is never dropped, got {names:?}"
+    );
+}
+
+// The report response echoes every named value, keeps the deprecated metric,
+// threshold, and boundary fields correct, and separates two grid points into two
+// results rather than merging them into one.
+#[tokio::test]
+async fn report_response_echoes_named_values_and_separates_grid_points() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "response").await;
+
+    // Enough history for the final report to carry a boundary.
+    for (day, value) in SMALL.into_iter().enumerate() {
+        report(
+            &server,
+            &fixture,
+            day + 1,
+            vec![v1(
+                "bench",
+                vec![
+                    entry(
+                        serde_json::json!({ "size_mb": 16 }),
+                        serde_json::json!({ "latency": { "value": value } }),
+                    ),
+                    entry(
+                        serde_json::json!({ "size_mb": 32 }),
+                        serde_json::json!({ "latency": { "value": value * 10.0 } }),
+                    ),
+                ],
+            )],
+            Some(threshold_models()),
+            None,
+        )
+        .await;
+    }
+
+    let response = report(
+        &server,
+        &fixture,
+        SMALL.len() + 1,
+        vec![v1(
+            "bench",
+            vec![
+                entry(
+                    serde_json::json!({ "size_mb": 16 }),
+                    serde_json::json!({
+                        "latency": { "value": 12.0, "lower_value": 11.0, "upper_value": 13.0, "p99": 20.0 }
+                    }),
+                ),
+                entry(
+                    serde_json::json!({ "size_mb": 32 }),
+                    serde_json::json!({ "latency": { "value": 120.0 } }),
+                ),
+            ],
+        )],
+        Some(threshold_models()),
+        None,
+    )
+    .await;
+
+    let results = response
+        .pointer("/results/0")
+        .and_then(serde_json::Value::as_array)
+        .expect("the report echoes its results");
+    assert_eq!(
+        results.len(),
+        2,
+        "two grid points are two results, got {results:#?}"
+    );
+
+    // The counts are computed two ways, from the loaded results and by aggregate
+    // query, and both have to see two grid points rather than one benchmark.
+    assert_eq!(
+        response.pointer("/counts/results/0"),
+        Some(&serde_json::json!({ "benchmarks": 2, "measures": 1 })),
+    );
+
+    let grid_points: Vec<JsonParameters> = results
+        .iter()
+        .map(|result| {
+            serde_json::from_value(
+                result
+                    .pointer("/parameter/parameters")
+                    .expect("each result names its parameter set")
+                    .clone(),
+            )
+            .expect("the parameter set parses")
+        })
+        .collect();
+    assert_eq!(
+        grid_points,
+        vec![
+            parameters(r#"{"size_mb": 16}"#),
+            parameters(r#"{"size_mb": 32}"#),
+        ],
+    );
+
+    let measure = results[0]
+        .pointer("/measures/0")
+        .expect("the result echoes its measure");
+
+    // The named values, in a stable order.
+    let names: Vec<&str> = measure
+        .pointer("/metrics")
+        .and_then(serde_json::Value::as_array)
+        .expect("the measure echoes its named values")
+        .iter()
+        .map(|metric| {
+            metric
+                .pointer("/name")
+                .and_then(serde_json::Value::as_str)
+                .expect("each named value has a name")
+        })
+        .collect();
+    assert_eq!(names, vec!["lower_value", "p99", "upper_value", "value"]);
+
+    // The deprecated trio, reconstructed from the `value` row and its siblings.
+    assert_eq!(
+        measure.pointer("/metric/value"),
+        Some(&serde_json::json!(12.0))
+    );
+    assert_eq!(
+        measure.pointer("/metric/lower_value"),
+        Some(&serde_json::json!(11.0))
+    );
+    assert_eq!(
+        measure.pointer("/metric/upper_value"),
+        Some(&serde_json::json!(13.0))
+    );
+    assert!(
+        measure
+            .pointer("/threshold")
+            .is_some_and(|threshold| !threshold.is_null()),
+        "the deprecated threshold is populated, got {measure:#?}"
+    );
+    assert!(
+        measure
+            .pointer("/boundary")
+            .is_some_and(|boundary| !boundary.is_null()),
+        "the deprecated boundary is populated, got {measure:#?}"
+    );
+
+    // The plural form pairs each threshold with the boundary it produced, and only
+    // the point estimate was gated.
+    let boundaries = |name: &str| -> usize {
+        measure
+            .pointer("/metrics")
+            .and_then(serde_json::Value::as_array)
+            .expect("the measure echoes its named values")
+            .iter()
+            .find(|metric| metric.pointer("/name") == Some(&serde_json::json!(name)))
+            .and_then(|metric| metric.pointer("/boundaries"))
+            .and_then(serde_json::Value::as_array)
+            .map_or(0, Vec::len)
+    };
+    assert_eq!(boundaries("value"), 1, "the point estimate was gated");
+    assert_eq!(boundaries("p99"), 0, "a named value was not gated");
+}

--- a/lib/api_projects/tests/parameters.rs
+++ b/lib/api_projects/tests/parameters.rs
@@ -945,3 +945,136 @@ async fn parameter_creation_is_rate_limited() {
         "no parameter set is minted past the ceiling"
     );
 }
+
+// A BMF v1 measure may name only percentiles and never mention `value` at all, which
+// is the one shape the deprecated `metric` field cannot describe. Its named rows are
+// stored like any other, and the measure is left out of the response rather than
+// echoed without the point estimate an older client requires.
+#[tokio::test]
+async fn value_less_measure_is_stored_but_not_echoed() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "valueless").await;
+
+    let response = report(
+        &server,
+        &fixture,
+        1,
+        vec![v1(
+            "bench",
+            &[entry(
+                &serde_json::json!({}),
+                &serde_json::json!({
+                    "latency": { "value": 1.0 },
+                    "throughput": { "p50": 2.0, "p99": 3.0 },
+                }),
+            )],
+        )],
+        None,
+        None,
+    )
+    .await;
+
+    // Stored. Ingest is best effort, and a measure that names no point estimate is a
+    // legitimate payload rather than an error.
+    let project_id = get_project_id(&server, &fixture.project_slug);
+    let mut conn = server.db_conn();
+    assert_eq!(
+        named_values(&mut conn, project_id),
+        vec![
+            (parameters("{}"), "p50".to_owned(), 2.0),
+            (parameters("{}"), "p99".to_owned(), 3.0),
+            (parameters("{}"), "value".to_owned(), 1.0),
+        ],
+    );
+
+    // Not echoed. The deprecated `metric` is a required field, so the measure that
+    // cannot fill it is omitted rather than sent without it.
+    let measures = response
+        .pointer("/results/0/0/measures")
+        .and_then(serde_json::Value::as_array)
+        .expect("the report echoes its measures");
+    let slugs: Vec<Option<&str>> = measures
+        .iter()
+        .map(|measure| {
+            measure
+                .pointer("/measure/slug")
+                .and_then(serde_json::Value::as_str)
+        })
+        .collect();
+    assert_eq!(
+        slugs,
+        vec![Some("latency")],
+        "the measure that named no point estimate is left out, got {measures:#?}"
+    );
+    assert_eq!(
+        measures[0].pointer("/metric/value"),
+        Some(&serde_json::json!(1.0)),
+        "the measure that named one is whole"
+    );
+}
+
+// `--fold` is deprecated, not deleted: a BMF v0 report folds exactly as it always
+// has. The iterations collapse into one `report_benchmark` row on the benchmark's
+// empty parameter set, carrying the folded triple, and the metric count meter that
+// bills Team, Enterprise, and licences reads exactly what it read before.
+//
+// The whole fold path was rewritten by this layer to speak parameter sets, so this
+// is the test that a pipeline running `bencher run --fold min` today sees no change
+// at all.
+#[tokio::test]
+async fn v0_fold_still_folds() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "v0-fold").await;
+
+    // One BMF v0 payload per iteration, each a whole metric triple.
+    let iteration = |value: f64| {
+        serde_json::to_string(&serde_json::json!({
+            "bench": {
+                "latency": {
+                    "value": value,
+                    "lower_value": value - 1.0,
+                    "upper_value": value + 1.0,
+                }
+            }
+        }))
+        .expect("the results serialize")
+    };
+
+    report(
+        &server,
+        &fixture,
+        1,
+        vec![iteration(10.0), iteration(20.0)],
+        None,
+        Some("min"),
+    )
+    .await;
+
+    let project_id = get_project_id(&server, &fixture.project_slug);
+    let mut conn = server.db_conn();
+
+    // One grid point, one row: the two iterations folded rather than landing apart.
+    assert_eq!(
+        parameter_sets(&mut conn, project_id),
+        vec![(parameters("{}"), 1)],
+        "the folded report is one row on the empty parameter set"
+    );
+
+    assert_eq!(
+        named_values(&mut conn, project_id),
+        vec![
+            (parameters("{}"), "lower_value".to_owned(), 9.0),
+            (parameters("{}"), "upper_value".to_owned(), 11.0),
+            (parameters("{}"), "value".to_owned(), 10.0),
+        ],
+        "the smaller iteration's whole triple survived the fold"
+    );
+
+    // The metric-count meter does not move: folding has always metered one metric
+    // here, and it still does.
+    let counted: i32 = schema::metric_count_by_report::table
+        .select(schema::metric_count_by_report::metric_count)
+        .first(&mut conn)
+        .expect("Failed to read the report's metric count");
+    assert_eq!(counted, 1, "one folded metric, metered once");
+}

--- a/lib/bencher_adapter/src/adapters/json/v1.rs
+++ b/lib/bencher_adapter/src/adapters/json/v1.rs
@@ -235,6 +235,54 @@ pub(crate) mod test_json_v1 {
         assert_eq!(named(metrics, "latency", "value"), None);
     }
 
+    /// Two entries that resolve to the same grid point union their named values.
+    /// Nothing is dropped, so nothing is counted, and a name that genuinely repeats
+    /// takes the later entry's value, deterministically, because entries are an
+    /// ordered array in wire order.
+    #[test]
+    fn adapter_json_v1_duplicate_grid_points_union_names() {
+        let input = r#"{"bench": [
+            {"measures": {"latency": {"p50": 1.0, "value": 3.0}}},
+            {"measures": {"latency": {"p99": 2.0, "value": 4.0}}}
+        ]}"#;
+        let results = AdapterJsonV1::parse(input, Settings::default())
+            .expect("Failed to parse the duplicate grid points");
+
+        let metrics = grid_point(&results, "bench", "{}");
+        assert_eq!(
+            names(metrics, "latency"),
+            vec![
+                "p50".parse::<MetricName>().unwrap(),
+                "p99".parse().unwrap(),
+                "value".parse().unwrap(),
+            ],
+            "both entries' names survive"
+        );
+        assert_eq!(named(metrics, "latency", "p50"), Some(1.0.into()));
+        assert_eq!(named(metrics, "latency", "p99"), Some(2.0.into()));
+        assert_eq!(
+            named(metrics, "latency", "value"),
+            Some(4.0.into()),
+            "a repeated name takes the later entry"
+        );
+        assert_eq!(results.dropped_names, 0, "nothing was dropped");
+    }
+
+    /// The union is per measure: a measure only one entry mentions is untouched.
+    #[test]
+    fn adapter_json_v1_duplicate_grid_points_union_measures() {
+        let input = r#"{"bench": [
+            {"measures": {"latency": {"value": 1.0}}},
+            {"measures": {"throughput": {"value": 2.0}}}
+        ]}"#;
+        let results = AdapterJsonV1::parse(input, Settings::default())
+            .expect("Failed to parse the duplicate grid points");
+
+        let metrics = grid_point(&results, "bench", "{}");
+        assert_eq!(named(metrics, "latency", "value"), Some(1.0.into()));
+        assert_eq!(named(metrics, "throughput", "value"), Some(2.0.into()));
+    }
+
     /// Two entries whose parameters differ only in key order or number spelling
     /// are the same grid point, and the measures of all three union by name.
     #[test]

--- a/lib/bencher_adapter/src/adapters/json/v1.rs
+++ b/lib/bencher_adapter/src/adapters/json/v1.rs
@@ -52,12 +52,14 @@ fn from_wire(results: JsonV1Results) -> AdapterResults {
             measures,
         } in entries
         {
-            // Two entries that canonicalize to the same parameter set are one
-            // grid point, so their measures merge rather than fork a series.
+            // Two entries that canonicalize to the same parameter set are one grid
+            // point, so their named values merge rather than fork a series. A name
+            // that genuinely repeats takes the later entry, which is deterministic
+            // because entries are an ordered array in wire order. Nothing is
+            // dropped, so nothing is counted: a harness that emits one entry per
+            // statistic is a plausible shape, not an error.
             let metrics: &mut AdapterMetrics = benchmark_entries.entry(parameters).or_default();
             for (measure, named) in measures {
-                // A measure in more than one entry unions its names, the later
-                // entry winning per name, exactly JSON object key semantics.
                 metrics
                     .inner
                     .entry(measure)

--- a/lib/bencher_adapter/src/results/adapter_results.rs
+++ b/lib/bencher_adapter/src/results/adapter_results.rs
@@ -6,7 +6,7 @@ use bencher_json::{
 };
 
 use super::{
-    adapter_metrics::AdapterMetrics,
+    adapter_metrics::{AdapterMetric, AdapterMetrics, MetricsMap},
     foldable::{FoldableMap, FoldableResults},
 };
 
@@ -50,6 +50,32 @@ impl From<ResultsMap> for AdapterResults {
             version: BmfVersion::V0,
             dropped_names: 0,
         }
+    }
+}
+
+/// Folded results are BMF v0 again: one grid point per benchmark, on the empty
+/// parameter set, with each metric triple spelled back out as its conventional names.
+///
+/// The round trip through [`AdapterResults::into_foldable`] and back is lossless
+/// because fold only ever runs on a v0 payload, which is exactly this shape.
+impl From<FoldableResults> for AdapterResults {
+    fn from(results: FoldableResults) -> Self {
+        results
+            .inner
+            .into_iter()
+            .map(|(benchmark, metrics)| {
+                let metrics: AdapterMetrics = metrics
+                    .into_iter()
+                    .map(|(measure, metric)| (measure, AdapterMetric::from(metric)))
+                    .collect::<MetricsMap>()
+                    .into();
+                (
+                    benchmark,
+                    std::iter::once((JsonParameters::default(), metrics)).collect(),
+                )
+            })
+            .collect::<ResultsMap>()
+            .into()
     }
 }
 

--- a/lib/bencher_api_tests/src/context.rs
+++ b/lib/bencher_api_tests/src/context.rs
@@ -44,13 +44,13 @@ pub struct TestServer {
 impl TestServer {
     /// Create a new test server with default settings.
     pub async fn new() -> Self {
-        Self::build(None, None, None, None).await
+        Self::build(None, None, None, None, None).await
     }
 
     /// Create a new test server with custom upload timeout and max body size.
     #[cfg(feature = "plus")]
     pub async fn new_with_limits(upload_timeout: u64, max_body_size: u64) -> Self {
-        Self::build(Some(upload_timeout), Some(max_body_size), None, None).await
+        Self::build(Some(upload_timeout), Some(max_body_size), None, None, None).await
     }
 
     /// Create a new test server with custom upload timeout, max body size, and injectable clock.
@@ -60,13 +60,34 @@ impl TestServer {
         max_body_size: u64,
         clock: bencher_json::Clock,
     ) -> Self {
-        Self::build(Some(upload_timeout), Some(max_body_size), Some(clock), None).await
+        Self::build(
+            Some(upload_timeout),
+            Some(max_body_size),
+            Some(clock),
+            None,
+            None,
+        )
+        .await
     }
 
     /// Create a new test server with a custom runner self-update base URL.
     #[cfg(feature = "plus")]
     pub async fn new_with_runner_update_base_url(base_url: url::Url) -> Self {
-        Self::build(None, None, None, Some(base_url)).await
+        Self::build(None, None, None, Some(base_url), None).await
+    }
+
+    /// Create a new test server with custom creation rate limits.
+    ///
+    /// Only the database-backed creation ceilings move: the in-memory request
+    /// limiters stay wide open, so a test reaches the ceiling it is testing rather
+    /// than a throttle on the requests that get it there.
+    #[cfg(feature = "plus")]
+    pub async fn new_with_creation_limits(unclaimed_limit: u32, claimed_limit: u32) -> Self {
+        let rate_limiting = bencher_schema::context::RateLimiting::max_with_creation_limits(
+            unclaimed_limit,
+            claimed_limit,
+        );
+        Self::build(None, None, None, None, Some(rate_limiting)).await
     }
 
     #[cfg(feature = "plus")]
@@ -80,6 +101,7 @@ impl TestServer {
         max_body_size: Option<u64>,
         clock: Option<bencher_json::Clock>,
         runner_update_base_url: Option<url::Url>,
+        rate_limiting: Option<bencher_schema::context::RateLimiting>,
     ) -> Self {
         // Create logger early so it can be used for OCI storage
         let log_config = ConfigLogging::StderrTerminal {
@@ -131,7 +153,9 @@ impl TestServer {
             rbac,
             messenger: Messenger::default(),
             database,
-            rate_limiting: Arc::new(bencher_schema::context::RateLimiting::max()),
+            rate_limiting: Arc::new(
+                rate_limiting.unwrap_or_else(bencher_schema::context::RateLimiting::max),
+            ),
             github_client: None,
             google_client: None,
             indexer: None,
@@ -173,6 +197,7 @@ impl TestServer {
         max_body_size: Option<u64>,
         _clock: Option<()>,
         _runner_update_base_url: Option<url::Url>,
+        _rate_limiting: Option<()>,
     ) -> Self {
         // Create logger early so it can be used for OCI storage
         let log_config = ConfigLogging::StderrTerminal {

--- a/lib/bencher_comment/src/lib.rs
+++ b/lib/bencher_comment/src/lib.rs
@@ -518,6 +518,9 @@ impl ReportComment {
                     .measures
                     .iter()
                     .find(|m| m.measure.slug == measure.slug);
+                // The point estimate. A measure that named no `value` has nothing for
+                // this table to draw, so its cells stay empty.
+                let point_estimate = report_measure.and_then(|m| m.metric.as_ref());
                 let alert = self.find_alert(result, measure);
 
                 if let Some(report_measure) = report_measure {
@@ -531,10 +534,10 @@ impl ReportComment {
                 } else {
                     html.push_str(EMPTY_CELL);
                 }
-                if let Some(report_measure) = report_measure {
+                if let (Some(report_measure), Some(metric)) = (report_measure, point_estimate) {
                     value_cell(
                         html,
-                        report_measure.metric.value,
+                        metric.value,
                         report_measure.boundary.and_then(|b| b.baseline),
                         factor,
                         &units_symbol,
@@ -544,10 +547,10 @@ impl ReportComment {
                     html.push_str(EMPTY_CELL);
                 }
                 if boundary_limits.lower {
-                    if let Some(report_measure) = report_measure {
+                    if let (Some(report_measure), Some(metric)) = (report_measure, point_estimate) {
                         lower_limit_cell(
                             html,
-                            report_measure.metric.value,
+                            metric.value,
                             report_measure.boundary.and_then(|b| b.lower_limit),
                             factor,
                             &units_symbol,
@@ -558,10 +561,10 @@ impl ReportComment {
                     }
                 }
                 if boundary_limits.upper {
-                    if let Some(report_measure) = report_measure {
+                    if let (Some(report_measure), Some(metric)) = (report_measure, point_estimate) {
                         upper_limit_cell(
                             html,
-                            report_measure.metric.value,
+                            metric.value,
                             report_measure.boundary.and_then(|b| b.upper_limit),
                             factor,
                             &units_symbol,
@@ -1119,9 +1122,13 @@ fn boundary_limits_map(
     let mut map = BTreeMap::new();
     for result in iteration {
         for report_measure in &result.measures {
+            // A measure that named no point estimate has no row in this table.
+            let Some(metric) = report_measure.metric.as_ref() else {
+                continue;
+            };
             let measure = Measure::from(report_measure.measure.clone());
             let min = {
-                let mut min = report_measure.metric.value;
+                let mut min = metric.value;
                 if let Some(lower_limit) = report_measure.boundary.and_then(|b| b.lower_limit) {
                     min = min.min(lower_limit);
                 }
@@ -1319,12 +1326,23 @@ mod tests {
         report.results = Some(value_less_results());
 
         let html = report_comment_for(report).html(false, None);
-        assert!(html.contains(">Latency</a></th>"), "unexpected table: {html}");
         assert!(
-            !html.contains("Throughput"),
+            html.contains(">Latency</a></th>"),
+            "unexpected table: {html}"
+        );
+        assert!(
+            html.contains("<td>1.00 ns</td>"),
+            "unexpected table: {html}"
+        );
+        assert!(
+            !html.contains(">Throughput</a></th>"),
             "the measure that named no point estimate has no column: {html}"
         );
-        assert!(html.contains(">bench</a></td>"), "unexpected table: {html}");
+        // It is still a measure of this report, so the threshold warning names it.
+        assert!(
+            html.contains("/measures/throughput\">Throughput"),
+            "unexpected report: {html}"
+        );
     }
 
     #[test]

--- a/lib/bencher_comment/src/lib.rs
+++ b/lib/bencher_comment/src/lib.rs
@@ -1160,7 +1160,10 @@ fn boundary_limits_map(
 mod tests {
     use bencher_json::{
         DateTime, JsonBranch, JsonHead, JsonProject, JsonReport, JsonReportCounts, JsonTestbed,
-        project::{Visibility, report::Adapter},
+        project::{
+            Visibility,
+            report::{Adapter, JsonReportResults},
+        },
     };
     use ordered_float::OrderedFloat;
 
@@ -1224,15 +1227,104 @@ mod tests {
     }
 
     fn report_comment(visibility: Visibility) -> ReportComment {
+        report_comment_for(json_report(visibility))
+    }
+
+    fn report_comment_for(report: JsonReport) -> ReportComment {
         ReportComment::new(
             CONSOLE_URL.parse().unwrap(),
-            json_report(visibility),
+            report,
             SubAdapter {
                 build_time: false,
                 file_size: false,
             },
             "cli".to_owned(),
         )
+    }
+
+    /// One iteration with two measures of one benchmark: one that named a point
+    /// estimate and one that named only a percentile.
+    ///
+    /// Built from JSON rather than constructors because the absent deprecated
+    /// `metric` is the wire shape under test.
+    fn value_less_results() -> JsonReportResults {
+        let date = serde_json::to_value(DateTime::TEST).unwrap();
+        let measure = |uuid: &str, name: &str, slug: &str| {
+            serde_json::json!({
+                "uuid": uuid,
+                "project": "11111111-1111-1111-1111-111111111111",
+                "name": name,
+                "slug": slug,
+                "units": "nanoseconds (ns)",
+                "created": date,
+                "modified": date,
+                "archived": null,
+            })
+        };
+        serde_json::from_value(serde_json::json!([[{
+            "iteration": 0,
+            "benchmark": {
+                "uuid": "66666666-6666-6666-6666-666666666666",
+                "project": "11111111-1111-1111-1111-111111111111",
+                "name": "bench",
+                "slug": "bench",
+                "created": date,
+                "modified": date,
+                "archived": null,
+            },
+            "parameter": {
+                "uuid": "77777777-7777-7777-7777-777777777777",
+                "parameters": {},
+            },
+            "measures": [
+                {
+                    "measure": measure("88888888-8888-8888-8888-888888888888", "Latency", "latency"),
+                    "metrics": [{
+                        "uuid": "99999999-9999-9999-9999-999999999999",
+                        "name": "value",
+                        "value": 1.0,
+                        "boundaries": [],
+                    }],
+                    "metric": {
+                        "uuid": "99999999-9999-9999-9999-999999999999",
+                        "value": 1.0,
+                        "lower_value": null,
+                        "upper_value": null,
+                    },
+                    "threshold": null,
+                    "boundary": null,
+                },
+                {
+                    "measure": measure("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "Throughput", "throughput"),
+                    "metrics": [{
+                        "uuid": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                        "name": "p99",
+                        "value": 2.0,
+                        "boundaries": [],
+                    }],
+                    "threshold": null,
+                    "boundary": null,
+                },
+            ],
+        }]]))
+        .unwrap()
+    }
+
+    // A measure that named no point estimate reaches the comment with the deprecated
+    // `metric` absent. There is nothing for the table to draw, so it has no column,
+    // and rendering neither panics nor invents a zero.
+    #[test]
+    fn report_table_value_less_measure() {
+        let mut report = json_report(Visibility::Public);
+        report.results = Some(value_less_results());
+
+        let html = report_comment_for(report).html(false, None);
+        assert!(html.contains(">Latency</a></th>"), "unexpected table: {html}");
+        assert!(
+            !html.contains("Throughput"),
+            "the measure that named no point estimate has no column: {html}"
+        );
+        assert!(html.contains(">bench</a></td>"), "unexpected table: {html}");
     }
 
     #[test]

--- a/lib/bencher_comment/src/lib.rs
+++ b/lib/bencher_comment/src/lib.rs
@@ -518,6 +518,9 @@ impl ReportComment {
                     .measures
                     .iter()
                     .find(|m| m.measure.slug == measure.slug);
+                // The point estimate. A measure that named no `value` has nothing for
+                // this table to draw, so its cells stay empty.
+                let point_estimate = report_measure.and_then(|m| m.metric.as_ref());
                 let alert = self.find_alert(result, measure);
 
                 if let Some(report_measure) = report_measure {
@@ -531,10 +534,10 @@ impl ReportComment {
                 } else {
                     html.push_str(EMPTY_CELL);
                 }
-                if let Some(report_measure) = report_measure {
+                if let (Some(report_measure), Some(metric)) = (report_measure, point_estimate) {
                     value_cell(
                         html,
-                        report_measure.metric.value,
+                        metric.value,
                         report_measure.boundary.and_then(|b| b.baseline),
                         factor,
                         &units_symbol,
@@ -544,10 +547,10 @@ impl ReportComment {
                     html.push_str(EMPTY_CELL);
                 }
                 if boundary_limits.lower {
-                    if let Some(report_measure) = report_measure {
+                    if let (Some(report_measure), Some(metric)) = (report_measure, point_estimate) {
                         lower_limit_cell(
                             html,
-                            report_measure.metric.value,
+                            metric.value,
                             report_measure.boundary.and_then(|b| b.lower_limit),
                             factor,
                             &units_symbol,
@@ -558,10 +561,10 @@ impl ReportComment {
                     }
                 }
                 if boundary_limits.upper {
-                    if let Some(report_measure) = report_measure {
+                    if let (Some(report_measure), Some(metric)) = (report_measure, point_estimate) {
                         upper_limit_cell(
                             html,
-                            report_measure.metric.value,
+                            metric.value,
                             report_measure.boundary.and_then(|b| b.upper_limit),
                             factor,
                             &units_symbol,
@@ -1119,9 +1122,13 @@ fn boundary_limits_map(
     let mut map = BTreeMap::new();
     for result in iteration {
         for report_measure in &result.measures {
+            // A measure that named no point estimate has no row in this table.
+            let Some(metric) = report_measure.metric.as_ref() else {
+                continue;
+            };
             let measure = Measure::from(report_measure.measure.clone());
             let min = {
-                let mut min = report_measure.metric.value;
+                let mut min = metric.value;
                 if let Some(lower_limit) = report_measure.boundary.and_then(|b| b.lower_limit) {
                     min = min.min(lower_limit);
                 }

--- a/lib/bencher_comment/src/lib.rs
+++ b/lib/bencher_comment/src/lib.rs
@@ -518,9 +518,6 @@ impl ReportComment {
                     .measures
                     .iter()
                     .find(|m| m.measure.slug == measure.slug);
-                // The point estimate. A measure that named no `value` has nothing for
-                // this table to draw, so its cells stay empty.
-                let point_estimate = report_measure.and_then(|m| m.metric.as_ref());
                 let alert = self.find_alert(result, measure);
 
                 if let Some(report_measure) = report_measure {
@@ -534,10 +531,10 @@ impl ReportComment {
                 } else {
                     html.push_str(EMPTY_CELL);
                 }
-                if let (Some(report_measure), Some(metric)) = (report_measure, point_estimate) {
+                if let Some(report_measure) = report_measure {
                     value_cell(
                         html,
-                        metric.value,
+                        report_measure.metric.value,
                         report_measure.boundary.and_then(|b| b.baseline),
                         factor,
                         &units_symbol,
@@ -547,10 +544,10 @@ impl ReportComment {
                     html.push_str(EMPTY_CELL);
                 }
                 if boundary_limits.lower {
-                    if let (Some(report_measure), Some(metric)) = (report_measure, point_estimate) {
+                    if let Some(report_measure) = report_measure {
                         lower_limit_cell(
                             html,
-                            metric.value,
+                            report_measure.metric.value,
                             report_measure.boundary.and_then(|b| b.lower_limit),
                             factor,
                             &units_symbol,
@@ -561,10 +558,10 @@ impl ReportComment {
                     }
                 }
                 if boundary_limits.upper {
-                    if let (Some(report_measure), Some(metric)) = (report_measure, point_estimate) {
+                    if let Some(report_measure) = report_measure {
                         upper_limit_cell(
                             html,
-                            metric.value,
+                            report_measure.metric.value,
                             report_measure.boundary.and_then(|b| b.upper_limit),
                             factor,
                             &units_symbol,
@@ -1122,13 +1119,9 @@ fn boundary_limits_map(
     let mut map = BTreeMap::new();
     for result in iteration {
         for report_measure in &result.measures {
-            // A measure that named no point estimate has no row in this table.
-            let Some(metric) = report_measure.metric.as_ref() else {
-                continue;
-            };
             let measure = Measure::from(report_measure.measure.clone());
             let min = {
-                let mut min = metric.value;
+                let mut min = report_measure.metric.value;
                 if let Some(lower_limit) = report_measure.boundary.and_then(|b| b.lower_limit) {
                     min = min.min(lower_limit);
                 }

--- a/lib/bencher_json/src/project/parameter/mod.rs
+++ b/lib/bencher_json/src/project/parameter/mod.rs
@@ -112,6 +112,43 @@ impl<'de> Deserialize<'de> for JsonParameters {
     }
 }
 
+/// An object whose every value is a JSON scalar: string, number, or bool.
+///
+/// Written out by hand because the serialized form is a map with a custom key
+/// order and a hand written value enum, neither of which derives.
+#[cfg(feature = "schema")]
+impl JsonSchema for JsonParameters {
+    fn schema_name() -> String {
+        "JsonParameters".to_owned()
+    }
+
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        use schemars::schema::{InstanceType, ObjectValidation, SchemaObject, SubschemaValidation};
+
+        let scalar = SchemaObject {
+            subschemas: Some(Box::new(SubschemaValidation {
+                any_of: Some(vec![
+                    String::json_schema(generator),
+                    f64::json_schema(generator),
+                    bool::json_schema(generator),
+                ]),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
+        SchemaObject {
+            instance_type: Some(InstanceType::Object.into()),
+            object: Some(Box::new(ObjectValidation {
+                additional_properties: Some(Box::new(scalar.into())),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }
+        .into()
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum ParametersError {
     #[error("Failed to parse benchmark parameters: {0}")]

--- a/lib/bencher_json/src/project/report.rs
+++ b/lib/bencher_json/src/project/report.rs
@@ -454,10 +454,9 @@ pub struct JsonReportMeasure {
 
     /// Deprecated. Reconstructed from the `value` row and its
     /// `lower_value`/`upper_value` siblings. Retained for compatibility with older
-    /// clients and removed in a future release. Absent only when the measure named
-    /// no `value` at all, which nothing before named metric values could produce.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub metric: Option<JsonMetric>,
+    /// clients and removed in a future release. A measure that named no `value` at
+    /// all has nothing to reconstruct it from, so it is left out of the results.
+    pub metric: JsonMetric,
     /// Deprecated. The threshold that gated the `value` row, if any.
     pub threshold: Option<JsonThresholdModel>,
     /// Deprecated. The boundary computed for the `value` row, if any.

--- a/lib/bencher_json/src/project/report.rs
+++ b/lib/bencher_json/src/project/report.rs
@@ -454,9 +454,12 @@ pub struct JsonReportMeasure {
 
     /// Deprecated. Reconstructed from the `value` row and its
     /// `lower_value`/`upper_value` siblings. Retained for compatibility with older
-    /// clients and removed in a future release. A measure that named no `value` at
-    /// all has nothing to reconstruct it from, so it is left out of the results.
-    pub metric: JsonMetric,
+    /// clients and removed in a future release.
+    ///
+    /// Absent when the measure carries no `value` name, which BMF v1 permits. Never
+    /// absent for anything an older client could produce.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metric: Option<JsonMetric>,
     /// Deprecated. The threshold that gated the `value` row, if any.
     pub threshold: Option<JsonThresholdModel>,
     /// Deprecated. The boundary computed for the `value` row, if any.

--- a/lib/bencher_json/src/project/report.rs
+++ b/lib/bencher_json/src/project/report.rs
@@ -505,7 +505,8 @@ pub struct JsonReportCounts {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct JsonReportIterationCounts {
-    /// The number of benchmarks in this iteration.
+    /// The number of results in this iteration: one per grid point, so one per
+    /// benchmark for a benchmark that reports a single parameter set.
     pub benchmarks: u32,
     /// The number of distinct measures in this iteration.
     pub measures: u32,

--- a/lib/bencher_json/src/project/report.rs
+++ b/lib/bencher_json/src/project/report.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, fmt};
 
-use bencher_valid::{DateTime, DateTimeMillis, GitHash, Model};
+use bencher_valid::{DateTime, DateTimeMillis, GitHash, MetricName, Model};
+use ordered_float::OrderedFloat;
 #[cfg(feature = "schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -9,7 +10,8 @@ use serde::{Deserialize, Serialize};
 use crate::runner::job::JobUuid;
 use crate::{
     BranchNameId, JsonAlert, JsonBenchmark, JsonBoundary, JsonBranch, JsonMeasure, JsonMetric,
-    JsonProject, JsonPubUser, JsonTestbed, MeasureNameId, TestbedNameId,
+    JsonParameters, JsonProject, JsonPubUser, JsonTestbed, MeasureNameId, MetricUuid,
+    ParameterUuid, TestbedNameId,
     urlencoded::{UrlEncodedError, from_urlencoded, to_urlencoded},
 };
 
@@ -418,13 +420,28 @@ pub type JsonReportResults = Vec<JsonReportIteration>;
 #[typeshare::typeshare]
 pub type JsonReportIteration = Vec<JsonReportResult>;
 
+/// One grid point of one benchmark, in one iteration of a report.
+///
+/// A benchmark reports as many results per iteration as it has parameter sets, so
+/// the parameter set is what tells two results of one benchmark apart.
 #[typeshare::typeshare]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct JsonReportResult {
     pub iteration: Iteration,
     pub benchmark: JsonBenchmark,
+    /// The parameter set this result ran with.
+    pub parameter: JsonReportParameter,
     pub measures: Vec<JsonReportMeasure>,
+}
+
+/// The parameter set a report result ran with.
+#[typeshare::typeshare]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub struct JsonReportParameter {
+    pub uuid: ParameterUuid,
+    pub parameters: JsonParameters,
 }
 
 #[typeshare::typeshare]
@@ -432,9 +449,41 @@ pub struct JsonReportResult {
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct JsonReportMeasure {
     pub measure: JsonMeasure,
-    pub metric: JsonMetric,
+    /// Every named scalar ingested for this measure, in a stable order.
+    pub metrics: Vec<JsonReportMetric>,
+
+    /// Deprecated. Reconstructed from the `value` row and its
+    /// `lower_value`/`upper_value` siblings. Retained for compatibility with older
+    /// clients and removed in a future release. Absent only when the measure named
+    /// no `value` at all, which nothing before named metric values could produce.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metric: Option<JsonMetric>,
+    /// Deprecated. The threshold that gated the `value` row, if any.
     pub threshold: Option<JsonThresholdModel>,
+    /// Deprecated. The boundary computed for the `value` row, if any.
     pub boundary: Option<JsonBoundary>,
+}
+
+/// Exactly one `metric` row: one named scalar.
+#[typeshare::typeshare]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub struct JsonReportMetric {
+    pub uuid: MetricUuid,
+    pub name: MetricName,
+    pub value: OrderedFloat<f64>,
+    /// Every threshold that gated this named scalar, with the boundary it produced.
+    /// Length 0 or 1 until threshold predicates ship.
+    pub boundaries: Vec<JsonReportBoundary>,
+}
+
+/// A threshold and the boundary it produced, together.
+#[typeshare::typeshare]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub struct JsonReportBoundary {
+    pub threshold: JsonThresholdModel,
+    pub boundary: JsonBoundary,
 }
 
 #[typeshare::typeshare]

--- a/lib/bencher_schema/migrations/2026-08-17-120000_series_last_seen_parameter/down.sql
+++ b/lib/bencher_schema/migrations/2026-08-17-120000_series_last_seen_parameter/down.sql
@@ -1,0 +1,45 @@
+PRAGMA foreign_keys = off;
+-- series_last_seen
+CREATE TABLE down_series_last_seen (
+    organization_id INTEGER NOT NULL,
+    project_id INTEGER NOT NULL,
+    testbed_id INTEGER NOT NULL,
+    benchmark_id INTEGER NOT NULL,
+    measure_id INTEGER NOT NULL,
+    last_seen BIGINT NOT NULL,
+    PRIMARY KEY (testbed_id, benchmark_id, measure_id),
+    FOREIGN KEY (organization_id) REFERENCES organization (id) ON DELETE CASCADE,
+    FOREIGN KEY (project_id) REFERENCES project (id) ON DELETE CASCADE,
+    FOREIGN KEY (testbed_id) REFERENCES testbed (id) ON DELETE CASCADE,
+    FOREIGN KEY (benchmark_id) REFERENCES benchmark (id) ON DELETE CASCADE,
+    FOREIGN KEY (measure_id) REFERENCES measure (id) ON DELETE CASCADE
+);
+-- Grid points of one benchmark collapse back into one series, keeping the greatest
+-- `last_seen` of the rows that merge, which is what the pre-parameter cache held.
+INSERT INTO down_series_last_seen (
+        organization_id,
+        project_id,
+        testbed_id,
+        benchmark_id,
+        measure_id,
+        last_seen
+    )
+SELECT organization_id,
+    project_id,
+    testbed_id,
+    benchmark_id,
+    measure_id,
+    MAX(last_seen)
+FROM series_last_seen
+GROUP BY testbed_id,
+    benchmark_id,
+    measure_id;
+DROP TABLE series_last_seen;
+ALTER TABLE down_series_last_seen
+    RENAME TO series_last_seen;
+CREATE INDEX index_series_last_seen_org_last_seen
+    ON series_last_seen (organization_id, last_seen);
+CREATE INDEX index_series_last_seen_project ON series_last_seen (project_id);
+CREATE INDEX index_series_last_seen_benchmark ON series_last_seen (benchmark_id);
+CREATE INDEX index_series_last_seen_measure ON series_last_seen (measure_id);
+PRAGMA foreign_keys = on;

--- a/lib/bencher_schema/migrations/2026-08-17-120000_series_last_seen_parameter/up.sql
+++ b/lib/bencher_schema/migrations/2026-08-17-120000_series_last_seen_parameter/up.sql
@@ -1,0 +1,65 @@
+PRAGMA foreign_keys = off;
+-- series_last_seen
+-- A series is a distinct `(testbed, benchmark, parameter, measure)` now: each grid
+-- point of a benchmark has its own history and bills as its own series. A project
+-- whose grid points are currently flat benchmarks bills exactly what it billed
+-- before, since every one of its `report_benchmark` rows rides its benchmark's
+-- empty parameter set.
+--
+-- Named metric values are deliberately absent from the key: they collapse into
+-- their measure's series and are not billed.
+CREATE TABLE up_series_last_seen (
+    organization_id INTEGER NOT NULL,
+    project_id INTEGER NOT NULL,
+    testbed_id INTEGER NOT NULL,
+    benchmark_id INTEGER NOT NULL,
+    parameter_id INTEGER NOT NULL,
+    measure_id INTEGER NOT NULL,
+    last_seen BIGINT NOT NULL,
+    PRIMARY KEY (testbed_id, benchmark_id, parameter_id, measure_id),
+    FOREIGN KEY (organization_id) REFERENCES organization (id) ON DELETE CASCADE,
+    FOREIGN KEY (project_id) REFERENCES project (id) ON DELETE CASCADE,
+    FOREIGN KEY (testbed_id) REFERENCES testbed (id) ON DELETE CASCADE,
+    FOREIGN KEY (benchmark_id) REFERENCES benchmark (id) ON DELETE CASCADE,
+    FOREIGN KEY (parameter_id) REFERENCES parameter (id) ON DELETE CASCADE,
+    FOREIGN KEY (measure_id) REFERENCES measure (id) ON DELETE CASCADE
+);
+-- Every existing row is a series over flat benchmarks, so it maps to its
+-- benchmark's empty parameter set. The join is inner because every benchmark has
+-- one: it is born with it, and the parameter migration backfilled every benchmark
+-- that predates the birth invariant. `last_seen` carries over untouched, so no
+-- series is resurrected and none is lost.
+INSERT INTO up_series_last_seen (
+        organization_id,
+        project_id,
+        testbed_id,
+        benchmark_id,
+        parameter_id,
+        measure_id,
+        last_seen
+    )
+SELECT s.organization_id,
+    s.project_id,
+    s.testbed_id,
+    s.benchmark_id,
+    p.id,
+    s.measure_id,
+    s.last_seen
+FROM series_last_seen s
+    INNER JOIN parameter p ON (
+        p.benchmark_id = s.benchmark_id
+        AND p.parameters = jsonb('{}')
+    );
+DROP TABLE series_last_seen;
+ALTER TABLE up_series_last_seen
+    RENAME TO series_last_seen;
+CREATE INDEX index_series_last_seen_org_last_seen
+    ON series_last_seen (organization_id, last_seen);
+-- Index the remaining cascaded foreign keys so parent deletes do not full-scan this
+-- table. `testbed_id` is already the primary key's prefix and `organization_id` is
+-- covered by the billing index above.
+CREATE INDEX index_series_last_seen_project ON series_last_seen (project_id);
+CREATE INDEX index_series_last_seen_benchmark ON series_last_seen (benchmark_id);
+CREATE INDEX index_series_last_seen_parameter ON series_last_seen (parameter_id);
+CREATE INDEX index_series_last_seen_measure ON series_last_seen (measure_id);
+PRAGMA foreign_keys = on;

--- a/lib/bencher_schema/migrations/2026-08-17-120000_series_last_seen_parameter/up.sql
+++ b/lib/bencher_schema/migrations/2026-08-17-120000_series_last_seen_parameter/up.sql
@@ -25,10 +25,14 @@ CREATE TABLE up_series_last_seen (
     FOREIGN KEY (measure_id) REFERENCES measure (id) ON DELETE CASCADE
 );
 -- Every existing row is a series over flat benchmarks, so it maps to its
--- benchmark's empty parameter set. The join is inner because every benchmark has
--- one: it is born with it, and the parameter migration backfilled every benchmark
--- that predates the birth invariant. `last_seen` carries over untouched, so no
+-- benchmark's empty parameter set. `last_seen` carries over untouched, so no
 -- series is resurrected and none is lost.
+--
+-- The join is a `LEFT JOIN` so that a `series_last_seen` row whose benchmark has
+-- no empty parameter set trips the `NOT NULL` on `parameter_id` and fails the
+-- migration. Every benchmark is born with one, and the parameter migration
+-- backfilled every benchmark that predates that invariant, so this cannot fire on
+-- valid data; an `INNER JOIN` would drop such a row silently instead.
 INSERT INTO up_series_last_seen (
         organization_id,
         project_id,
@@ -46,7 +50,7 @@ SELECT s.organization_id,
     s.measure_id,
     s.last_seen
 FROM series_last_seen s
-    INNER JOIN parameter p ON (
+    LEFT JOIN parameter p ON (
         p.benchmark_id = s.benchmark_id
         AND p.parameters = jsonb('{}')
     );

--- a/lib/bencher_schema/src/context/rate_limiting/mod.rs
+++ b/lib/bencher_schema/src/context/rate_limiting/mod.rs
@@ -232,6 +232,17 @@ impl RateLimiting {
         }
     }
 
+    /// Every in-memory limiter wide open, with the database-backed creation limits
+    /// set. Exercising a creation ceiling otherwise means throttling the requests
+    /// that reach it.
+    pub fn max_with_creation_limits(unclaimed_limit: u32, claimed_limit: u32) -> Self {
+        Self {
+            unclaimed_limit,
+            claimed_limit,
+            ..Self::max()
+        }
+    }
+
     pub fn prune(&self) {
         self.public.prune();
         self.user.prune();

--- a/lib/bencher_schema/src/model/project/metric.rs
+++ b/lib/bencher_schema/src/model/project/metric.rs
@@ -1,4 +1,4 @@
-use bencher_json::{JsonNewMetric, MetricName, MetricUuid};
+use bencher_json::{MetricName, MetricUuid};
 #[cfg(feature = "plus")]
 use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 use dropshot::HttpError;
@@ -92,46 +92,12 @@ pub struct InsertMetric {
 }
 
 impl InsertMetric {
-    /// The point estimate, which every metric has.
-    pub fn value(
-        report_benchmark_id: ReportBenchmarkId,
-        measure_id: MeasureId,
-        metric: JsonNewMetric,
-    ) -> Self {
-        Self::new(
-            report_benchmark_id,
-            measure_id,
-            MetricName::value(),
-            metric.value.into(),
-        )
-    }
-
-    /// The bounds, which a metric has zero, one, or two of.
+    /// One named scalar.
     ///
-    /// `lower_value` and `upper_value` are ordinary named rows: the metric triple
-    /// is a convention over three names, not a shape the table knows about.
-    pub fn bounds(
-        report_benchmark_id: ReportBenchmarkId,
-        measure_id: MeasureId,
-        metric: JsonNewMetric,
-    ) -> Vec<Self> {
-        let JsonNewMetric {
-            value: _,
-            lower_value,
-            upper_value,
-        } = metric;
-        [
-            (MetricName::lower_value(), lower_value),
-            (MetricName::upper_value(), upper_value),
-        ]
-        .into_iter()
-        .filter_map(|(name, bound)| {
-            bound.map(|bound| Self::new(report_benchmark_id, measure_id, name, bound.into()))
-        })
-        .collect()
-    }
-
-    fn new(
+    /// `value`, `lower_value`, and `upper_value` are ordinary named rows: the
+    /// metric triple is a convention over three names, not a shape the table
+    /// knows about.
+    pub fn named(
         report_benchmark_id: ReportBenchmarkId,
         measure_id: MeasureId,
         name: MetricName,

--- a/lib/bencher_schema/src/model/project/parameter.rs
+++ b/lib/bencher_schema/src/model/project/parameter.rs
@@ -1,12 +1,20 @@
-use bencher_json::{DateTime, JsonParameters, ParameterUuid};
-use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
+use bencher_json::{DateTime, JsonParameters, ParameterUuid, project::report::JsonReportParameter};
+use diesel::{
+    ExpressionMethods as _, OptionalExtension as _, QueryDsl as _, RunQueryDsl as _,
+    SelectableHelper as _,
+};
 use dropshot::HttpError;
 
 use crate::{
-    context::DbConnection,
-    error::issue_error,
-    macros::fn_get::{fn_from_uuid, fn_get, fn_get_id, fn_get_uuid},
+    auth_conn,
+    context::{ApiContext, DbConnection},
+    error::{issue_error, resource_conflict_err},
+    macros::{
+        fn_get::{fn_from_uuid, fn_get, fn_get_id, fn_get_uuid},
+        sql::last_insert_rowid,
+    },
     schema::{self, parameter as parameter_table},
+    write_conn, write_transaction,
 };
 
 use super::benchmark::{BenchmarkId, QueryBenchmark};
@@ -64,6 +72,121 @@ impl QueryParameter {
                 issue_error(&message, &message, e)
             })
     }
+
+    /// Resolve a reported parameter set to its row, creating it if it is new.
+    ///
+    /// The empty parameter set is never created here: every benchmark is born with
+    /// one, so its absence is data corruption rather than a row to mint. Every
+    /// other set is created on first sight by its canonical form, and
+    /// `UNIQUE (benchmark_id, parameters)` is what makes that idempotent under
+    /// concurrent reports.
+    ///
+    /// Mirrors [`QueryBenchmark::get_or_create`]: a resolved set that is archived is
+    /// unarchived, because a grid point that reports again is a live grid point.
+    ///
+    /// Called from report ingest's read phase, so the write transaction it opens
+    /// never nests inside the ingest write transaction.
+    pub async fn get_or_create(
+        context: &ApiContext,
+        benchmark_id: BenchmarkId,
+        parameters: &JsonParameters,
+    ) -> Result<ParameterId, HttpError> {
+        let query_parameter = Self::get_or_create_inner(context, benchmark_id, parameters).await?;
+
+        if query_parameter.archived.is_some() {
+            let update_parameter = UpdateParameter::unarchive();
+            diesel::update(
+                schema::parameter::table.filter(schema::parameter::id.eq(query_parameter.id)),
+            )
+            .set(&update_parameter)
+            .execute(write_conn!(context))
+            .map_err(resource_conflict_err!(Parameter, &query_parameter))?;
+        }
+
+        Ok(query_parameter.id)
+    }
+
+    async fn get_or_create_inner(
+        context: &ApiContext,
+        benchmark_id: BenchmarkId,
+        parameters: &JsonParameters,
+    ) -> Result<Self, HttpError> {
+        if let Some(query_parameter) =
+            Self::from_parameters(auth_conn!(context), benchmark_id, parameters)?
+        {
+            return Ok(query_parameter);
+        }
+
+        if parameters.is_empty() {
+            let message =
+                format!("Benchmark ({benchmark_id}) has no empty parameter set to report to");
+            return Err(issue_error(
+                "Failed to find the empty parameter set",
+                &message,
+                diesel::result::Error::NotFound,
+            ));
+        }
+
+        match Self::create(context, benchmark_id, parameters).await {
+            Ok(query_parameter) => Ok(query_parameter),
+            Err(e) if crate::error::is_conflict(&e) => {
+                // Another concurrent report created this parameter set.
+                Self::from_parameters(auth_conn!(context), benchmark_id, parameters)?.ok_or(e)
+            },
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn create(
+        context: &ApiContext,
+        benchmark_id: BenchmarkId,
+        parameters: &JsonParameters,
+    ) -> Result<Self, HttpError> {
+        let insert_parameter =
+            InsertParameter::new(benchmark_id, parameters.clone(), DateTime::now());
+
+        write_transaction!(context, |conn| {
+            diesel::insert_into(schema::parameter::table)
+                .values(&insert_parameter)
+                .execute(conn)?;
+            diesel::select(last_insert_rowid()).get_result::<ParameterId>(conn)
+        })
+        .map_err(resource_conflict_err!(Parameter, &insert_parameter))
+        .map(|id| insert_parameter.into_query(id))
+    }
+
+    fn from_parameters(
+        conn: &mut DbConnection,
+        benchmark_id: BenchmarkId,
+        parameters: &JsonParameters,
+    ) -> Result<Option<Self>, HttpError> {
+        schema::parameter::table
+            .filter(schema::parameter::benchmark_id.eq(benchmark_id))
+            .filter(schema::parameter::parameters.eq(parameters))
+            .select(Self::as_select())
+            .first(conn)
+            .optional()
+            .map_err(|e| {
+                let message = format!(
+                    "Failed to query parameter set ({parameters}) for benchmark ({benchmark_id})"
+                );
+                issue_error(&message, &message, e)
+            })
+    }
+
+    /// The parameter set as a report result names it.
+    pub fn into_report_json(self) -> JsonReportParameter {
+        let Self {
+            id: _,
+            uuid,
+            benchmark_id: _,
+            parameters,
+            created: _,
+            modified: _,
+            archived: _,
+        } = self;
+        JsonReportParameter { uuid, parameters }
+    }
 }
 
 #[derive(Debug, diesel::Insertable)]
@@ -83,10 +206,15 @@ impl InsertParameter {
     /// The timestamp is the benchmark's own creation timestamp:
     /// the parameter set is created in the same transaction as its benchmark.
     pub fn empty_set(benchmark_id: BenchmarkId, timestamp: DateTime) -> Self {
+        Self::new(benchmark_id, JsonParameters::default(), timestamp)
+    }
+
+    /// A parameter set as a report first named it, already canonical.
+    pub fn new(benchmark_id: BenchmarkId, parameters: JsonParameters, timestamp: DateTime) -> Self {
         Self {
             uuid: ParameterUuid::new(),
             benchmark_id,
-            parameters: JsonParameters::default(),
+            parameters,
             created: timestamp,
             modified: timestamp,
             archived: None,
@@ -120,6 +248,17 @@ pub struct UpdateParameter {
     pub parameters: Option<JsonParameters>,
     pub modified: DateTime,
     pub archived: Option<Option<DateTime>>,
+}
+
+impl UpdateParameter {
+    /// A grid point that reports again is a live grid point.
+    fn unarchive() -> Self {
+        Self {
+            parameters: None,
+            modified: DateTime::now(),
+            archived: Some(None),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/lib/bencher_schema/src/model/project/parameter.rs
+++ b/lib/bencher_schema/src/model/project/parameter.rs
@@ -17,7 +17,10 @@ use crate::{
     write_conn, write_transaction,
 };
 
-use super::benchmark::{BenchmarkId, QueryBenchmark};
+use super::{
+    ProjectId, QueryProject,
+    benchmark::{BenchmarkId, QueryBenchmark},
+};
 
 crate::macros::typed_id::typed_id!(ParameterId);
 
@@ -88,10 +91,12 @@ impl QueryParameter {
     /// never nests inside the ingest write transaction.
     pub async fn get_or_create(
         context: &ApiContext,
+        project_id: ProjectId,
         benchmark_id: BenchmarkId,
         parameters: &JsonParameters,
     ) -> Result<ParameterId, HttpError> {
-        let query_parameter = Self::get_or_create_inner(context, benchmark_id, parameters).await?;
+        let query_parameter =
+            Self::get_or_create_inner(context, project_id, benchmark_id, parameters).await?;
 
         if query_parameter.archived.is_some() {
             let update_parameter = UpdateParameter::unarchive();
@@ -108,6 +113,7 @@ impl QueryParameter {
 
     async fn get_or_create_inner(
         context: &ApiContext,
+        project_id: ProjectId,
         benchmark_id: BenchmarkId,
         parameters: &JsonParameters,
     ) -> Result<Self, HttpError> {
@@ -127,7 +133,7 @@ impl QueryParameter {
             ));
         }
 
-        match Self::create(context, benchmark_id, parameters).await {
+        match Self::create(context, project_id, benchmark_id, parameters).await {
             Ok(query_parameter) => Ok(query_parameter),
             Err(e) if crate::error::is_conflict(&e) => {
                 // Another concurrent report created this parameter set.
@@ -139,9 +145,15 @@ impl QueryParameter {
 
     async fn create(
         context: &ApiContext,
+        project_id: ProjectId,
         benchmark_id: BenchmarkId,
         parameters: &JsonParameters,
     ) -> Result<Self, HttpError> {
+        #[cfg(feature = "plus")]
+        InsertParameter::rate_limit(context, project_id).await?;
+        #[cfg(not(feature = "plus"))]
+        let _ = project_id;
+
         let insert_parameter =
             InsertParameter::new(benchmark_id, parameters.clone(), DateTime::now());
 
@@ -201,6 +213,65 @@ pub struct InsertParameter {
 }
 
 impl InsertParameter {
+    /// The per project ceiling on minting parameter sets.
+    ///
+    /// Hand written rather than [`fn_rate_limit`](crate::macros::rate_limit) because
+    /// `parameter` has no `project_id` of its own: a parameter set belongs to its
+    /// benchmark, and the benchmark is what belongs to the project. The window is
+    /// counted through that join instead, with the same limits and the same error as
+    /// every other resource a report mints.
+    ///
+    /// The count includes the empty parameter set each benchmark is born with, which
+    /// makes the ceiling slightly conservative for a project creating benchmarks and
+    /// grid points in the same window. That is the safe direction, and it costs a
+    /// project nothing that the benchmark ceiling was not already going to cost it.
+    #[cfg(feature = "plus")]
+    async fn rate_limit(context: &ApiContext, project_id: ProjectId) -> Result<(), HttpError> {
+        use crate::error::BencherResource;
+
+        let query_project = QueryProject::get(auth_conn!(context), project_id)?;
+        let query_organization = query_project.organization(auth_conn!(context))?;
+        let is_claimed = query_organization.is_claimed(auth_conn!(context))?;
+
+        let (start_time, end_time) = context.rate_limiting.window();
+        let window_usage: u32 = schema::parameter::table
+            .inner_join(schema::benchmark::table)
+            .filter(schema::benchmark::project_id.eq(project_id))
+            .filter(schema::parameter::created.ge(start_time))
+            .filter(schema::parameter::created.le(end_time))
+            .count()
+            .get_result::<i64>(auth_conn!(context))
+            .map_err(crate::error::resource_not_found_err!(
+                Parameter,
+                (project_id, start_time, end_time)
+            ))?
+            .try_into()
+            .map_err(|e| {
+                issue_error(
+                    "Failed to count creation",
+                    &format!(
+                        "Failed to count parameter creation for project ({project_id}) between {start_time} and {end_time}."
+                    ),
+                    e,
+                )
+            })?;
+
+        context.rate_limiting.check_claimable_limit(
+            is_claimed,
+            window_usage,
+            |rate_limit| crate::context::RateLimitingError::UnclaimedProject {
+                project: query_project.clone(),
+                resource: BencherResource::Parameter,
+                rate_limit,
+            },
+            |rate_limit| crate::context::RateLimitingError::ClaimedProject {
+                project: query_project.clone(),
+                resource: BencherResource::Parameter,
+                rate_limit,
+            },
+        )
+    }
+
     /// The empty parameter set that every benchmark is born with.
     ///
     /// The timestamp is the benchmark's own creation timestamp:

--- a/lib/bencher_schema/src/model/project/report/mod.rs
+++ b/lib/bencher_schema/src/model/project/report/mod.rs
@@ -1649,10 +1649,10 @@ mod tests {
         );
     }
 
-    /// A measure that named no `value` is left out of the report results, because the
-    /// deprecated metric triple it would carry cannot be reconstructed. The counts
-    /// have to leave it out too, or the same report is one measure from the endpoint
-    /// that loads its results and two from the endpoint that counts them.
+    /// A measure that named no `value` is returned like any other, carrying its named
+    /// values and no deprecated metric triple. The counts have to count it too, or the
+    /// same report is two measures from the endpoint that loads its results and one
+    /// from the endpoint that counts them.
     #[test]
     fn full_and_collapsed_counts_agree_for_a_value_less_measure() {
         let mut conn = setup_test_db();
@@ -1720,14 +1720,23 @@ mod tests {
             .into_json(&log, &mut conn, ReportMode::Collapsed)
             .expect("Failed to convert collapsed report");
 
+        let returned = full
+            .results
+            .as_ref()
+            .and_then(|results| results.first())
+            .and_then(|iteration| iteration.first())
+            .map(|result| result.measures.len())
+            .expect("the full report carries its results");
+        assert_eq!(returned, 2, "both measures are returned");
+
         assert_eq!(full.counts, collapsed.counts);
         assert_eq!(
             full.counts.results,
             vec![JsonReportIterationCounts {
                 benchmarks: 1,
-                measures: 1,
+                measures: 2,
             }],
-            "the measure that named no point estimate is counted by neither"
+            "the measure that named no point estimate is counted by both"
         );
     }
 

--- a/lib/bencher_schema/src/model/project/report/mod.rs
+++ b/lib/bencher_schema/src/model/project/report/mod.rs
@@ -939,7 +939,11 @@ fn get_report_counts(
             // A `report_benchmark` row is exactly one grid point, which is exactly one
             // result, so this agrees with the count taken from the loaded results.
             diesel::dsl::count(schema::report_benchmark::id).aggregate_distinct(),
-            diesel::dsl::count(schema::metric::measure_id).aggregate_distinct(),
+            // Only measures that named a `value`, because a measure that named none
+            // is left out of the results and has to be left out of their count too.
+            diesel::dsl::count(schema::metric::measure_id)
+                .aggregate_distinct()
+                .aggregate_filter(schema::metric::name.eq(MetricName::value())),
         ))
         .load::<(Iteration, i64, i64)>(conn)
         .map_err(resource_not_found_err!(ReportBenchmark, report_id))?

--- a/lib/bencher_schema/src/model/project/report/mod.rs
+++ b/lib/bencher_schema/src/model/project/report/mod.rs
@@ -3,14 +3,14 @@ use bencher_json::runner::job::{JobUuid, JsonNewRunJob};
 use std::collections::HashSet;
 
 use bencher_json::{
-    DateTime, JsonMetric, JsonNewReport, JsonReport, JsonReportAlertsCounts, JsonReportCounts,
-    JsonReportIterationCounts, MetricName, ReportUuid,
+    DateTime, JsonBenchmark, JsonMeasure, JsonMetric, JsonNewReport, JsonReport,
+    JsonReportAlertsCounts, JsonReportCounts, JsonReportIterationCounts, MetricName, ReportUuid,
     project::{
         alert::AlertStatus,
         report::{
             Adapter, Iteration, JsonReportAlerts, JsonReportBoundary, JsonReportMeasure,
-            JsonReportMetric, JsonReportResult, JsonReportResults, JsonReportSettings,
-            ReportIdempotencyKey,
+            JsonReportMetric, JsonReportParameter, JsonReportResult, JsonReportResults,
+            JsonReportSettings, ReportIdempotencyKey,
         },
     },
 };
@@ -736,8 +736,8 @@ fn into_report_results_json(
     project: &QueryProject,
     results: Vec<ResultsQuery>,
 ) -> JsonReportResults {
-    let mut report_results: JsonReportResults = Vec::new();
-    let mut report_iteration: Vec<JsonReportResult> = Vec::new();
+    let mut report_results: Vec<Vec<PendingResult>> = Vec::new();
+    let mut report_iteration: Vec<PendingResult> = Vec::new();
     let mut prev_iteration: Option<Iteration> = None;
 
     for (iteration, query_benchmark, query_parameter, query_measure, query_metric, gate) in results
@@ -760,7 +760,7 @@ fn into_report_results_json(
         if report_iteration.last().is_none_or(|result| {
             result.benchmark.uuid != benchmark_uuid || result.parameter.uuid != parameter_uuid
         }) {
-            report_iteration.push(JsonReportResult {
+            report_iteration.push(PendingResult {
                 iteration,
                 benchmark: query_benchmark.into_json_for_project(project),
                 parameter: query_parameter.into_report_json(),
@@ -778,12 +778,9 @@ fn into_report_results_json(
             .last()
             .is_none_or(|report_measure| report_measure.measure.uuid != measure_uuid)
         {
-            report_result.measures.push(JsonReportMeasure {
+            report_result.measures.push(PendingMeasure {
                 measure: query_measure.into_json_for_project(project),
                 metrics: Vec::new(),
-                metric: None,
-                threshold: None,
-                boundary: None,
             });
         }
         let Some(report_measure) = report_result.measures.last_mut() else {
@@ -831,44 +828,97 @@ fn into_report_results_json(
         report_results.push(report_iteration);
     }
 
-    for report_result in report_results.iter_mut().flatten() {
-        for report_measure in &mut report_result.measures {
-            set_deprecated(report_measure);
-        }
-    }
+    let report_results: JsonReportResults = report_results
+        .into_iter()
+        .map(|report_iteration| {
+            report_iteration
+                .into_iter()
+                .map(PendingResult::into_json)
+                .collect()
+        })
+        .collect();
 
     slog::trace!(log, "Report results: {report_results:#?}");
 
     report_results
 }
 
-/// Fill in the deprecated `metric`, `threshold`, and `boundary` fields.
+/// One report result under construction.
 ///
-/// The metric triple is the `value` row and its `lower_value`/`upper_value`
-/// siblings, and the threshold and boundary are the ones that gated the `value` row.
-/// A measure that named no `value` has none of them, which is a shape only a BMF v1
-/// payload can produce.
-fn set_deprecated(report_measure: &mut JsonReportMeasure) {
-    let named = |name: &MetricName| -> Option<&JsonReportMetric> {
-        report_measure
-            .metrics
-            .iter()
-            .find(|report_metric| report_metric.name == *name)
-    };
+/// The deprecated metric triple is reconstructed from a measure's `value` row and its
+/// siblings, which are only all in hand once the last row of that measure has been
+/// read, so the results are built in this shape and finished at the end.
+struct PendingResult {
+    iteration: Iteration,
+    benchmark: JsonBenchmark,
+    parameter: JsonReportParameter,
+    measures: Vec<PendingMeasure>,
+}
 
-    let Some(value) = named(&MetricName::value()) else {
-        return;
-    };
-    report_measure.metric = Some(JsonMetric {
-        uuid: value.uuid,
-        value: value.value,
-        lower_value: named(&MetricName::lower_value()).map(|metric| metric.value),
-        upper_value: named(&MetricName::upper_value()).map(|metric| metric.value),
-    });
+/// One measure of a report result under construction.
+struct PendingMeasure {
+    measure: JsonMeasure,
+    metrics: Vec<JsonReportMetric>,
+}
 
-    if let Some(gate) = value.boundaries.first() {
-        report_measure.threshold = Some(gate.threshold.clone());
-        report_measure.boundary = Some(gate.boundary);
+impl PendingResult {
+    fn into_json(self) -> JsonReportResult {
+        let Self {
+            iteration,
+            benchmark,
+            parameter,
+            measures,
+        } = self;
+        JsonReportResult {
+            iteration,
+            benchmark,
+            parameter,
+            measures: measures
+                .into_iter()
+                .filter_map(PendingMeasure::into_json)
+                .collect(),
+        }
+    }
+}
+
+impl PendingMeasure {
+    /// Fill in the deprecated `metric`, `threshold`, and `boundary` fields.
+    ///
+    /// The metric triple is the `value` row and its `lower_value`/`upper_value`
+    /// siblings, and the threshold and boundary are the ones that gated the `value`
+    /// row.
+    ///
+    /// A measure that named no `value` at all has no triple to reconstruct, and the
+    /// deprecated `metric` is a required field that an older client's generated
+    /// deserializer insists on, so such a measure is left out of the results rather
+    /// than sent without it. Only a BMF v1 payload can report that shape, and its
+    /// named values are stored either way.
+    fn into_json(self) -> Option<JsonReportMeasure> {
+        let Self { measure, metrics } = self;
+
+        let named = |name: &MetricName| -> Option<&JsonReportMetric> {
+            metrics
+                .iter()
+                .find(|report_metric| report_metric.name == *name)
+        };
+        let value = named(&MetricName::value())?;
+        let metric = JsonMetric {
+            uuid: value.uuid,
+            value: value.value,
+            lower_value: named(&MetricName::lower_value()).map(|metric| metric.value),
+            upper_value: named(&MetricName::upper_value()).map(|metric| metric.value),
+        };
+        let (threshold, boundary) = value.boundaries.first().map_or((None, None), |gate| {
+            (Some(gate.threshold.clone()), Some(gate.boundary))
+        });
+
+        Some(JsonReportMeasure {
+            measure,
+            metrics,
+            metric,
+            threshold,
+            boundary,
+        })
     }
 }
 

--- a/lib/bencher_schema/src/model/project/report/mod.rs
+++ b/lib/bencher_schema/src/model/project/report/mod.rs
@@ -875,7 +875,7 @@ impl PendingResult {
             parameter,
             measures: measures
                 .into_iter()
-                .filter_map(PendingMeasure::into_json)
+                .map(PendingMeasure::into_json)
                 .collect(),
         }
     }
@@ -888,12 +888,10 @@ impl PendingMeasure {
     /// siblings, and the threshold and boundary are the ones that gated the `value`
     /// row.
     ///
-    /// A measure that named no `value` at all has no triple to reconstruct, and the
-    /// deprecated `metric` is a required field that an older client's generated
-    /// deserializer insists on, so such a measure is left out of the results rather
-    /// than sent without it. Only a BMF v1 payload can report that shape, and its
-    /// named values are stored either way.
-    fn into_json(self) -> Option<JsonReportMeasure> {
+    /// A measure that named no `value` at all has no triple to reconstruct, so all
+    /// three deprecated fields are absent. Only a BMF v1 payload can report that
+    /// shape, and its named values are stored, billed, and returned like any other.
+    fn into_json(self) -> JsonReportMeasure {
         let Self { measure, metrics } = self;
 
         let named = |name: &MetricName| -> Option<&JsonReportMetric> {
@@ -901,24 +899,26 @@ impl PendingMeasure {
                 .iter()
                 .find(|report_metric| report_metric.name == *name)
         };
-        let value = named(&MetricName::value())?;
-        let metric = JsonMetric {
+        let value = named(&MetricName::value());
+        let metric = value.map(|value| JsonMetric {
             uuid: value.uuid,
             value: value.value,
             lower_value: named(&MetricName::lower_value()).map(|metric| metric.value),
             upper_value: named(&MetricName::upper_value()).map(|metric| metric.value),
-        };
-        let (threshold, boundary) = value.boundaries.first().map_or((None, None), |gate| {
-            (Some(gate.threshold.clone()), Some(gate.boundary))
         });
+        let (threshold, boundary) = value
+            .and_then(|value| value.boundaries.first())
+            .map_or((None, None), |gate| {
+                (Some(gate.threshold.clone()), Some(gate.boundary))
+            });
 
-        Some(JsonReportMeasure {
+        JsonReportMeasure {
             measure,
             metrics,
             metric,
             threshold,
             boundary,
-        })
+        }
     }
 }
 
@@ -939,11 +939,9 @@ fn get_report_counts(
             // A `report_benchmark` row is exactly one grid point, which is exactly one
             // result, so this agrees with the count taken from the loaded results.
             diesel::dsl::count(schema::report_benchmark::id).aggregate_distinct(),
-            // Only measures that named a `value`, because a measure that named none
-            // is left out of the results and has to be left out of their count too.
-            diesel::dsl::count(schema::metric::measure_id)
-                .aggregate_distinct()
-                .aggregate_filter(schema::metric::name.eq(MetricName::value())),
+            // Every measure with a metric row, whatever it named, because that is
+            // exactly the set the loaded results carry.
+            diesel::dsl::count(schema::metric::measure_id).aggregate_distinct(),
         ))
         .load::<(Iteration, i64, i64)>(conn)
         .map_err(resource_not_found_err!(ReportBenchmark, report_id))?

--- a/lib/bencher_schema/src/model/project/report/mod.rs
+++ b/lib/bencher_schema/src/model/project/report/mod.rs
@@ -1195,8 +1195,8 @@ mod tests {
         test_util::{
             BranchIds, create_alert, create_base_entities, create_benchmark, create_boundary,
             create_branch_with_head, create_head_version, create_measure, create_metric,
-            create_model, create_report, create_report_benchmark, create_testbed, create_threshold,
-            create_version, setup_test_db,
+            create_model, create_named_metric, create_report, create_report_benchmark,
+            create_testbed, create_threshold, create_version, setup_test_db,
         },
     };
 
@@ -1642,6 +1642,88 @@ mod tests {
                 total: 1,
                 active: 1,
             }
+        );
+    }
+
+    /// A measure that named no `value` is left out of the report results, because the
+    /// deprecated metric triple it would carry cannot be reconstructed. The counts
+    /// have to leave it out too, or the same report is one measure from the endpoint
+    /// that loads its results and two from the endpoint that counts them.
+    #[test]
+    fn full_and_collapsed_counts_agree_for_a_value_less_measure() {
+        let mut conn = setup_test_db();
+        let fixture = create_report_fixture(&mut conn);
+
+        let latency = create_measure(
+            &mut conn,
+            fixture.project_id,
+            "00000000-0000-0000-0000-000000000060",
+            "Latency",
+            "latency",
+        );
+        let throughput = create_measure(
+            &mut conn,
+            fixture.project_id,
+            "00000000-0000-0000-0000-000000000061",
+            "Throughput",
+            "throughput",
+        );
+        let benchmark_id = create_benchmark(
+            &mut conn,
+            fixture.project_id,
+            "00000000-0000-0000-0000-000000000070",
+            "bench",
+            "bench",
+        );
+        let report_benchmark = create_report_benchmark(
+            &mut conn,
+            "00000000-0000-0000-0000-000000000080",
+            fixture.report_id,
+            0,
+            benchmark_id,
+        );
+
+        // One measure with a point estimate, one measure with only a percentile.
+        create_metric(
+            &mut conn,
+            "00000000-0000-0000-0000-000000000090",
+            report_benchmark,
+            latency,
+            1.0,
+        );
+        create_named_metric(
+            &mut conn,
+            "00000000-0000-0000-0000-000000000091",
+            report_benchmark,
+            throughput,
+            &"p99".parse().expect("Failed to parse the metric name"),
+            2.0,
+        );
+
+        let log = test_logger();
+        let load_report = |conn: &mut DbConnection| -> QueryReport {
+            schema::report::table
+                .filter(schema::report::id.eq(fixture.report_id))
+                .select(QueryReport::as_select())
+                .first(conn)
+                .expect("Failed to load report")
+        };
+
+        let full = load_report(&mut conn)
+            .into_json(&log, &mut conn, ReportMode::Full)
+            .expect("Failed to convert full report");
+        let collapsed = load_report(&mut conn)
+            .into_json(&log, &mut conn, ReportMode::Collapsed)
+            .expect("Failed to convert collapsed report");
+
+        assert_eq!(full.counts, collapsed.counts);
+        assert_eq!(
+            full.counts.results,
+            vec![JsonReportIterationCounts {
+                benchmarks: 1,
+                measures: 1,
+            }],
+            "the measure that named no point estimate is counted by neither"
         );
     }
 

--- a/lib/bencher_schema/src/model/project/report/mod.rs
+++ b/lib/bencher_schema/src/model/project/report/mod.rs
@@ -3,13 +3,14 @@ use bencher_json::runner::job::{JobUuid, JsonNewRunJob};
 use std::collections::HashSet;
 
 use bencher_json::{
-    DateTime, JsonNewReport, JsonReport, JsonReportAlertsCounts, JsonReportCounts,
-    JsonReportIterationCounts, ReportUuid,
+    DateTime, JsonMetric, JsonNewReport, JsonReport, JsonReportAlertsCounts, JsonReportCounts,
+    JsonReportIterationCounts, MetricName, ReportUuid,
     project::{
         alert::AlertStatus,
         report::{
-            Adapter, Iteration, JsonReportAlerts, JsonReportMeasure, JsonReportResult,
-            JsonReportResults, JsonReportSettings, ReportIdempotencyKey,
+            Adapter, Iteration, JsonReportAlerts, JsonReportBoundary, JsonReportMeasure,
+            JsonReportMetric, JsonReportResult, JsonReportResults, JsonReportSettings,
+            ReportIdempotencyKey,
         },
     },
 };
@@ -46,6 +47,8 @@ use crate::{
             benchmark::QueryBenchmark,
             branch::version::{InsertVersion, QueryVersion},
             measure::QueryMeasure,
+            metric::QueryMetric,
+            parameter::QueryParameter,
             testbed::{QueryTestbed, ResolvedTestbed, TestbedId},
             threshold::{QueryThreshold, alert::QueryAlert, model::QueryModel},
         },
@@ -640,12 +643,15 @@ pub enum ReportMode {
     Collapsed,
 }
 
+/// One row of the results query: one named scalar of one measure at one grid point,
+/// with the threshold and boundary that gated it, if any.
 type ResultsQuery = (
     Iteration,
     QueryBenchmark,
+    QueryParameter,
     QueryMeasure,
-    QueryMetricBoundary,
-    Option<(QueryThreshold, QueryModel)>,
+    QueryMetric,
+    Option<(QueryThreshold, QueryModel, QueryBoundary)>,
 );
 
 fn get_report_results(
@@ -657,20 +663,32 @@ fn get_report_results(
     schema::report_benchmark::table
     .filter(schema::report_benchmark::report_id.eq(report_id))
     .inner_join(schema::benchmark::table)
-    .inner_join(view::metric_boundary::table
+    .inner_join(schema::parameter::table)
+    .inner_join(schema::metric::table
         .inner_join(schema::measure::table)
-        // There may or may not be a boundary for any given metric
-        .left_join(schema::threshold::table)
-        .left_join(schema::model::table)
+        // There may or may not be a boundary for any given named value
+        .left_join(schema::boundary::table
+            .inner_join(schema::threshold::table)
+            .inner_join(schema::model::table)
+        )
     )
-    // It is important to order by the iteration first in order to make sure they are grouped together below
-    // Then ordering by benchmark and finally measure name makes sure that the benchmarks are in the same order for each iteration
-    .order((schema::report_benchmark::iteration, schema::benchmark::name, schema::measure::name))
+    // It is important to order by the iteration first in order to make sure they are grouped together below.
+    // The parameter set comes between the benchmark and the measure because a grid point is what a result is:
+    // two parameter sets of one benchmark are two results, not one result with the measures interleaved.
+    // Finally the metric name orders a measure's named values, so the response order is stable.
+    .order((
+        schema::report_benchmark::iteration,
+        schema::benchmark::name,
+        schema::parameter::id,
+        schema::measure::name,
+        schema::metric::name,
+    ))
     .select((
         schema::report_benchmark::iteration,
         QueryBenchmark::as_select(),
+        QueryParameter::as_select(),
         QueryMeasure::as_select(),
-        QueryMetricBoundary::as_select(),
+        QueryMetric::as_select(),
         (
             (
                 schema::threshold::id,
@@ -695,7 +713,17 @@ fn get_report_results(
                 schema::model::upper_boundary,
                 schema::model::created,
                 schema::model::replaced,
-            )
+            ),
+            (
+                schema::boundary::id,
+                schema::boundary::uuid,
+                schema::boundary::metric_id,
+                schema::boundary::threshold_id,
+                schema::boundary::model_id,
+                schema::boundary::baseline,
+                schema::boundary::lower_limit,
+                schema::boundary::upper_limit,
+            ),
         ).nullable(),
     ))
     .load::<ResultsQuery>(conn)
@@ -708,77 +736,140 @@ fn into_report_results_json(
     project: &QueryProject,
     results: Vec<ResultsQuery>,
 ) -> JsonReportResults {
-    let mut report_results = Vec::new();
-    let mut report_iteration = Vec::new();
-    let mut prev_iteration = None;
-    let mut report_result: Option<JsonReportResult> = None;
-    for (iteration, query_benchmark, query_measure, query_metric_boundary, threshold_model) in
-        results
+    let mut report_results: JsonReportResults = Vec::new();
+    let mut report_iteration: Vec<JsonReportResult> = Vec::new();
+    let mut prev_iteration: Option<Iteration> = None;
+
+    for (iteration, query_benchmark, query_parameter, query_measure, query_metric, gate) in results
     {
-        // If onto a new iteration, then add the result to the report iteration list.
-        // Then add the report iteration list to the report results list.
+        // If onto a new iteration, then add the report iteration list to the report results list.
         if let Some(prev_iteration) = prev_iteration.take()
             && iteration != prev_iteration
         {
             slog::trace!(log, "Iteration {prev_iteration} => {iteration}");
-            if let Some(result) = report_result.take() {
-                report_iteration.push(result);
-            }
             if !report_iteration.is_empty() {
                 report_results.push(std::mem::take(&mut report_iteration));
             }
         }
         prev_iteration = Some(iteration);
 
-        // If there is a current report result, make sure that the benchmark is the same.
-        // Otherwise, add it to the report iteration list.
-        if let Some(result) = report_result.take() {
-            if query_benchmark.uuid == result.benchmark.uuid {
-                report_result = Some(result);
-            } else {
-                slog::trace!(
-                    log,
-                    "Benchmark {} => {}",
-                    result.benchmark.uuid,
-                    query_benchmark.uuid,
-                );
-                report_iteration.push(result);
-            }
-        }
-
-        let (json_metric, query_boundary) = query_metric_boundary.split();
-        let report_measure = JsonReportMeasure {
-            measure: query_measure.into_json_for_project(project),
-            metric: json_metric,
-            threshold: threshold_model.map(|(threshold, model)| {
-                threshold.into_threshold_model_json_for_project(project, model)
-            }),
-            boundary: query_boundary.map(QueryBoundary::into_json),
-        };
-
-        // If there is a current report result, add the report measure to it.
-        // Otherwise, create a new report result and add the report measure to it.
-        if let Some(result) = report_result.as_mut() {
-            result.measures.push(report_measure);
-        } else {
-            report_result = Some(JsonReportResult {
+        // A result is one grid point: the same benchmark on a different parameter set
+        // is a different result.
+        let benchmark_uuid = query_benchmark.uuid;
+        let parameter_uuid = query_parameter.uuid;
+        if report_iteration.last().is_none_or(|result| {
+            result.benchmark.uuid != benchmark_uuid || result.parameter.uuid != parameter_uuid
+        }) {
+            report_iteration.push(JsonReportResult {
                 iteration,
                 benchmark: query_benchmark.into_json_for_project(project),
-                measures: vec![report_measure],
+                parameter: query_parameter.into_report_json(),
+                measures: Vec::new(),
+            });
+        }
+        let Some(report_result) = report_iteration.last_mut() else {
+            debug_assert!(false, "the report result was just pushed");
+            continue;
+        };
+
+        let measure_uuid = query_measure.uuid;
+        if report_result
+            .measures
+            .last()
+            .is_none_or(|report_measure| report_measure.measure.uuid != measure_uuid)
+        {
+            report_result.measures.push(JsonReportMeasure {
+                measure: query_measure.into_json_for_project(project),
+                metrics: Vec::new(),
+                metric: None,
+                threshold: None,
+                boundary: None,
+            });
+        }
+        let Some(report_measure) = report_result.measures.last_mut() else {
+            debug_assert!(false, "the report measure was just pushed");
+            continue;
+        };
+
+        // One named value repeats across rows only when several thresholds gated it.
+        let QueryMetric {
+            id: _,
+            uuid,
+            report_benchmark_id: _,
+            measure_id: _,
+            name,
+            value,
+        } = query_metric;
+        if report_measure
+            .metrics
+            .last()
+            .is_none_or(|report_metric| report_metric.uuid != uuid)
+        {
+            report_measure.metrics.push(JsonReportMetric {
+                uuid,
+                name,
+                value: value.into(),
+                boundaries: Vec::new(),
+            });
+        }
+        let Some(report_metric) = report_measure.metrics.last_mut() else {
+            debug_assert!(false, "the report metric was just pushed");
+            continue;
+        };
+
+        if let Some((query_threshold, query_model, query_boundary)) = gate {
+            report_metric.boundaries.push(JsonReportBoundary {
+                threshold: query_threshold
+                    .into_threshold_model_json_for_project(project, query_model),
+                boundary: query_boundary.into_json(),
             });
         }
     }
 
     // Save from the last iteration
-    if let Some(result) = report_result.take() {
-        report_iteration.push(result);
-    }
     if !report_iteration.is_empty() {
         report_results.push(report_iteration);
     }
+
+    for report_result in report_results.iter_mut().flatten() {
+        for report_measure in &mut report_result.measures {
+            set_deprecated(report_measure);
+        }
+    }
+
     slog::trace!(log, "Report results: {report_results:#?}");
 
     report_results
+}
+
+/// Fill in the deprecated `metric`, `threshold`, and `boundary` fields.
+///
+/// The metric triple is the `value` row and its `lower_value`/`upper_value`
+/// siblings, and the threshold and boundary are the ones that gated the `value` row.
+/// A measure that named no `value` has none of them, which is a shape only a BMF v1
+/// payload can produce.
+fn set_deprecated(report_measure: &mut JsonReportMeasure) {
+    let named = |name: &MetricName| -> Option<&JsonReportMetric> {
+        report_measure
+            .metrics
+            .iter()
+            .find(|report_metric| report_metric.name == *name)
+    };
+
+    let Some(value) = named(&MetricName::value()) else {
+        return;
+    };
+    report_measure.metric = Some(JsonMetric {
+        uuid: value.uuid,
+        value: value.value,
+        lower_value: named(&MetricName::lower_value()).map(|metric| metric.value),
+        upper_value: named(&MetricName::upper_value()).map(|metric| metric.value),
+    });
+
+    if let Some(gate) = value.boundaries.first() {
+        report_measure.threshold = Some(gate.threshold.clone());
+        report_measure.boundary = Some(gate.boundary);
+    }
 }
 
 /// Compute the report counts with aggregate queries, without loading the results or alerts.
@@ -795,7 +886,9 @@ fn get_report_counts(
         .order(schema::report_benchmark::iteration.asc())
         .select((
             schema::report_benchmark::iteration,
-            diesel::dsl::count(schema::report_benchmark::benchmark_id).aggregate_distinct(),
+            // A `report_benchmark` row is exactly one grid point, which is exactly one
+            // result, so this agrees with the count taken from the loaded results.
+            diesel::dsl::count(schema::report_benchmark::id).aggregate_distinct(),
             diesel::dsl::count(schema::metric::measure_id).aggregate_distinct(),
         ))
         .load::<(Iteration, i64, i64)>(conn)

--- a/lib/bencher_schema/src/model/project/report/results/detector/data.rs
+++ b/lib/bencher_schema/src/model/project/report/results/detector/data.rs
@@ -6,7 +6,10 @@ use dropshot::HttpError;
 use slog::{Logger, warn};
 
 use crate::{
-    context::DbConnection, error::not_found_error, model::project::benchmark::BenchmarkId, schema,
+    context::DbConnection,
+    error::not_found_error,
+    model::project::{benchmark::BenchmarkId, parameter::ParameterId},
+    schema,
 };
 
 pub fn metrics_data(
@@ -14,6 +17,7 @@ pub fn metrics_data(
     conn: &mut DbConnection,
     detector: &super::Detector,
     benchmark_id: BenchmarkId,
+    parameter_id: ParameterId,
 ) -> Result<MetricsData, HttpError> {
     let mut query = schema::metric::table
         .inner_join(
@@ -35,6 +39,9 @@ pub fn metrics_data(
         .filter(schema::head::id.eq(detector.head_id))
         .filter(schema::testbed::id.eq(detector.testbed_id))
         .filter(schema::benchmark::id.eq(benchmark_id))
+        // A parameter set is a grid point with its own series history, so the
+        // sample is the one grid point's, never the benchmark's grid pooled.
+        .filter(schema::report_benchmark::parameter_id.eq(parameter_id))
         .filter(schema::metric::measure_id.eq(detector.measure_id))
         // Detection has only ever gated the `value` scalar, and the sample it is
         // gated against is the point estimates alone. A measure's bounds are named

--- a/lib/bencher_schema/src/model/project/report/results/detector/mod.rs
+++ b/lib/bencher_schema/src/model/project/report/results/detector/mod.rs
@@ -11,6 +11,7 @@ use crate::{
         benchmark::BenchmarkId,
         branch::{BranchId, head::HeadId},
         measure::MeasureId,
+        parameter::ParameterId,
         testbed::TestbedId,
     },
 };
@@ -60,11 +61,12 @@ impl Detector {
         log: &Logger,
         conn: &mut DbConnection,
         benchmark_id: BenchmarkId,
+        parameter_id: ParameterId,
         metric_value: f64,
         ignore_benchmark: bool,
     ) -> Result<PreparedDetection, HttpError> {
-        // Query the historical population/sample data for the benchmark
-        let metrics_data = metrics_data(log, conn, self, benchmark_id)?;
+        // Query the historical population/sample data for the grid point
+        let metrics_data = metrics_data(log, conn, self, benchmark_id, parameter_id)?;
 
         // Check to see if the metric has a boundary check for the given threshold model.
         let boundary = MetricsBoundary::new(

--- a/lib/bencher_schema/src/model/project/report/results/mod.rs
+++ b/lib/bencher_schema/src/model/project/report/results/mod.rs
@@ -2,7 +2,10 @@ use std::collections::HashMap;
 
 use bencher_adapter::{
     AdapterResults, AdapterResultsArray, Settings as AdapterSettings,
-    results::adapter_metrics::{AdapterMetrics, NamedMap},
+    results::{
+        adapter_metrics::{AdapterMetrics, NamedMap},
+        adapter_results::BmfVersion,
+    },
 };
 use bencher_json::{
     BenchmarkName, BenchmarkNameId, JsonParameters, MeasureNameId, MetricName, Slug,
@@ -201,6 +204,16 @@ impl ReportResults {
         // Resolve IDs (get_or_create), fetch historical data, compute boundaries.
         let mut prepared_grid_points = Vec::with_capacity(results.inner.len());
 
+        // A BMF v1 entry that names no measure measured nothing, so it writes
+        // nothing: its parameter set is never resolved, it writes no
+        // `report_benchmark` row, it touches no series, and it bills nothing.
+        //
+        // Gated on the version because BMF v0 says the same thing with `{"bench": {}}`
+        // and has always written that row on the benchmark's empty parameter set.
+        // Skipping every empty grid point would move a v0 payload, which this whole
+        // layer promises not to do.
+        let skip_empty_grid_points = results.version == BmfVersion::V1;
+
         for (benchmark, entries) in results.inner {
             // If benchmark name is ignored then strip the special suffix before querying
             let (benchmark, ignore_benchmark) = strip_ignore_suffix(benchmark);
@@ -208,6 +221,9 @@ impl ReportResults {
             // A benchmark reports as many grid points as it has parameter sets, and
             // each is its own `report_benchmark` row with its own series history.
             for (parameters, metrics) in entries {
+                if skip_empty_grid_points && metrics.inner.is_empty() {
+                    continue;
+                }
                 let prepared = self
                     .prepare_grid_point(
                         log,

--- a/lib/bencher_schema/src/model/project/report/results/mod.rs
+++ b/lib/bencher_schema/src/model/project/report/results/mod.rs
@@ -389,7 +389,9 @@ impl ReportResults {
         Ok(if let Some(id) = self.parameter_cache.get(&key) {
             *id
         } else {
-            let parameter_id = QueryParameter::get_or_create(context, benchmark_id, &key.1).await?;
+            let parameter_id =
+                QueryParameter::get_or_create(context, self.project_id, benchmark_id, &key.1)
+                    .await?;
             self.parameter_cache.insert(key, parameter_id);
             parameter_id
         })

--- a/lib/bencher_schema/src/model/project/report/results/mod.rs
+++ b/lib/bencher_schema/src/model/project/report/results/mod.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
 use bencher_adapter::{
-    AdapterResultsArray, FoldableResults, Settings as AdapterSettings,
-    results::foldable::FoldableMetrics,
+    AdapterResults, AdapterResultsArray, Settings as AdapterSettings,
+    results::adapter_metrics::{AdapterMetrics, NamedMap},
 };
 use bencher_json::{
-    BenchmarkName, BenchmarkNameId, JsonNewMetric, MeasureNameId, Slug,
+    BenchmarkName, BenchmarkNameId, JsonParameters, MeasureNameId, MetricName, Slug,
     project::report::{Adapter, Iteration, JsonReportSettings},
 };
 use diesel::RunQueryDsl as _;
@@ -18,7 +18,10 @@ use bencher_json::DateTime;
 use crate::macros::sql::last_insert_rowid;
 use crate::model::spec::SpecId;
 #[cfg(feature = "plus")]
-use crate::model::{organization::OrganizationId, project::series::upsert_series_last_seen};
+use crate::model::{
+    organization::OrganizationId,
+    project::series::{SeriesKey, upsert_series_last_seen},
+};
 use crate::{
     auth_conn,
     context::ApiContext,
@@ -56,7 +59,7 @@ pub struct ReportResults {
     #[cfg(feature = "plus")]
     pub series_cache: SeriesCacheContext,
     pub benchmark_cache: HashMap<BenchmarkNameId, BenchmarkId>,
-    pub parameter_cache: HashMap<BenchmarkId, ParameterId>,
+    pub parameter_cache: HashMap<(BenchmarkId, JsonParameters), ParameterId>,
     pub measure_cache: HashMap<MeasureNameId, MeasureId>,
     pub detector_cache: HashMap<MeasureId, Option<Detector>>,
 }
@@ -125,17 +128,39 @@ impl ReportResults {
                 ))
             })?;
 
-        // BMF v1 parses but does not yet reach the database, so it is refused
-        // here rather than silently ingested as if it had no parameter sets.
-        // The parameter aware ingest path replaces this in a following release.
-        let results_array = results_array.foldable().map_err(|_unfoldable| {
-            bad_request_error(
-                "Benchmark parameters and named metric values are not yet supported on ingest.",
-            )
-        })?;
+        // The per measure cap has already truncated, so this is the report of it and
+        // never an ingest error: a harness that names more statistics than the cap
+        // allows still gets its report. The adapter counts; the log line and the
+        // counter are here because this is where the providers are in scope.
+        let dropped_names = results_array.dropped_names();
+        let report_id = self.report_id;
+        if dropped_names > 0 {
+            slog::warn!(
+                log,
+                "Dropped {dropped_names} named metric value(s) over the per measure cap for report ({report_id})"
+            );
+            #[cfg(feature = "otel")]
+            bencher_otel::ApiMeter::increment_by(
+                bencher_otel::ApiCounter::MetricNamesDropped,
+                u64::try_from(dropped_names).unwrap_or(u64::MAX),
+            );
+        }
 
+        // Fold is a BMF v0 operation and nothing else: the mean of per iteration
+        // `p99` values is not the `p99` of the pooled sample. A v1 payload with fold
+        // requested warns and ingests unfolded, one `report_benchmark` row per
+        // iteration, because a harness upgrade must never turn a pipeline red.
         let results_array = if let Some(fold) = settings.fold {
-            vec![results_array.fold(fold)]
+            match results_array.foldable() {
+                Ok(foldable) => vec![foldable.fold(fold).into()],
+                Err(unfoldable) => {
+                    slog::warn!(
+                        log,
+                        "Ignoring the requested fold ({fold:?}) for report ({report_id}): fold is not supported for benchmark parameters or named metric values"
+                    );
+                    unfoldable.inner
+                },
+            }
         } else {
             results_array.inner
         };
@@ -169,24 +194,50 @@ impl ReportResults {
         log: &Logger,
         context: &ApiContext,
         iteration: Iteration,
-        results: FoldableResults,
+        results: AdapterResults,
         #[cfg(feature = "plus")] usage: &mut u32,
     ) -> Result<(), HttpError> {
         // Phase 1: Pre-compute all data using read connections.
         // Resolve IDs (get_or_create), fetch historical data, compute boundaries.
-        let mut prepared_benchmarks = Vec::with_capacity(results.inner.len());
+        let mut prepared_grid_points = Vec::with_capacity(results.inner.len());
 
-        for (benchmark, metrics) in results.inner {
-            let prepared = self
-                .prepare_benchmark(log, context, iteration, benchmark, metrics)
-                .await?;
-            prepared_benchmarks.push(prepared);
+        for (benchmark, entries) in results.inner {
+            // If benchmark name is ignored then strip the special suffix before querying
+            let (benchmark, ignore_benchmark) = strip_ignore_suffix(benchmark);
+            let benchmark_id = self.benchmark_id(context, benchmark).await?;
+            // A benchmark reports as many grid points as it has parameter sets, and
+            // each is its own `report_benchmark` row with its own series history.
+            for (parameters, metrics) in entries {
+                let prepared = self
+                    .prepare_grid_point(
+                        log,
+                        context,
+                        iteration,
+                        benchmark_id,
+                        ignore_benchmark,
+                        parameters,
+                        metrics,
+                    )
+                    .await?;
+                prepared_grid_points.push(prepared);
+            }
         }
 
-        // Compute metric count once before acquiring write lock
-        let iteration_metric_count: i32 = prepared_benchmarks
+        // Compute metric count once before acquiring write lock. Named values collapse
+        // into their measure's point estimate, so this counts exactly the rows
+        // `QueryMetric::usage` reads back: one per measure that named a `value`.
+        let iteration_metric_count: i32 = prepared_grid_points
             .iter()
-            .map(|p| i32::try_from(p.metrics.len()).unwrap_or(i32::MAX))
+            .map(|grid_point| {
+                i32::try_from(
+                    grid_point
+                        .measures
+                        .iter()
+                        .filter(|measure| measure.named.contains_key(&MetricName::value()))
+                        .count(),
+                )
+                .unwrap_or(i32::MAX)
+            })
             .fold(0i32, i32::saturating_add);
 
         // Phase 2: Write all data in a single transaction.
@@ -194,71 +245,33 @@ impl ReportResults {
         let write_start = context.clock.now();
 
         write_transaction!(context, |conn| {
-            // Series (testbed x benchmark x measure) seen in this iteration, upserted
-            // into the active-series cache in this same transaction so the cache cannot
-            // drift from the metrics it bills.
+            // Series (testbed x benchmark x parameter x measure) seen in this iteration,
+            // upserted into the active-series cache in this same transaction so the
+            // cache cannot drift from the metrics it bills.
             #[cfg(feature = "plus")]
-            let mut series_keys: Vec<(BenchmarkId, MeasureId)> = Vec::new();
-            for prepared in prepared_benchmarks {
-                // Insert report_benchmark
-                diesel::insert_into(schema::report_benchmark::table)
-                    .values(&prepared.insert_report_benchmark)
-                    .execute(conn)?;
-                let report_benchmark_id: ReportBenchmarkId =
-                    diesel::select(last_insert_rowid()).get_result(conn)?;
+            let mut series_keys: Vec<SeriesKey> = Vec::new();
+            for prepared in prepared_grid_points {
+                // The series this grid point touches, taken before it is written out.
                 #[cfg(feature = "plus")]
-                let benchmark_id = prepared.insert_report_benchmark.benchmark_id;
-
-                // Insert all metrics for this benchmark
-                for prepared_metric in prepared.metrics {
-                    #[cfg(feature = "plus")]
-                    series_keys.push((benchmark_id, prepared_metric.measure_id));
-                    // The point estimate goes in first so that `last_insert_rowid`
-                    // still names the row a boundary attaches to. Detection has only
-                    // ever gated the `value` scalar.
-                    let insert_metric = InsertMetric::value(
-                        report_benchmark_id,
-                        prepared_metric.measure_id,
-                        prepared_metric.metric,
-                    );
-                    diesel::insert_into(schema::metric::table)
-                        .values(&insert_metric)
-                        .execute(conn)?;
-
-                    // If there's a prepared detection, write boundary + optional alert
-                    if let Some(prepared_detection) = prepared_metric.detection {
-                        let metric_id = diesel::select(last_insert_rowid()).get_result(conn)?;
-                        prepared_detection.write(conn, metric_id)?;
-                    }
-
-                    let insert_bounds = InsertMetric::bounds(
-                        report_benchmark_id,
-                        prepared_metric.measure_id,
-                        prepared_metric.metric,
-                    );
-                    if !insert_bounds.is_empty() {
-                        diesel::insert_into(schema::metric::table)
-                            .values(&insert_bounds)
-                            .execute(conn)?;
-                    }
-                }
+                let grid_point_series = prepared.series_keys(self.testbed_id);
+                write_grid_point(conn, prepared)?;
+                #[cfg(feature = "plus")]
+                series_keys.extend(grid_point_series);
             }
 
             // Upsert metric count summary (count computed before acquiring write lock)
             super::upsert_metric_count(conn, self.report_id, iteration_metric_count)?;
 
             // Refresh each seen series' last_seen to this report's creation time, in the
-            // same transaction as the metric inserts above. The (benchmark, measure) pairs
-            // are distinct within an iteration; repeats across iterations are idempotent.
+            // same transaction as the metric inserts above. The series keys are distinct
+            // within an iteration; repeats across iterations are idempotent.
             #[cfg(feature = "plus")]
-            for (benchmark_id, measure_id) in series_keys {
+            for series in series_keys {
                 upsert_series_last_seen(
                     conn,
                     self.series_cache.organization_id,
                     self.project_id,
-                    self.testbed_id,
-                    benchmark_id,
-                    measure_id,
+                    series,
                     self.series_cache.report_created,
                 )?;
             }
@@ -291,52 +304,61 @@ impl ReportResults {
         Ok(())
     }
 
-    /// Phase 1: Prepare all data for a single benchmark (reads + compute only).
-    async fn prepare_benchmark(
+    /// Phase 1: Prepare all data for a single grid point (reads + compute only).
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "a grid point is a benchmark, its parameter set, and its metrics"
+    )]
+    async fn prepare_grid_point(
         &mut self,
         log: &Logger,
         context: &ApiContext,
         iteration: Iteration,
-        benchmark: BenchmarkNameId,
-        metrics: FoldableMetrics,
-    ) -> Result<PreparedBenchmark, HttpError> {
-        // If benchmark name is ignored then strip the special suffix before querying
-        let (benchmark, ignore_benchmark) = strip_ignore_suffix(benchmark);
-        let benchmark_id = self.benchmark_id(context, benchmark).await?;
-        // Every result in this layer rides its benchmark's empty parameter set.
-        // Resolved here in Phase 1 so the Phase 2 write transaction stays read free.
-        let parameter_id = self.parameter_id(context, benchmark_id).await?;
+        benchmark_id: BenchmarkId,
+        ignore_benchmark: bool,
+        parameters: JsonParameters,
+        metrics: AdapterMetrics,
+    ) -> Result<PreparedGridPoint, HttpError> {
+        // Resolved here in Phase 1, alongside the benchmark and the measures, so the
+        // Phase 2 write transaction stays read free and never nests a transaction.
+        let parameter_id = self.parameter_id(context, benchmark_id, parameters).await?;
 
         let insert_report_benchmark =
             InsertReportBenchmark::from_json(self.report_id, iteration, benchmark_id, parameter_id);
 
-        let mut prepared_metrics = Vec::with_capacity(metrics.len());
-        for (measure_key, metric) in metrics {
+        let mut prepared_measures = Vec::with_capacity(metrics.inner.len());
+        for (measure_key, metric) in metrics.inner {
             let measure_id = self.measure_id(context, measure_key).await?;
+            let named = metric.inner;
 
-            // Pre-compute detection if a detector exists for this measure
-            let detection = if let Some(detector) = self.detector(context, measure_id).await? {
-                Some(detector.prepare_detection(
+            // A bare threshold gates the conventional `value` series, of every
+            // parameter set under its measure, and nothing else. That is exactly what
+            // a measure level threshold over flat benchmarks has always done, so no
+            // project's alert volume moves.
+            let value = named.get(&MetricName::value()).copied();
+            let detector = self.detector(context, measure_id).await?;
+            let detection = match (value, detector) {
+                (Some(value), Some(detector)) => Some(detector.prepare_detection(
                     log,
                     auth_conn!(context),
                     benchmark_id,
-                    metric.value.into(),
+                    parameter_id,
+                    value.into_inner(),
                     ignore_benchmark,
-                )?)
-            } else {
-                None
+                )?),
+                _ => None,
             };
 
-            prepared_metrics.push(PreparedMetric {
+            prepared_measures.push(PreparedMeasure {
                 measure_id,
-                metric,
+                named,
                 detection,
             });
         }
 
-        Ok(PreparedBenchmark {
+        Ok(PreparedGridPoint {
             insert_report_benchmark,
-            metrics: prepared_metrics,
+            measures: prepared_measures,
         })
     }
 
@@ -355,16 +377,20 @@ impl ReportResults {
         })
     }
 
+    /// The parameter set's row, keyed on both the benchmark and the set itself:
+    /// one benchmark has as many grid points as it has parameter sets.
     async fn parameter_id(
         &mut self,
         context: &ApiContext,
         benchmark_id: BenchmarkId,
+        parameters: JsonParameters,
     ) -> Result<ParameterId, HttpError> {
-        Ok(if let Some(id) = self.parameter_cache.get(&benchmark_id) {
+        let key = (benchmark_id, parameters);
+        Ok(if let Some(id) = self.parameter_cache.get(&key) {
             *id
         } else {
-            let parameter_id = QueryParameter::get_empty_set_id(auth_conn!(context), benchmark_id)?;
-            self.parameter_cache.insert(benchmark_id, parameter_id);
+            let parameter_id = QueryParameter::get_or_create(context, benchmark_id, &key.1).await?;
+            self.parameter_cache.insert(key, parameter_id);
             parameter_id
         })
     }
@@ -408,16 +434,100 @@ impl ReportResults {
     }
 }
 
-/// Pre-computed data for a single benchmark within a report iteration.
-struct PreparedBenchmark {
+/// Pre-computed data for a single grid point within a report iteration.
+struct PreparedGridPoint {
     insert_report_benchmark: InsertReportBenchmark,
-    metrics: Vec<PreparedMetric>,
+    measures: Vec<PreparedMeasure>,
 }
 
-/// Pre-computed data for a single metric within a benchmark.
-struct PreparedMetric {
+impl PreparedGridPoint {
+    /// The series this grid point bills: one per measure, however many names the
+    /// measure carried.
+    #[cfg(feature = "plus")]
+    fn series_keys(&self, testbed_id: TestbedId) -> Vec<SeriesKey> {
+        self.measures
+            .iter()
+            .map(|prepared_measure| SeriesKey {
+                testbed_id,
+                benchmark_id: self.insert_report_benchmark.benchmark_id,
+                parameter_id: self.insert_report_benchmark.parameter_id,
+                measure_id: prepared_measure.measure_id,
+            })
+            .collect()
+    }
+}
+
+/// Phase 2: write one grid point's `report_benchmark` row, every named metric row
+/// under it, and the boundary and alert its point estimate earned.
+///
+/// Runs inside the ingest write transaction and opens none of its own.
+fn write_grid_point(
+    conn: &mut crate::context::DbConnection,
+    prepared: PreparedGridPoint,
+) -> diesel::QueryResult<()> {
+    let PreparedGridPoint {
+        insert_report_benchmark,
+        measures,
+    } = prepared;
+
+    diesel::insert_into(schema::report_benchmark::table)
+        .values(&insert_report_benchmark)
+        .execute(conn)?;
+    let report_benchmark_id: ReportBenchmarkId =
+        diesel::select(last_insert_rowid()).get_result(conn)?;
+
+    for prepared_measure in measures {
+        let PreparedMeasure {
+            measure_id,
+            mut named,
+            detection,
+        } = prepared_measure;
+
+        // The point estimate goes in first so that `last_insert_rowid` still names
+        // the row a boundary attaches to. Detection has only ever gated the `value`
+        // scalar. A BMF v1 measure may name no `value` at all, in which case there
+        // is nothing to gate.
+        if let Some(value) = named.remove(&MetricName::value()) {
+            let insert_metric = InsertMetric::named(
+                report_benchmark_id,
+                measure_id,
+                MetricName::value(),
+                value.into_inner(),
+            );
+            diesel::insert_into(schema::metric::table)
+                .values(&insert_metric)
+                .execute(conn)?;
+
+            // If there's a prepared detection, write boundary + optional alert
+            if let Some(prepared_detection) = detection {
+                let metric_id = diesel::select(last_insert_rowid()).get_result(conn)?;
+                prepared_detection.write(conn, metric_id)?;
+            }
+        }
+
+        let insert_named = named
+            .into_iter()
+            .map(|(name, value)| {
+                InsertMetric::named(report_benchmark_id, measure_id, name, value.into_inner())
+            })
+            .collect::<Vec<_>>();
+        if !insert_named.is_empty() {
+            diesel::insert_into(schema::metric::table)
+                .values(&insert_named)
+                .execute(conn)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Pre-computed data for a single measure at one grid point.
+struct PreparedMeasure {
     measure_id: MeasureId,
-    metric: JsonNewMetric,
+    /// Every named scalar the measure reported, in lexicographic order.
+    named: NamedMap,
+    /// The detection prepared for the `value` scalar. `None` when no threshold
+    /// covers the measure, or when the measure named no point estimate.
     detection: Option<PreparedDetection>,
 }
 

--- a/lib/bencher_schema/src/model/project/series.rs
+++ b/lib/bencher_schema/src/model/project/series.rs
@@ -708,6 +708,106 @@ mod tests {
         );
     }
 
+    /// Revert every migration down to and including the series migration.
+    ///
+    /// Mirrors the parameter migration's own test: the series migration is the last
+    /// one today, but reverting by version rather than by count keeps the test correct
+    /// when it stops being last.
+    fn revert_to_series_migration(conn: &mut DbConnection) {
+        use diesel_migrations::MigrationHarness as _;
+
+        const SERIES_MIGRATION: &str = "20260817120000";
+
+        loop {
+            let version = conn
+                .revert_last_migration(crate::MIGRATIONS)
+                .expect("Failed to revert a migration");
+            if version.to_string() == SERIES_MIGRATION {
+                break;
+            }
+        }
+    }
+
+    // Upgrading carries every existing cache row over. The rows are seeded in the
+    // shape the old schema had, keyed on `(testbed, benchmark, measure)` with no
+    // parameter at all, and the empty parameter sets they have to land on are the ones
+    // Diesel minted rather than ones spelled with `jsonb('{}')` in SQL. That is the
+    // point of seeding this way: the backfill joins the two encodings together, so
+    // this is where they have to agree.
+    //
+    // A dropped row is not a visible failure in production. It silently zeroes an
+    // organization's active-series count for the current period until every series
+    // reports again, which is a billing read, not an error.
+    #[test]
+    fn migration_backfill_preserves_every_series_row() {
+        use diesel::connection::SimpleConnection as _;
+        use diesel_migrations::MigrationHarness as _;
+
+        let mut conn = setup_test_db();
+        let mut uuids = Uuids(1);
+        let org = make_org(&mut conn, &mut uuids);
+        let proj = make_proj(&mut conn, &mut uuids, org, Visibility::Public);
+        let testbed = make_testbed(&mut conn, &mut uuids, proj.project);
+        let first = make_benchmark(&mut conn, &mut uuids, proj.project);
+        let second = make_benchmark(&mut conn, &mut uuids, proj.project);
+        let measure = make_measure(&mut conn, &mut uuids, proj.project);
+
+        // Distinct `last_seen` values on two benchmarks, so neither a dropped row nor
+        // rows collapsing into one another can pass by accident.
+        let legacy = [(first, 1_000i64), (second, 2_000i64)];
+
+        // Foreign keys cannot be toggled inside a transaction, and Diesel runs each
+        // migration in one, so they are disabled around the revert and re-apply.
+        conn.batch_execute("PRAGMA foreign_keys = OFF")
+            .expect("Failed to disable foreign keys");
+        revert_to_series_migration(&mut conn);
+
+        for (benchmark, last_seen) in legacy {
+            conn.batch_execute(&format!(
+                "INSERT INTO series_last_seen (
+                    organization_id, project_id, testbed_id, benchmark_id, measure_id, last_seen
+                 ) VALUES ({org}, {project}, {testbed}, {benchmark}, {measure}, {last_seen});",
+                project = proj.project,
+            ))
+            .expect("Failed to seed a legacy series row");
+        }
+
+        conn.run_pending_migrations(crate::MIGRATIONS)
+            .expect("Failed to re-apply the series migration");
+        conn.batch_execute("PRAGMA foreign_keys = ON")
+            .expect("Failed to enable foreign keys");
+
+        let carried: Vec<(TestbedId, BenchmarkId, ParameterId, MeasureId, i64)> =
+            schema::series_last_seen::table
+                .order(schema::series_last_seen::benchmark_id.asc())
+                .select((
+                    schema::series_last_seen::testbed_id,
+                    schema::series_last_seen::benchmark_id,
+                    schema::series_last_seen::parameter_id,
+                    schema::series_last_seen::measure_id,
+                    schema::series_last_seen::last_seen,
+                ))
+                .load(&mut conn)
+                .expect("Failed to load the carried over series rows");
+
+        let expected: Vec<_> = legacy
+            .into_iter()
+            .map(|(benchmark, last_seen)| {
+                (
+                    testbed,
+                    benchmark,
+                    get_empty_parameter(&mut conn, benchmark),
+                    measure,
+                    last_seen,
+                )
+            })
+            .collect();
+        assert_eq!(
+            carried, expected,
+            "every legacy series row is carried onto its benchmark's empty parameter set, untouched"
+        );
+    }
+
     /// Ingest on the project's primary head.
     fn ingest(
         conn: &mut DbConnection,

--- a/lib/bencher_schema/src/model/project/series.rs
+++ b/lib/bencher_schema/src/model/project/series.rs
@@ -259,6 +259,7 @@ mod tests {
                 benchmark::BenchmarkId,
                 branch::{head::HeadId, version::VersionId},
                 measure::MeasureId,
+                parameter::ParameterId,
                 report::ReportId,
                 testbed::TestbedId,
             },
@@ -266,8 +267,9 @@ mod tests {
         schema,
         test_util::{
             archive_benchmark, archive_measure, archive_testbed, create_benchmark,
-            create_branch_with_head, create_measure, create_report_benchmark, create_testbed,
-            create_version, setup_test_db,
+            create_branch_with_head, create_measure, create_parameter, create_report_benchmark,
+            create_report_benchmark_for_parameter, create_testbed, create_version,
+            get_empty_parameter, setup_test_db,
         },
     };
 
@@ -446,6 +448,210 @@ mod tests {
             end_time,
         )
         .expect("upsert series");
+    }
+
+    /// Ingest one report for a single grid point, writing every `named` scalar as
+    /// its own metric row.
+    ///
+    /// A grid point is its own series and a named value is not, so this is the
+    /// helper the parameter and named value billing tests reach for.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "test helper threads the full series key"
+    )]
+    fn ingest_grid_point(
+        conn: &mut DbConnection,
+        uuids: &mut Uuids,
+        proj: Proj,
+        testbed: TestbedId,
+        benchmark: BenchmarkId,
+        parameter: ParameterId,
+        measure: MeasureId,
+        named: &[MetricName],
+        end_time: DateTime,
+    ) {
+        let report_uuid = uuids.next();
+        diesel::insert_into(schema::report::table)
+            .values((
+                schema::report::uuid.eq(&report_uuid),
+                schema::report::project_id.eq(proj.project),
+                schema::report::head_id.eq(proj.head),
+                schema::report::version_id.eq(proj.version),
+                schema::report::testbed_id.eq(testbed),
+                schema::report::adapter.eq(0),
+                schema::report::start_time.eq(end_time),
+                schema::report::end_time.eq(end_time),
+                schema::report::created.eq(end_time),
+            ))
+            .execute(conn)
+            .expect("insert report");
+        let report: ReportId = diesel::select(last_insert_rowid())
+            .get_result(conn)
+            .expect("report id");
+        let rb_uuid = uuids.next();
+        let report_benchmark =
+            create_report_benchmark_for_parameter(conn, &rb_uuid, report, 0, benchmark, parameter);
+        for name in named {
+            let metric_uuid = uuids.next();
+            diesel::insert_into(schema::metric::table)
+                .values((
+                    schema::metric::uuid.eq(&metric_uuid),
+                    schema::metric::report_benchmark_id.eq(report_benchmark),
+                    schema::metric::measure_id.eq(measure),
+                    schema::metric::name.eq(name),
+                    schema::metric::value.eq(1.0f64),
+                ))
+                .execute(conn)
+                .expect("insert metric");
+        }
+        upsert_series_last_seen(
+            conn,
+            proj.org,
+            proj.project,
+            testbed,
+            benchmark,
+            measure,
+            end_time,
+        )
+        .expect("upsert series");
+    }
+
+    /// A non-empty parameter set under `benchmark`.
+    fn make_parameter(
+        conn: &mut DbConnection,
+        benchmark: BenchmarkId,
+        canonical: &str,
+    ) -> ParameterId {
+        create_parameter(
+            conn,
+            benchmark,
+            &canonical.parse().expect("Failed to parse the parameters"),
+        )
+    }
+
+    // Each grid point bills as its own series, which is exactly today's economics:
+    // a project whose grid points are currently flat benchmarks bills the same after
+    // migrating to parameters.
+    #[test]
+    fn grid_points_count_as_distinct_series() {
+        let mut conn = setup_test_db();
+        let mut uuids = Uuids(1);
+        let org = make_org(&mut conn, &mut uuids);
+        let proj = make_proj(&mut conn, &mut uuids, org, Visibility::Public);
+        let testbed = make_testbed(&mut conn, &mut uuids, proj.project);
+        let benchmark = make_benchmark(&mut conn, &mut uuids, proj.project);
+        let measure = make_measure(&mut conn, &mut uuids, proj.project);
+
+        let empty_set = get_empty_parameter(&mut conn, benchmark);
+        let sixteen = make_parameter(&mut conn, benchmark, r#"{"size_mb": 16}"#);
+        let thirty_two = make_parameter(&mut conn, benchmark, r#"{"size_mb": 32}"#);
+
+        for parameter in [empty_set, sixteen, thirty_two] {
+            ingest_grid_point(
+                &mut conn,
+                &mut uuids,
+                proj,
+                testbed,
+                benchmark,
+                parameter,
+                measure,
+                &[MetricName::value()],
+                at(0),
+            );
+        }
+
+        let (start, end) = always();
+        assert_eq!(count_active(&mut conn, org, start, end).unwrap(), 3);
+        assert_eq!(oracle_count(&mut conn, org, start, end, None), 3);
+    }
+
+    // Named values collapse into their measure's series. Names are not billed; the
+    // cap of eight is the guardrail on that.
+    #[test]
+    fn named_values_collapse_into_their_measure_series() {
+        let mut conn = setup_test_db();
+        let mut uuids = Uuids(1);
+        let org = make_org(&mut conn, &mut uuids);
+        let proj = make_proj(&mut conn, &mut uuids, org, Visibility::Public);
+        let testbed = make_testbed(&mut conn, &mut uuids, proj.project);
+        let benchmark = make_benchmark(&mut conn, &mut uuids, proj.project);
+        let measure = make_measure(&mut conn, &mut uuids, proj.project);
+
+        let empty_set = get_empty_parameter(&mut conn, benchmark);
+        let sixteen = make_parameter(&mut conn, benchmark, r#"{"size_mb": 16}"#);
+        let named = [
+            MetricName::value(),
+            MetricName::lower_value(),
+            MetricName::upper_value(),
+            "p99".parse().expect("Failed to parse the metric name"),
+        ];
+
+        for parameter in [empty_set, sixteen] {
+            ingest_grid_point(
+                &mut conn,
+                &mut uuids,
+                proj,
+                testbed,
+                benchmark,
+                parameter,
+                measure,
+                &named,
+                at(0),
+            );
+        }
+
+        let (start, end) = always();
+        // Two grid points, four names each: two series, not eight.
+        assert_eq!(count_active(&mut conn, org, start, end).unwrap(), 2);
+        assert_eq!(oracle_count(&mut conn, org, start, end, None), 2);
+    }
+
+    // The migration's backfill maps every existing series row to its benchmark's
+    // empty parameter set, which is the set every legacy `report_benchmark` row was
+    // itself backfilled to.
+    #[test]
+    fn backfill_maps_existing_rows_to_the_empty_parameter_set() {
+        use diesel::sql_query;
+
+        #[derive(diesel::QueryableByName)]
+        struct SqlCount {
+            #[diesel(sql_type = diesel::sql_types::BigInt)]
+            count: i64,
+        }
+
+        let mut conn = setup_test_db();
+        let mut uuids = Uuids(1);
+        let org = make_org(&mut conn, &mut uuids);
+        let proj = make_proj(&mut conn, &mut uuids, org, Visibility::Public);
+        let testbed = make_testbed(&mut conn, &mut uuids, proj.project);
+        let benchmark = make_benchmark(&mut conn, &mut uuids, proj.project);
+        let measure = make_measure(&mut conn, &mut uuids, proj.project);
+        ingest(
+            &mut conn,
+            &mut uuids,
+            proj,
+            testbed,
+            benchmark,
+            measure,
+            at(0),
+        );
+
+        // Every cache row names a parameter set, and it is the benchmark's empty one.
+        let mismatched = sql_query(
+            "SELECT COUNT(*) AS count
+             FROM series_last_seen s
+             LEFT JOIN parameter p ON p.id = s.parameter_id
+             WHERE p.id IS NULL
+                OR p.benchmark_id != s.benchmark_id
+                OR p.parameters != jsonb('{}')",
+        )
+        .get_result::<SqlCount>(&mut conn)
+        .expect("Failed to check the backfilled parameter sets")
+        .count;
+        assert_eq!(
+            mismatched, 0,
+            "every series row names its benchmark's empty parameter set"
+        );
     }
 
     /// Ingest on the project's primary head.

--- a/lib/bencher_schema/src/model/project/series.rs
+++ b/lib/bencher_schema/src/model/project/series.rs
@@ -2,17 +2,19 @@
 
 //! Cache of each monitored series' most recent activity.
 //!
-//! A *series* is a distinct `(testbed, benchmark, measure)` an organization reports
-//! to. `series_last_seen` stores, per series, the greatest `report.created` (the
-//! server-side ingestion time, not the user-supplied `end_time`) ever recorded for it
-//! (`last_seen`). The cache is written on ingest in the same transaction as the metric
+//! A *series* is a distinct `(testbed, benchmark, parameter, measure)` an organization
+//! reports to: each grid point of a benchmark has its own history and bills as its own
+//! series, and named metric values collapse into their measure's series rather than
+//! multiplying it. `series_last_seen` stores, per series, the greatest `report.created`
+//! (the server-side ingestion time, not the user-supplied `end_time`) ever recorded for
+//! it (`last_seen`). The cache is written on ingest in the same transaction as the metric
 //! inserts and backfilled from existing metrics by the migration. `last_seen` only ever
 //! rises (`MAX`): reprocessing an older report cannot lower it, and deleting a report
 //! does NOT lower it either; a series that reported during a period was active that
 //! period and stays billed for it. The one way a series leaves the count early is
-//! hard-deleting its testbed, benchmark, or measure, which cascades its rows away and
-//! can lower the current period's count. Accepted: entity deletion requires first
-//! deleting all of that entity's reports (destroying the org's own history), and an
+//! hard-deleting its testbed, benchmark, parameter set, or measure, which cascades its
+//! rows away and can lower the current period's count. Accepted: entity deletion requires
+//! first deleting all of that entity's reports (destroying the org's own history), and an
 //! inactive series stops billing next period anyway.
 //!
 //! The cache exists so that billing on monthly-active series (and the matching telemetry
@@ -29,16 +31,31 @@ use crate::{
     error::issue_error,
     model::{
         organization::OrganizationId,
-        project::{ProjectId, benchmark::BenchmarkId, measure::MeasureId, testbed::TestbedId},
+        project::{
+            ProjectId, benchmark::BenchmarkId, measure::MeasureId, parameter::ParameterId,
+            testbed::TestbedId,
+        },
     },
     schema::{self, series_last_seen as series_table},
 };
 
+/// One billable series: a grid point's measure on a testbed.
+///
+/// The four columns travel together because they are one identity, and because
+/// they are what the primary key is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SeriesKey {
+    pub testbed_id: TestbedId,
+    pub benchmark_id: BenchmarkId,
+    pub parameter_id: ParameterId,
+    pub measure_id: MeasureId,
+}
+
 /// Record that a series produced a metric at `last_seen`, keeping the stored value
 /// the greater of its current and new value.
 ///
-/// Called once per distinct `(testbed, benchmark, measure)` in an ingested report,
-/// inside the same write transaction as that report's metric inserts. `last_seen` is the
+/// Called once per distinct [`SeriesKey`] in an ingested report, inside the same
+/// write transaction as that report's metric inserts. `last_seen` is the
 /// report's server-side creation time. `MAX` keeps it monotonic: reprocessing an older
 /// report cannot lower a series' recorded activity, and a repeat within the same report
 /// (across iterations) is an idempotent no-op.
@@ -50,12 +67,17 @@ pub fn upsert_series_last_seen(
     conn: &mut DbConnection,
     organization_id: OrganizationId,
     project_id: ProjectId,
-    testbed_id: TestbedId,
-    benchmark_id: BenchmarkId,
-    measure_id: MeasureId,
+    series: SeriesKey,
     last_seen: DateTime,
 ) -> diesel::QueryResult<()> {
     use crate::macros::sql::max;
+
+    let SeriesKey {
+        testbed_id,
+        benchmark_id,
+        parameter_id,
+        measure_id,
+    } = series;
 
     diesel::insert_into(series_table::table)
         .values((
@@ -63,12 +85,14 @@ pub fn upsert_series_last_seen(
             series_table::project_id.eq(project_id),
             series_table::testbed_id.eq(testbed_id),
             series_table::benchmark_id.eq(benchmark_id),
+            series_table::parameter_id.eq(parameter_id),
             series_table::measure_id.eq(measure_id),
             series_table::last_seen.eq(last_seen),
         ))
         .on_conflict((
             series_table::testbed_id,
             series_table::benchmark_id,
+            series_table::parameter_id,
             series_table::measure_id,
         ))
         .do_update()
@@ -166,7 +190,8 @@ fn count_inner(
 /// Test-only oracle: the distinct-series count the cache must equal, computed from
 /// scratch over the raw metric rows in plain Rust (independent of the cache's SQL).
 ///
-/// Counts distinct `(testbed, benchmark, measure)` whose latest `report.created`
+/// Counts distinct `(testbed, benchmark, parameter, measure)` whose latest
+/// `report.created`
 /// falls in `[start_time, end_time]`, excluding soft-deleted projects, optionally
 /// restricted to a `visibility`. Never run at runtime; [`count_inner`] is the
 /// runtime source and this pins it in tests (shared with the ingest tests).
@@ -180,14 +205,19 @@ pub(crate) fn oracle_count(
 ) -> u32 {
     use std::collections::HashMap;
 
-    let rows: Vec<(
+    /// One metric row, reduced to the series it belongs to, when its report was
+    /// created, and the project filters the cache read applies.
+    type OracleRow = (
         TestbedId,
         BenchmarkId,
+        ParameterId,
         MeasureId,
         DateTime,
         Visibility,
         Option<DateTime>,
-    )> = schema::metric::table
+    );
+
+    let rows: Vec<OracleRow> = schema::metric::table
         .inner_join(
             schema::report_benchmark::table
                 .inner_join(schema::benchmark::table.inner_join(schema::project::table))
@@ -198,6 +228,7 @@ pub(crate) fn oracle_count(
         .select((
             schema::report::testbed_id,
             schema::report_benchmark::benchmark_id,
+            schema::report_benchmark::parameter_id,
             schema::metric::measure_id,
             schema::report::created,
             schema::project::visibility,
@@ -208,8 +239,17 @@ pub(crate) fn oracle_count(
 
     // Reduce to the latest creation time per series, applying the same project filters
     // the cache read applies.
-    let mut last_by_series: HashMap<(TestbedId, BenchmarkId, MeasureId), DateTime> = HashMap::new();
-    for (testbed_id, benchmark_id, measure_id, created_row, project_visibility, deleted) in rows {
+    let mut last_by_series: HashMap<SeriesKey, DateTime> = HashMap::new();
+    for (
+        testbed_id,
+        benchmark_id,
+        parameter_id,
+        measure_id,
+        created_row,
+        project_visibility,
+        deleted,
+    ) in rows
+    {
         if deleted.is_some() {
             continue;
         }
@@ -222,7 +262,12 @@ pub(crate) fn oracle_count(
         // `DateTime` has no `Ord`; compare by timestamp (whole seconds, exactly what
         // SQL stores and compares).
         last_by_series
-            .entry((testbed_id, benchmark_id, measure_id))
+            .entry(SeriesKey {
+                testbed_id,
+                benchmark_id,
+                parameter_id,
+                measure_id,
+            })
             .and_modify(|latest| {
                 if created_row.timestamp() > latest.timestamp() {
                     *latest = created_row;
@@ -248,7 +293,9 @@ mod tests {
     use bencher_json::{DateTime, MetricName, project::Visibility};
     use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 
-    use super::{count_active, count_active_private, oracle_count, upsert_series_last_seen};
+    use super::{
+        SeriesKey, count_active, count_active_private, oracle_count, upsert_series_last_seen,
+    };
     use crate::{
         context::DbConnection,
         macros::sql::last_insert_rowid,
@@ -438,13 +485,17 @@ mod tests {
             ))
             .execute(conn)
             .expect("insert metric");
+        let parameter = get_empty_parameter(conn, benchmark);
         upsert_series_last_seen(
             conn,
             proj.org,
             proj.project,
-            testbed,
-            benchmark,
-            measure,
+            SeriesKey {
+                testbed_id: testbed,
+                benchmark_id: benchmark,
+                parameter_id: parameter,
+                measure_id: measure,
+            },
             end_time,
         )
         .expect("upsert series");
@@ -508,9 +559,12 @@ mod tests {
             conn,
             proj.org,
             proj.project,
-            testbed,
-            benchmark,
-            measure,
+            SeriesKey {
+                testbed_id: testbed,
+                benchmark_id: benchmark,
+                parameter_id: parameter,
+                measure_id: measure,
+            },
             end_time,
         )
         .expect("upsert series");
@@ -1075,28 +1129,17 @@ mod tests {
             make_benchmark(&mut conn, &mut uuids, proj.project),
             make_measure(&mut conn, &mut uuids, proj.project),
         );
+        let parameter = get_empty_parameter(&mut conn, benchmark);
+        let series = SeriesKey {
+            testbed_id: testbed,
+            benchmark_id: benchmark,
+            parameter_id: parameter,
+            measure_id: measure,
+        };
         // Two bare upserts of the same series key converge to one row, last_seen = MAX,
         // with no duplicate-key error.
-        upsert_series_last_seen(
-            &mut conn,
-            org,
-            proj.project,
-            testbed,
-            benchmark,
-            measure,
-            at(5),
-        )
-        .unwrap();
-        upsert_series_last_seen(
-            &mut conn,
-            org,
-            proj.project,
-            testbed,
-            benchmark,
-            measure,
-            at(3),
-        )
-        .unwrap();
+        upsert_series_last_seen(&mut conn, org, proj.project, series, at(5)).unwrap();
+        upsert_series_last_seen(&mut conn, org, proj.project, series, at(3)).unwrap();
         let (start, end) = always();
         assert_eq!(count_active(&mut conn, org, start, end).unwrap(), 1);
         // last_seen stayed at the max (5), so the [4, 10] window still counts it.
@@ -1186,16 +1229,20 @@ mod tests {
     fn backfill_equals_oracle() {
         use diesel::sql_query;
 
-        // Mirrors the backfill in migration 2026-06-24-120000_series_last_seen/up.sql.
+        // What the two backfills compose to: 2026-06-24-120000_series_last_seen fills
+        // the cache from the metrics, and 2026-08-17-120000_series_last_seen_parameter
+        // gives every row a parameter set, which for a legacy row is its benchmark's
+        // empty set, which is the set the parameter migration gave every legacy
+        // `report_benchmark` row.
         const BACKFILL: &str = "\
-INSERT INTO series_last_seen (organization_id, project_id, testbed_id, benchmark_id, measure_id, last_seen)
-SELECT p.organization_id, p.id, r.testbed_id, rb.benchmark_id, m.measure_id, MAX(r.created)
+INSERT INTO series_last_seen (organization_id, project_id, testbed_id, benchmark_id, parameter_id, measure_id, last_seen)
+SELECT p.organization_id, p.id, r.testbed_id, rb.benchmark_id, rb.parameter_id, m.measure_id, MAX(r.created)
 FROM metric m
 INNER JOIN report_benchmark rb ON m.report_benchmark_id = rb.id
 INNER JOIN report r ON rb.report_id = r.id
 INNER JOIN benchmark b ON rb.benchmark_id = b.id
 INNER JOIN project p ON b.project_id = p.id
-GROUP BY r.testbed_id, rb.benchmark_id, m.measure_id";
+GROUP BY r.testbed_id, rb.benchmark_id, rb.parameter_id, m.measure_id";
 
         let mut conn = setup_test_db();
         let mut uuids = Uuids(1);

--- a/lib/bencher_schema/src/schema.rs
+++ b/lib/bencher_schema/src/schema.rs
@@ -339,11 +339,12 @@ diesel::table! {
 }
 
 diesel::table! {
-    series_last_seen (testbed_id, benchmark_id, measure_id) {
+    series_last_seen (testbed_id, benchmark_id, parameter_id, measure_id) {
         organization_id -> Integer,
         project_id -> Integer,
         testbed_id -> Integer,
         benchmark_id -> Integer,
+        parameter_id -> Integer,
         measure_id -> Integer,
         last_seen -> BigInt,
     }
@@ -512,6 +513,7 @@ diesel::joinable!(runner_spec -> spec (spec_id));
 diesel::joinable!(series_last_seen -> benchmark (benchmark_id));
 diesel::joinable!(series_last_seen -> measure (measure_id));
 diesel::joinable!(series_last_seen -> organization (organization_id));
+diesel::joinable!(series_last_seen -> parameter (parameter_id));
 diesel::joinable!(series_last_seen -> project (project_id));
 diesel::joinable!(series_last_seen -> testbed (testbed_id));
 diesel::joinable!(sso -> organization (organization_id));

--- a/lib/bencher_schema/src/test_util.rs
+++ b/lib/bencher_schema/src/test_util.rs
@@ -610,7 +610,7 @@ pub fn create_report_benchmark_for_parameter(
         .expect("Failed to get report_benchmark id")
 }
 
-/// Create a metric for testing.
+/// Create a metric for testing: the conventional point estimate.
 pub fn create_metric(
     conn: &mut SqliteConnection,
     metric_uuid: &str,
@@ -618,12 +618,31 @@ pub fn create_metric(
     measure_id: MeasureId,
     value: f64,
 ) -> MetricId {
+    create_named_metric(
+        conn,
+        metric_uuid,
+        report_benchmark_id,
+        measure_id,
+        &MetricName::value(),
+        value,
+    )
+}
+
+/// Create a metric for testing under any name.
+pub fn create_named_metric(
+    conn: &mut SqliteConnection,
+    metric_uuid: &str,
+    report_benchmark_id: ReportBenchmarkId,
+    measure_id: MeasureId,
+    name: &MetricName,
+    value: f64,
+) -> MetricId {
     diesel::insert_into(schema::metric::table)
         .values((
             schema::metric::uuid.eq(metric_uuid),
             schema::metric::report_benchmark_id.eq(report_benchmark_id),
             schema::metric::measure_id.eq(measure_id),
-            schema::metric::name.eq(MetricName::value()),
+            schema::metric::name.eq(name),
             schema::metric::value.eq(value),
         ))
         .execute(conn)

--- a/plus/bencher_otel/src/api_meter.rs
+++ b/plus/bencher_otel/src/api_meter.rs
@@ -86,6 +86,7 @@ pub enum ApiCounter {
     ReportDelete,
 
     MetricsCreate(Priority),
+    MetricNamesDropped,
     MetricsBilled,
     MetricsBilledFailed,
     ActiveSeriesBilled,
@@ -178,7 +179,10 @@ impl ApiCounter {
 
             Self::ReportCreate | Self::ReportDelete | Self::SelfHostedServerStats(_) => "{report}",
 
-            Self::MetricsCreate(_) | Self::MetricsBilled | Self::MetricsBilledFailed => "{metric}",
+            Self::MetricsCreate(_)
+            | Self::MetricNamesDropped
+            | Self::MetricsBilled
+            | Self::MetricsBilledFailed => "{metric}",
 
             Self::ActiveSeriesBilled | Self::ActiveSeriesBilledFailed => "{series}",
 
@@ -244,6 +248,7 @@ impl ApiCounter {
             Self::ReportDelete => "report.delete",
 
             Self::MetricsCreate(_) => "metrics.create",
+            Self::MetricNamesDropped => "metrics.names.dropped",
             Self::MetricsBilled => "metrics.billed",
             Self::MetricsBilledFailed => "metrics.billed.failed",
             Self::ActiveSeriesBilled => "active_series.billed",
@@ -323,6 +328,10 @@ impl ApiCounter {
         }
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "exhaustive match over every counter variant"
+    )]
     fn description(&self) -> &'static str {
         match self {
             Self::ServerStartup => "Counts the number of server startups",
@@ -342,6 +351,9 @@ impl ApiCounter {
             Self::ReportDelete => "Counts the number of report deletions",
 
             Self::MetricsCreate(_) => "Counts the number of metrics created",
+            Self::MetricNamesDropped => {
+                "Counts the named metric values dropped over the per measure cap"
+            },
             Self::MetricsBilled => "Counts the number of metrics successfully billed",
             Self::MetricsBilledFailed => "Counts the number of metrics billing failures",
             Self::ActiveSeriesBilled => "Counts the number of active series successfully billed",
@@ -475,6 +487,7 @@ impl ApiCounter {
             | Self::UserKeyUpdateBlocked
             | Self::UserKeyRevoke
             | Self::UserKeyRevokeBlocked
+            | Self::MetricNamesDropped
             | Self::MetricsBilled
             | Self::MetricsBilledFailed
             | Self::ActiveSeriesBilled

--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -16183,7 +16183,7 @@
         "type": "object",
         "properties": {
           "benchmarks": {
-            "description": "The number of benchmarks in this iteration.",
+            "description": "The number of results in this iteration: one per grid point, so one per benchmark for a benchmark that reports a single parameter set.",
             "type": "integer",
             "format": "uint32",
             "minimum": 0

--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -16216,8 +16216,7 @@
             "$ref": "#/components/schemas/JsonMeasure"
           },
           "metric": {
-            "nullable": true,
-            "description": "Deprecated. Reconstructed from the `value` row and its `lower_value`/`upper_value` siblings. Retained for compatibility with older clients and removed in a future release. Absent only when the measure named no `value` at all, which nothing before named metric values could produce.",
+            "description": "Deprecated. Reconstructed from the `value` row and its `lower_value`/`upper_value` siblings. Retained for compatibility with older clients and removed in a future release. A measure that named no `value` at all has nothing to reconstruct it from, so it is left out of the results.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/JsonMetric"
@@ -16243,6 +16242,7 @@
         },
         "required": [
           "measure",
+          "metric",
           "metrics"
         ]
       },

--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -16216,7 +16216,8 @@
             "$ref": "#/components/schemas/JsonMeasure"
           },
           "metric": {
-            "description": "Deprecated. Reconstructed from the `value` row and its `lower_value`/`upper_value` siblings. Retained for compatibility with older clients and removed in a future release. A measure that named no `value` at all has nothing to reconstruct it from, so it is left out of the results.",
+            "nullable": true,
+            "description": "Deprecated. Reconstructed from the `value` row and its `lower_value`/`upper_value` siblings. Retained for compatibility with older clients and removed in a future release.\n\nAbsent when the measure carries no `value` name, which BMF v1 permits. Never absent for anything an older client could produce.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/JsonMetric"
@@ -16242,7 +16243,6 @@
         },
         "required": [
           "measure",
-          "metric",
           "metrics"
         ]
       },

--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -14791,6 +14791,23 @@
           "protocol"
         ]
       },
+      "JsonParameters": {
+        "type": "object",
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number",
+              "format": "double"
+            },
+            {
+              "type": "boolean"
+            }
+          ]
+        }
+      },
       "JsonPerf": {
         "type": "object",
         "properties": {
@@ -16120,6 +16137,22 @@
           "total"
         ]
       },
+      "JsonReportBoundary": {
+        "description": "A threshold and the boundary it produced, together.",
+        "type": "object",
+        "properties": {
+          "boundary": {
+            "$ref": "#/components/schemas/JsonBoundary"
+          },
+          "threshold": {
+            "$ref": "#/components/schemas/JsonThresholdModel"
+          }
+        },
+        "required": [
+          "boundary",
+          "threshold"
+        ]
+      },
       "JsonReportCounts": {
         "description": "Counts for a report.",
         "type": "object",
@@ -16172,6 +16205,7 @@
         "properties": {
           "boundary": {
             "nullable": true,
+            "description": "Deprecated. The boundary computed for the `value` row, if any.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/JsonBoundary"
@@ -16182,10 +16216,24 @@
             "$ref": "#/components/schemas/JsonMeasure"
           },
           "metric": {
-            "$ref": "#/components/schemas/JsonMetric"
+            "nullable": true,
+            "description": "Deprecated. Reconstructed from the `value` row and its `lower_value`/`upper_value` siblings. Retained for compatibility with older clients and removed in a future release. Absent only when the measure named no `value` at all, which nothing before named metric values could produce.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonMetric"
+              }
+            ]
+          },
+          "metrics": {
+            "description": "Every named scalar ingested for this measure, in a stable order.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/JsonReportMetric"
+            }
           },
           "threshold": {
             "nullable": true,
+            "description": "Deprecated. The threshold that gated the `value` row, if any.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/JsonThresholdModel"
@@ -16195,10 +16243,56 @@
         },
         "required": [
           "measure",
-          "metric"
+          "metrics"
+        ]
+      },
+      "JsonReportMetric": {
+        "description": "Exactly one `metric` row: one named scalar.",
+        "type": "object",
+        "properties": {
+          "boundaries": {
+            "description": "Every threshold that gated this named scalar, with the boundary it produced. Length 0 or 1 until threshold predicates ship.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/JsonReportBoundary"
+            }
+          },
+          "name": {
+            "$ref": "#/components/schemas/MetricName"
+          },
+          "uuid": {
+            "$ref": "#/components/schemas/MetricUuid"
+          },
+          "value": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "required": [
+          "boundaries",
+          "name",
+          "uuid",
+          "value"
+        ]
+      },
+      "JsonReportParameter": {
+        "description": "The parameter set a report result ran with.",
+        "type": "object",
+        "properties": {
+          "parameters": {
+            "$ref": "#/components/schemas/JsonParameters"
+          },
+          "uuid": {
+            "$ref": "#/components/schemas/ParameterUuid"
+          }
+        },
+        "required": [
+          "parameters",
+          "uuid"
         ]
       },
       "JsonReportResult": {
+        "description": "One grid point of one benchmark, in one iteration of a report.\n\nA benchmark reports as many results per iteration as it has parameter sets, so the parameter set is what tells two results of one benchmark apart.",
         "type": "object",
         "properties": {
           "benchmark": {
@@ -16212,12 +16306,21 @@
             "items": {
               "$ref": "#/components/schemas/JsonReportMeasure"
             }
+          },
+          "parameter": {
+            "description": "The parameter set this result ran with.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonReportParameter"
+              }
+            ]
           }
         },
         "required": [
           "benchmark",
           "iteration",
-          "measures"
+          "measures",
+          "parameter"
         ]
       },
       "JsonReportSettings": {
@@ -18339,6 +18442,10 @@
         "format": "uint64",
         "minimum": 0
       },
+      "MetricName": {
+        "description": "The name of a single scalar inside a metric.\n\nEvery name is equal on the wire. `value`, `lower_value`, and `upper_value` are conventional, not privileged: they are the names the metric triple maps onto, and the names the console knows well enough to draw a band.",
+        "type": "string"
+      },
       "MetricUuid": {
         "type": "string",
         "format": "uuid"
@@ -18476,6 +18583,10 @@
             ]
           }
         ]
+      },
+      "ParameterUuid": {
+        "type": "string",
+        "format": "uuid"
       },
       "PlanLevel": {
         "type": "string",

--- a/services/console/src/types/bencher.ts
+++ b/services/console/src/types/bencher.ts
@@ -387,10 +387,10 @@ export interface JsonReportMeasure {
 	/**
 	 * Deprecated. Reconstructed from the `value` row and its
 	 * `lower_value`/`upper_value` siblings. Retained for compatibility with older
-	 * clients and removed in a future release. Absent only when the measure named
-	 * no `value` at all, which nothing before named metric values could produce.
+	 * clients and removed in a future release. A measure that named no `value` at
+	 * all has nothing to reconstruct it from, so it is left out of the results.
 	 */
-	metric?: JsonMetric;
+	metric: JsonMetric;
 	/** Deprecated. The threshold that gated the `value` row, if any. */
 	threshold?: JsonThresholdModel;
 	/** Deprecated. The boundary computed for the `value` row, if any. */

--- a/services/console/src/types/bencher.ts
+++ b/services/console/src/types/bencher.ts
@@ -349,6 +349,12 @@ export interface JsonAlert {
 
 export type JsonReportAlerts = JsonAlert[];
 
+/** The parameter set a report result ran with. */
+export interface JsonReportParameter {
+	uuid: Uuid;
+	parameters: Record<string, string | number | boolean>;
+}
+
 export interface JsonThresholdModel {
 	uuid: Uuid;
 	project: Uuid;
@@ -356,16 +362,52 @@ export interface JsonThresholdModel {
 	created: string;
 }
 
+/** A threshold and the boundary it produced, together. */
+export interface JsonReportBoundary {
+	threshold: JsonThresholdModel;
+	boundary: JsonBoundary;
+}
+
+/** Exactly one `metric` row: one named scalar. */
+export interface JsonReportMetric {
+	uuid: Uuid;
+	name: string;
+	value: number;
+	/**
+	 * Every threshold that gated this named scalar, with the boundary it produced.
+	 * Length 0 or 1 until threshold predicates ship.
+	 */
+	boundaries: JsonReportBoundary[];
+}
+
 export interface JsonReportMeasure {
 	measure: JsonMeasure;
-	metric: JsonMetric;
+	/** Every named scalar ingested for this measure, in a stable order. */
+	metrics: JsonReportMetric[];
+	/**
+	 * Deprecated. Reconstructed from the `value` row and its
+	 * `lower_value`/`upper_value` siblings. Retained for compatibility with older
+	 * clients and removed in a future release. Absent only when the measure named
+	 * no `value` at all, which nothing before named metric values could produce.
+	 */
+	metric?: JsonMetric;
+	/** Deprecated. The threshold that gated the `value` row, if any. */
 	threshold?: JsonThresholdModel;
+	/** Deprecated. The boundary computed for the `value` row, if any. */
 	boundary?: JsonBoundary;
 }
 
+/**
+ * One grid point of one benchmark, in one iteration of a report.
+ * 
+ * A benchmark reports as many results per iteration as it has parameter sets, so
+ * the parameter set is what tells two results of one benchmark apart.
+ */
 export interface JsonReportResult {
 	iteration: Iteration;
 	benchmark: JsonBenchmark;
+	/** The parameter set this result ran with. */
+	parameter: JsonReportParameter;
 	measures: JsonReportMeasure[];
 }
 

--- a/services/console/src/types/bencher.ts
+++ b/services/console/src/types/bencher.ts
@@ -1119,7 +1119,10 @@ export enum Adapter {
 
 /** Counts for a single iteration of a report. */
 export interface JsonReportIterationCounts {
-	/** The number of benchmarks in this iteration. */
+	/**
+	 * The number of results in this iteration: one per grid point, so one per
+	 * benchmark for a benchmark that reports a single parameter set.
+	 */
 	benchmarks: number;
 	/** The number of distinct measures in this iteration. */
 	measures: number;

--- a/services/console/src/types/bencher.ts
+++ b/services/console/src/types/bencher.ts
@@ -387,10 +387,12 @@ export interface JsonReportMeasure {
 	/**
 	 * Deprecated. Reconstructed from the `value` row and its
 	 * `lower_value`/`upper_value` siblings. Retained for compatibility with older
-	 * clients and removed in a future release. A measure that named no `value` at
-	 * all has nothing to reconstruct it from, so it is left out of the results.
+	 * clients and removed in a future release.
+	 * 
+	 * Absent when the measure carries no `value` name, which BMF v1 permits. Never
+	 * absent for anything an older client could produce.
 	 */
-	metric: JsonMetric;
+	metric?: JsonMetric;
 	/** Deprecated. The threshold that gated the `value` row, if any. */
 	threshold?: JsonThresholdModel;
 	/** Deprecated. The boundary computed for the `value` row, if any. */

--- a/services/console/typeshare.toml
+++ b/services/console/typeshare.toml
@@ -20,6 +20,7 @@
 "SpecUuid" = "Uuid"
 "RunnerUuid" = "Uuid"
 "JobUuid" = "Uuid"
+"ParameterUuid" = "Uuid"
 # Typed Slugs
 "Slug" = "string"
 "OrganizationSlug" = "Slug"
@@ -40,6 +41,8 @@
 "ImageReference" = "string"
 "Utf8PathBuf" = "string"
 "OrderedFloat" = "number"
+"MetricName" = "string"
+"JsonParameters" = "Record<string, string | number | boolean>"
 "BigInt" = "number"
 "TimestampMillis" = "number"
 "Cpu" = "number"


### PR DESCRIPTION
Benchmark parameters and named metric values become rows. The schema underneath is settled; this layer is behavior: ingest, detection, billing, and the report response.

Fourth of the benchmark parameters stack. Targets `benchmark-parameters/bmf-v1` and stays a draft while the layers below it are drafts.

## The one decision this layer could not make for itself

Flagged in review and since decided: the legacy metric-count meter keeps its current behavior, and a measure that names no point estimate counts zero on it. See billing below. The two other open decisions of earlier rounds, a missing ceiling on parameter creation and the nullability of the deprecated `metric` field, are both closed.

### An optional `metric` field and a value-less measure

A BMF v1 measure may name only `p99` and never mention `value` at all, which the design states in as many words, and ingest is best effort by rule, so such a measure is accepted rather than refused. It has no `value` row for the deprecated `metric` to be reconstructed from.

**`JsonReportMeasure.metric` is optional, and it is absent exactly when the measure carries no `value` name.** Such a measure appears in the report response like any other, carrying its named values in `metrics` with no deprecated triple beside them. The field is skipped rather than serialized as null, matching the other optional fields on `JsonReport`. `threshold` and `boundary` are already optional and come back null there, as they do for any ungated measure: a bare threshold gates only the `value` name, so a value-less measure has no boundary to report. That is asserted rather than reasoned.

The alternative was leaving such a measure out of the results, which an earlier round of this branch shipped. It made data that is stored, billed as an active series, and queryable invisible in the response that created it. Filling `metric` from another named scalar was never on the table: it asserts a `value` the user never reported, which is exactly the invention the fold ruling refuses.

**Why this is compatible.** The field can only ever be absent on a measure with no `value` name, which is a shape only a BMF v1 payload can create. Every legacy response, meaning anything reachable from a BMF v0 payload on any CLI age, keeps the field exactly as before. A pinned older CLI handed a v1 file would see the absent field and fail to deserialize the response after ingest succeeds; that is a new-format adoption error rather than a legacy break, and the v1 reference docs will state that BMF v1 requires a current CLI. `v0_measure_response_is_unchanged` pins that claim: it captures the whole measure object of a BMF v0 report, with only the minted UUIDs and the measure entity normalized, and asserts it byte for byte, the populated `metric` and the null `threshold` and `boundary` included. The regenerated spec has `JsonReportMeasure.required` as `["measure", "metrics"]` with `metric` nullable, and `metrics` and `measure` both still required.

The counts follow the results, which is what they always had to do. `counts.measures` is computed two ways, from the loaded results on the report endpoint and by aggregate query on the list endpoint, and `into_json_full_and_collapsed_agree` exists to keep the two saying the same thing. A value-less measure is returned, so it is counted: the aggregate counts every measure with a metric row, which is precisely the set the results carry. No BMF v0 project's counts move, because a v0 measure always names a `value`.

## The parameter creation ceiling

Parameter rows are minted straight from report content, one per grid point, and until this round nothing bounded them. `QueryBenchmark`, `QueryMeasure`, `QueryBranch`, `QueryTestbed`, `QueryThreshold`, and `QueryReport` all carry a per project ceiling; the report-level limit bounds reports per window, not entities minted inside a single payload, which is why each of those needs its own. A harness that interpolates a commit sha or a timestamp into `parameters` would otherwise mint a fresh parameter row per report without limit, and every new grid point is also a new billable active series.

`parameter` has no `project_id`, so `fn_rate_limit!` does not apply as written. The ceiling is hand written instead and counts the window through the join that already exists: a parameter set belongs to its benchmark, and the benchmark belongs to the project. The limits and the error are the ones every other resource a report mints already uses, so a project that trips it gets exactly the message it gets today for a flood of benchmark names.

Two consequences worth stating.

No existing project is touched. A BMF v0 payload only ever resolves the empty parameter set, which every benchmark is born with and which is returned before any creation is attempted, so the ceiling is only ever reached by a payload that names parameters.

The count includes the empty parameter set each benchmark is born with, which makes the ceiling slightly conservative for a project creating benchmarks and grid points in the same window. That is the safe direction, and it costs a project nothing the benchmark ceiling was not already going to cost it.

The alternatives were denormalizing `project_id` onto `parameter`, which reopens a settled lower layer's schema for a count, and recording the gap as accepted, which leaves the same unbounded path `fn_rate_limit!` exists to close.

## Ingest

Each BMF v1 entry resolves to its parameter row during the existing **phase 1** preparation, alongside `QueryBenchmark::get_or_create` and `QueryMeasure::get_or_create`, never inside the phase 2 write transaction. That placement is forced: `write_transaction!` does not nest, and `QueryParameter::get_or_create` opens one of its own to insert a new parameter set. An entry with no `parameters` resolves to the benchmark's empty parameter set, which already exists by the birth invariant and is never created lazily; a missing empty set is data corruption and is reported as such rather than minted. A resolved parameter row that is archived is unarchived, exactly as `QueryBenchmark::get_or_create` does.

The parameter cache keys on `(benchmark, parameter set)` rather than on the benchmark, since one benchmark has as many grid points as it has parameter sets.

Named metric rows are one `metric` row per name per measure per `report_benchmark`. The `value` row is written first so `last_insert_rowid` still names the row a boundary attaches to.

**Duplicate grid points.** Two v1 entries that canonicalize to the same parameter set and carry the same measure now union at the metric-name level, last wins per name. Previously the later entry replaced the whole `AdapterMetric`, so `[{measures:{latency:{p50:1.0}}}, {measures:{latency:{p99:2.0}}}]` yielded `p99` alone with a drop count of zero. Nothing is dropped now, so nothing needs counting. The comment at the merge site was narrowed from measure granularity to name granularity.

## Detection

Baselines key on `(benchmark, parameter, measure)`: the historical query in `detector/data.rs` gains `report_benchmark.parameter_id`, so one grid point's sample is never the benchmark's grid pooled.

Bare thresholds gate only the conventional `value` series, of every parameter set under their measure. That is exactly what a measure-level threshold over flat benchmarks has always done, so no project's alert volume changes. Threshold matching itself is untouched: still `(branch, testbed, measure)`, and `threshold` gains no columns.

**Alert-parity evidence.** `alert_volume_is_identical_for_flat_benchmarks_and_grid_points` ingests the same six reports of the same two measurement series twice: once as two flat benchmarks (`bench_16`, `bench_32`) under one measure-level threshold, and once as one benchmark's two parameter sets under the same threshold. Both projects raise exactly one alert, and the grid project's alert is on the grid point that regressed.

**Per grid point baselines, proved separately.** The parity fixture cannot tell a per grid point baseline from a pooled one: its two grid points are a decade apart and the regression is tenfold, so it is an outlier either way. `baselines_separate_by_parameter` therefore has its own numbers, chosen so that pooling hides the regression: two tight histories two decades apart, `[10, 11, 12, 13, 14]` beside `[1000, 1001, 1002, 1003, 1004]`, with the small grid point finishing at 50 and the large one steady at 1004. Fifty is a large outlier against its own history and sits well inside the pooled spread. Delete the `parameter_id` filter from `detector/data.rs` and the test goes from one alert to none, which is recorded below.

## Billing

`series_last_seen` is recreated with `parameter_id` in its primary key, per the table-recreate convention, with every existing row backfilled to its benchmark's empty parameter set and all four indexes re-created (plus a fifth on the new `parameter_id` foreign key). The backfill joins `parameter` on the empty set, which is an inner join because every benchmark has one: it is born with it, and the parameter migration backfilled every benchmark that predates the birth invariant. `last_seen` carries over untouched, so no series is resurrected and none is lost. `down.sql` collapses grid points back into one series per `(testbed, benchmark, measure)`, keeping the greatest `last_seen` of the rows that merge.

Each grid point bills as its own series, which preserves today's economics exactly: a project whose grid points are currently flat benchmarks bills the same after migrating to parameters. Named values collapse into their measure's series and are not billed; the cap of eight is the guardrail on that.

The four series columns now travel together as a `SeriesKey`, because they are one identity and they are what the primary key is.

The backfill itself is pinned against a legacy database by `migration_backfill_preserves_every_series_row`, described under the tests below.

### What happened to metric-count billing

The legacy metric-count meter (`QueryMetric::usage`, used for Team, metered Enterprise, and licensed entitlements) already filters on `name = 'value'`, so **named values do not raise a v1 project's metric count**. A measure carrying `value`, `lower_value`, `upper_value`, and `p99` counts one, which is exactly what the row-per-measure table counted. That filter predates this layer.

The reachable change runs the other way. A BMF v1 measure may name only `p99` and never name `value`. Such a measure counts **zero** on `QueryMetric::usage`, zero in `metric_count_by_report`, and zero in the in-request usage the plan check and the `metrics.create` counter see, while still billing as an active series on Pro. That is a meter hole that no payload could reach before this layer.

Nothing was adjusted for it. `QueryMetric::usage` is untouched. The only alignment made was to `iteration_metric_count`, which now counts measures that named a `value` rather than measures outright, so the in-request meter and the billing read cannot drift from each other. `named_values_do_not_change_the_metric_count` pins both halves of what happens today. Decided 2026-08-22: this behavior is kept. The metric-count plans retire by the v1 ship, both meters already agree, and the exposure is bounded by the per-measure name cap and by the fact that only v1 payloads can produce a value-less measure.

## The report response

`JsonReportMeasure` gains `metrics: Vec<JsonReportMetric>`, one entry per named scalar in lexicographic order, each carrying `boundaries: Vec<JsonReportBoundary>` that pairs every threshold that gated it with the boundary it produced. The list is plural now so the wire never breaks again when threshold predicates ship; it is length 0 or 1 until then.

It **retains** `metric`, `threshold`, and `boundary` as deprecated fields reconstructed from the `value` row and its `lower_value`/`upper_value` siblings. Nothing in the repository uses `deny_unknown_fields`, so the additive fields are invisible to existing clients. For a measure that named no `value`, `metric` is absent and `threshold` and `boundary` are null, per the section above; all three are present for everything an older client can produce.

The results are assembled in a pending shape and finished at the end, because the deprecated triple is only in hand once every row of a measure has been read.

**The grouping fix this layer owed regardless of response shape.** `into_report_results_json` grouped by consecutive rows sharing a benchmark uuid, so two parameter sets under one benchmark silently merged into one `JsonReportResult`. The ordering is now `(iteration, benchmark.name, parameter.id, measure.name, metric.name)` and the grouping keys on the grid point, so two grid points are two results. `JsonReportResult` carries `parameter: JsonReportParameter { uuid, parameters }`, so the response is never ambiguous about which grid point a result belongs to.

Both halves of that fix are pinned. `report_response_echoes_named_values_and_separates_grid_points` runs two measures across two parameter sets, which is the smallest fixture that can see the ordering: with one measure per grid point the rows arrive grouped whether or not the parameter is in the `ORDER BY`. With two, dropping the parameter lets the measure name outrank it, the rows interleave by grid point, and the consecutive row grouping emits four results of one measure each. The test asserts two results each carrying both measures.

The counts follow: `JsonReportIterationCounts.benchmarks` is now a count of distinct `report_benchmark.id`, which is exactly one per grid point, so the aggregate-query count and the count taken from the loaded results still agree. `into_json_full_and_collapsed_agree` covers that, and `full_and_collapsed_counts_agree_for_a_value_less_measure` covers the measure count when a measure carries no `value` name.

The alerts query still reads through the `metric_boundary` view, since alerts only ever attach to `value` rows, which is what the view keys on.

## Fold

Per the ruling, `--fold` stays a BMF v0 operation. A v1 payload with fold requested warns and ingests unfolded: each iteration lands as its own `report_benchmark` row, exactly as it would without the flag. Never an error, and never a silently dropped named value. The fold machinery is not removed and v0 fold works exactly as before; fold over v0 keys on the benchmark and its empty parameter set by construction, since a v0 payload only ever carries the empty set. `v0_fold_still_folds` is the end-to-end guard on that promise, described under the tests below. The CLI-side deprecation warning is a following layer.

## The cap's log and counter

The adapter truncates and reports a drop count. This layer emits the log line and increments a new `metrics.names.dropped` counter, because this is where the logger and the meter are in scope. Never an ingest error: `named_value_cap_does_not_fail_the_report` posts a measure with ten names and gets a report back with eight.

## Tests, red before green

Commit `8fce999` is tests only, and every hunk in it is inside a `#[cfg(test)]` module or a test binary. How each area failed there:

- The ten end-to-end ingest tests failed with `400` against `201`, from the "not yet supported on ingest" refusal this layer removes.
- The two adapter union tests failed on assertions: `p50` was missing from the unioned names.
- `grid_points_count_as_distinct_series` and `named_values_collapse_into_their_measure_series` failed on assertions, 1 against 3 and 1 against 2, because the cache and its oracle both keyed without the parameter.
- `backfill_maps_existing_rows_to_the_empty_parameter_set` failed at runtime with `no such column: s.parameter_id`, deliberately written as raw SQL so the red failure is a runtime one rather than a compile error across the crate.

`named_values_do_not_change_the_metric_count` was added after the implementation, as a probe that records what the legacy meter does rather than as a red-first invariant.

### The two hardened tests, proved by mutation rather than by red

Commit `4aaa122` changes no production code. It rewrites two tests that named an invariant they could not observe, so they cannot be red against a correct implementation; the gap was in the tests, and the proof is that each now fails when the code it describes is removed. Both mutations were applied to a clean tree, built, run, and reverted.

| Mutation | Test | Before | After |
| --- | --- | --- | --- |
| Delete `.filter(schema::report_benchmark::parameter_id.eq(parameter_id))` from `detector/data.rs` | `baselines_separate_by_parameter` | passed | fails, `left: []` against `right: [({"size_mb": 16}, "value")]` |
| Delete `schema::parameter::id` from the results `ORDER BY` in `report/mod.rs` | `report_response_echoes_named_values_and_separates_grid_points` | passed | fails, `left: 4` against `right: 2` results |

Unmutated, every test in the file passes.

### This round: the migration backfill, and the ceiling

Two more commits, in that order.

`Rate limit parameter creation per project` follows the red-first rule literally. The test commit before it posts one report over the ceiling and expects the refusal a benchmark name flood already gets; it failed there with `left: 201` against `right: 429`. The test server grew a creation limit knob in the same commit, because every existing test server has its limits wide open and that is the only way to reach a ceiling without throttling the requests that get there.

`Pin the series migration backfill against a legacy database` cannot be committed red, because it pins behavior that is already correct. The gap it closes is that the existing `backfill_maps_existing_rows_to_the_empty_parameter_set` runs against a database where every migration has already been applied, so its rows are inserted afterwards and the backfill statement never executes against one: deleting the join leaves it green. The new test reverts to the series migration, seeds rows in the shape the old schema had, keyed on testbed, benchmark, and measure with no parameter at all, and re-applies. The empty parameter sets those rows have to land on are the ones Diesel minted rather than ones spelled with `jsonb('{}')` in SQL, which is exactly where the two encodings have to agree. Two mutations stand in for the red commit:

| Mutation of the backfill | Result |
| --- | --- |
| `AND 1 = 0` on the join, so it matches nothing | fails: every legacy row is silently dropped |
| Drop `p.benchmark_id = s.benchmark_id` from the join | fails: every row lands on every benchmark's empty set, four rows where there should be two |

What a dropped row costs in production is worth naming: it is not an error. An organization's active-series count for the current period reads zero until every series reports again, and the upgrade looks clean throughout.

### An earlier round: v0 fold, and a first pass at the value-less measure

Commit `697883d` is tests only. `value_less_measure_is_stored_but_not_echoed` failed there on an assertion, `left: [Some("latency"), Some("throughput")]` against `right: [Some("latency")]`: the measure that named no point estimate was echoed without a `metric`.

`v0_fold_still_folds` rides along in that commit as a probe rather than a red-first invariant, because it pins behavior that is already correct. It is the test the fold ruling was owed: `--fold` is deprecated, not deleted, so a BMF v0 report must fold exactly as it always has. Two BMF v0 iterations with `fold: min` land as one `report_benchmark` row on the benchmark's empty parameter set, carrying the smaller iteration's whole triple, and metering one metric, which is the half of the ruling that says no bill moves. The conversion it covers, `From<FoldableResults> for AdapterResults`, is new in this layer and every folded v0 report passes through it. Two mutations stand in for the red commit:

| Mutation of the fold conversion | Result |
| --- | --- |
| Yield an empty results map, so a folded report lands no rows at all | fails: `left: []` against `right: [({}, 1)]` |
| Key the folded results on a parameter set other than the empty one | fails: the row lands on a minted grid point, `left` carries two parameter sets where there should be one |

Before this test, the first of those mutations left the entire workspace green: a pipeline running `bencher run --fold min` would have landed reports with no metrics, no boundaries, no alerts, and a metric count of zero, at `201` with a green build.

Commit `d515105` is then tests only again, for the counts. `full_and_collapsed_counts_agree_for_a_value_less_measure` failed there on the two counts disagreeing, `measures: 1` from the loaded results against `measures: 2` from the aggregate query, which is the defect the following commit fixes.

Those four commits took the response call in the other direction, leaving a value-less measure out of the results and out of the counts. The round below reverses it. `v0_fold_still_folds` and its mutation evidence stand unchanged.

### This round: a value-less measure is returned

Commit `71e07c5` is tests only, and every hunk in it is inside a `#[cfg(test)]` module or a test binary. How each failed there:

| Test | Red failure |
| --- | --- |
| `value_less_measure_is_stored_billed_and_echoed` | assertion, `left: [Some("latency")]` against `right: [Some("latency"), Some("throughput")]` |
| `full_and_collapsed_counts_agree_for_a_value_less_measure` | assertion, `left: 1` against `right: 2` measures returned |
| `report_table_value_less_measure` | `missing field metric` |

The comment test is red on the wire contract itself rather than on an assertion: it builds its report results from JSON rather than from constructors, precisely because the absent deprecated field is what is under test, so a required `metric` fails it at deserialization.

`v0_measure_response_is_unchanged` rides along in that commit as a probe rather than a red-first invariant, because it pins the compatibility claim, which is already true and has to stay true.

The counts expectation flips deliberately, and it is the one behavior of the earlier round that this reverses rather than extends: a value-less measure is counted because it is returned, so `get_report_counts` drops the `name = 'value'` filter that round added.

The three views a report has of the same measure are asserted together, since the whole point of the change is that they agree: `value_less_measure_is_stored_billed_and_echoed` reads the metric rows that ingest wrote, the `series_last_seen` row that bills them, and the measure the response carries. The legacy metric-count meter is pinned in the same test at one, unchanged, per the decision under billing above.

`bencher_comment` renders such a report without panicking. There is no point estimate to draw, so the measure takes no column in the results table and the report's missing-threshold warning still names it, which is what the code did before the field was ever required.

## Changes to a lower layer's tests

Two are worth a reviewer's attention.

**The single-valued metric equivalence test no longer captures the report response.** `metric_migration.rs` seeds a database in the pre-migration shape, captures the raw bytes of every response that reads a metric, migrates, and captures again. The report response can no longer participate: it is built from the named `metric` rows, and those rows do not exist before the migration, so it has no pre-migration form to compare. It is also not stable across a down-and-up round trip, because the migration mints a fresh uuid for every bound row it recreates and the response now echoes those uuids. Neither is a regression: a server runs its migrations before it serves, and the `value` row, which every reader of the old shape saw, keeps its identity. The perf, metrics, and alerts responses still capture on both sides and still pin the equivalence, since they all read through the `metric_boundary` view whose column list that migration holds unchanged.

**`revert_migration` now reverts down to the metric migration rather than reverting the last one.** The metric migration is no longer last, so reverting only the last one would revert this layer's instead. Same pattern the parameter layer already uses.

## Gates

| Gate | Outcome |
| --- | --- |
| `cargo nextest run` | 2080 passed, 3 skipped |
| `cargo nextest run -p bencher_schema --features plus` | 198 passed |
| `cargo nextest run -p api_projects --features plus` | 205 passed |
| `cargo test --doc` | passed |
| `cargo fmt --check` | clean |
| `cargo clippy --no-deps --all-targets --all-features -- -Dwarnings` | clean |
| `cargo check --no-default-features` | clean |
| `cargo gen-types` | ran; the regenerated `services/api/openapi.json` and `services/console/src/types/bencher.ts` are committed |
| `cargo deny check` | not run; no dependency changed |
| Console typecheck | `tsc --noEmit`, 435 errors with this branch's `bencher.ts` and 435 with the previous commit's, an identical set once line numbers are normalized, so no new error. The console has a pre-existing backlog that this is measured against rather than into |

`bencher_client` and `bencher_cli` build against the regenerated spec, so progenitor accepts the new `JsonParameters` schema (an object whose additional properties are a string, number, or bool).

## One lint suppression

`ApiCounter::description` crossed `clippy::too_many_lines` when the new counter's arm was added, and carries `#[expect(clippy::too_many_lines, reason = "exhaustive match over every counter variant")]`, matching how exhaustive matches are already handled elsewhere in the workspace.

