### PR TITLE
Update h2 to 0.4.18 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4306,9 +4306,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Summary

The **Cargo Deny Advisories** CI job is failing on `devel` on a newly published RustSec advisory.

[RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258) ([GHSA-q83h-524g-xf6h](https://github.com/hyperium/hyper/security/advisories/GHSA-q83h-524g-xf6h)): `h2` accepts and queues empty DATA frames without limit, which can lead to unbounded memory usage, or a panic if the length overflows. Low severity, patched in `0.4.16`.

`h2` is only a transitive dependency (`hyper`, `reqwest`, `aws-smithy-http-client`), so this is a `Cargo.lock` only change: `h2` `0.4.14` -> `0.4.18`.

Applied as a minimal lockfile edit. A plain `cargo update -p h2` also re-unifies six unrelated `windows-sys` dependency edges (`errno`, `is-terminal`, `rustix`, `rustls-platform-verifier`, `tempfile`, `winapi-util`) down from `0.61.2` to `0.52.0`. Those are left untouched.

## Verification

- `cargo deny --locked check advisories` -> `advisories ok`
- `cargo metadata --locked` -> clean, the lockfile still resolves

