### PR TITLE
Repin moving action tags after they moved upstream

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -31,7 +31,7 @@ runs:
           ${{ runner.os }}-${{ runner.arch }}-cargo-
 
     - name: Setup mold linker
-      uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
       with:
         mold-version: ${{ inputs.mold-version }}
 

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
         with:
           mold-version: ${{ env.MOLD_VERSION }}
       - name: Install `bencher` CLI

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -292,7 +292,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ env.CLI_BIN_NAME }}-${{ env.CLI_VERSION }}-${{ matrix.build }}
-      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
         with:
           mold-version: ${{ inputs.mold-version }}
       - name: Build .deb package

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,7 +143,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: npx wrangler deploy --env dev
-      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
         with:
           mold-version: ${{ inputs.mold-version }}
       - name: Run Console Dev Test
@@ -176,7 +176,7 @@ jobs:
       - name: Deploy Litestream API to Fly.io Test
         working-directory: ./services/api
         run: flyctl deploy --local-only --config fly/fly.test.toml --wait-timeout 300
-      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
         with:
           mold-version: ${{ inputs.mold-version }}
       - name: Run Smoke Test
@@ -250,7 +250,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: npx wrangler deploy --env ""
-      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
         with:
           mold-version: ${{ inputs.mold-version }}
       - name: Run Console Test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
         with:
           mold-version: ${{ inputs.mold-version }}
       - name: Generate OpenAPI Spec

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
         if: matrix.os == 'ubuntu-22.04'
         with:
           mold-version: ${{ inputs.mold-version }}
@@ -182,7 +182,7 @@ jobs:
             ${GITHUB_IMAGE}:${{ github.sha }}
 
       # Generate release notes and publish
-      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
         with:
           mold-version: ${{ inputs.mold-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
         with:
           mold-version: ${{ inputs.mold-version }}
       - name: Install cargo-nextest
@@ -96,7 +96,7 @@ jobs:
         with:
           cache-key: api
           mold-version: ${{ inputs.mold-version }}
-      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
         if: ${{ inputs.is-fork }}
         with:
           mold-version: ${{ inputs.mold-version }}
@@ -215,7 +215,7 @@ jobs:
         with:
           cache-key: nightly
           mold-version: ${{ inputs.mold-version }}
-      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
         if: ${{ inputs.is-fork }}
         with:
           mold-version: ${{ inputs.mold-version }}
@@ -239,7 +239,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
         with:
           mold-version: ${{ inputs.mold-version }}
       - name: cargo check
@@ -274,7 +274,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
         with:
           mold-version: ${{ inputs.mold-version }}
       - name: Run Smoke Test

--- a/.github/workflows/update_sandbox.yml
+++ b/.github/workflows/update_sandbox.yml
@@ -15,10 +15,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked] this job commits and force-pushes the update/sandbox branch, so it needs the persisted GITHUB_TOKEN
         with:
           ref: devel
-      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: stable
-      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
         with:
           mold-version: "2.34.1"
       - name: Update sandbox dependencies


### PR DESCRIPTION
## Problem

`Lint / Zizmor Online` fails on every pull request with 16 medium `ref-version-mismatch` findings, exit 13. The job is `continue-on-error`, so this is red noise rather than a merge blocker, but it hides any real finding that lands later.

Both pins name a moving ref in the trailing comment, and upstream moved that ref out from under the hash. The audit is online only, which is why the offline `Zizmor` job stays green.

## Change

- **`rui314/setup-mold`, 15 sites.** The `v1` tag now points at `7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3` ("Update default version to 2.42.0"), not the pinned `9c9c13bf`.
- **`dtolnay/rust-toolchain`, 1 site in `update_sandbox.yml`.** This one was not in the original report but is the same audit, and without it the job stays red. The comment said `# master`, and `master` moved off the pinned `fa04a145`. The hash now points at `6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772` with a `# v1` comment. Upstream `v1` and `master` are the same commit today, and `v1` is the convention every other pin in this repo uses, so this one does not go stale on the next upstream push.

Both hashes were resolved from the GitHub refs API rather than copied from a release page.

## Proof

zizmor 1.29.0 locally, against CI's pinned v1.25.2, so CI has the final word.

- Base tree, online: 315 findings, 16 medium, exit 13
- This tree, online: 283 findings, 0 medium, exit 12

The 3 remaining low `adhoc-packages` findings predate this change and are untouched. They are also present in the offline run, which passes CI today, so low findings do not fail the job. Zero medium is the green condition.
