### PR TITLE
Run the Console against the dev API without a local API

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -61,6 +61,25 @@ Once the application is running, you can access it by visiting
 1. Sign up for an account by entering your name and email address.
 2. Click on the "Confirm Email" link that is provided in the API logs.
 
+### Running the Console Against the Dev API
+
+The steps above run the Console against an API on your own machine, which is
+what you want when you are changing the API or need the "Confirm Email" link
+from its logs.
+
+To work on the Console alone, you can skip running the API and point the
+Console at the deployed dev API instead:
+
+```shell
+cd services/console
+npm run dev:dev-api
+```
+
+The Console is still served from
+[http://localhost:3000](http://localhost:3000), but every request goes to
+`https://dev.api.bencher.dev`, so you need an account on
+[dev.bencher.dev](https://dev.bencher.dev) to log in.
+
 ### Accessing the API
 
 The API is accessible at [http://localhost:6610](http://localhost:6610).

--- a/services/console/package.json
+++ b/services/console/package.json
@@ -14,6 +14,7 @@
 		"setup": "npm run typeshare && npm run wasm && npm run copy",
 		"dev": "npm run setup && export BENCHER_API_URL=http://127.0.0.1:6610 && export OAUTH_GITHUB=true && export OAUTH_GOOGLE=true && astro dev --port 3000",
 		"dev:not-plus": "IS_BENCHER_PLUS=false npm run dev",
+		"dev:dev-api": "npm run setup && export BENCHER_API_URL=https://dev.api.bencher.dev && export OAUTH_GITHUB=true && export OAUTH_GOOGLE=true && astro dev --port 3000",
 		"start": "astro dev --port 3000",
 		"test": "npm run setup && vitest",
 		"build": "export $(cat .env.runtime) && npm run copy && astro build",


### PR DESCRIPTION
Working on the Console alone meant building and running the API too. `npm run
dev` points the Console at `http://127.0.0.1:6610`, and there was no other way
to aim it somewhere else.

`npm run dev:dev-api` serves the same Console on port 3000 against
`https://dev.api.bencher.dev`. It is the fast path for Console-only work: no
Rust build, no local database, and the data is whatever is on
[dev.bencher.dev](https://dev.bencher.dev), so you need an account there to log
in.

Running the API locally stays the right choice when you are changing the API or
need the "Confirm Email" link from its logs. `DEVELOPMENT.md` now documents
both side by side.
