### PR TITLE
Run CI on stacked pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
     branches: [devel, cloud]
     tags: [v**]
   pull_request:
-    branches: [main, cloud, devel]
 
 env:
   GITHUB_REGISTRY: ghcr.io


### PR DESCRIPTION
## Problem

The `pull_request` trigger in `ci.yml` allowlisted `main`, `cloud`, and `devel` as base branches. A pull request based on any other branch matched no trigger at all, so it ran no CI and only Socket reported back. Stacked pull requests sit on top of one another, so every pull request below the top of a stack went unchecked.

The allowlist itself earns its place. A CI run carries secrets, and the allowlist decides which refs can host one. A repository collects stale branches over time, so an open ended trigger hands a secrets bearing run to any branch that is still lying around. Dropping the filter would buy CI on stacked pull requests at that price.

## Design

Work branches live under a `u/<user>/` namespace, and the allowlist gains that namespace instead of going away:

```yaml
  pull_request:
    branches: [main, cloud, devel, 'u/**']
```

The pattern is `u/**` and not `u/*` because a single asterisk does not match a slash, and stacked base names carry slashes, for example `u/ep/benchmark-parameters/parameter-table`.

## What enforces the namespace

A branch ruleset on `refs/heads/u/**` restricts creation, update, and deletion to actors that hold the Write role and to the HQueueAI app. A stale or untrusted `u/` branch cannot appear, so the namespace stays as controlled as the branches already on the list.

## What does not change

The `push` triggers still fire only on `devel`, `cloud`, and `v**` tags. `workflow_dispatch` is untouched. CI's downstream workflows are all `workflow_call` reusable and need no edit.
