### PR TITLE
Cap landing page section width on wide screens

### DIFF
--- a/services/console/src/styles/_landing.scss
+++ b/services/console/src/styles/_landing.scss
@@ -49,6 +49,16 @@
   }
 }
 
+// Cap the marketing sections on wide screens. 1344px total minus the 6rem
+// side padding at >= 1216px leaves an 1152px content column, the same as
+// Bulma's .container at widescreen.
+.landing-section,
+.hero-landing,
+.cta-section {
+  max-width: 1344px;
+  margin-inline: auto;
+}
+
 .landing-eyebrow {
   font-size: 0.85rem;
   font-weight: 600;


### PR DESCRIPTION
The landing page has no width cap. On a widescreen monitor, every section stretches the full viewport.

## Change

One rule in `_landing.scss` caps the marketing sections and centers them:

```scss
.landing-section,
.hero-landing,
.cta-section {
  max-width: 1344px;
  margin-inline: auto;
}
```

## The cap value

1344px is Bulma's `.container` width at fullhd. With the existing 6rem side padding at >= 1216px, the content column is 1152px, the same as Bulma's `.container` at widescreen. The alternative is 1536px, which gives a 1344px content column and matches `.container` at fullhd. 1344px is the recommendation: the landing content is a two column layout that reads better at 1152px.

## Scope

- `.landing-section` is also used by the `/hyperfine` and `/rust/*` marketing pages. The cap aligns those sections with the adjacent Bulma `.container` content on the same pages.
- `.cta-section` renders on the docs and learn pages inside a `.column.is-two-thirds`. Its content is internally capped and centered, so the rule changes nothing visible there.
- No capped section has a full bleed background, so no seam appears.

## Verification

- `npm run fmt` and `npm run lint` pass with no drift.
- `npm run check` reports the same 758 pre-existing diagnostics as `devel`; the diff of the diagnostic sets is empty.
- Dev server at 2560px: all 3 section classes compute `max-width: 1344px` and center with even margins. At 1366px the cap is a 22px difference; at 375px nothing changes; no horizontal scroll at any width.
