### PR TITLE
Make the metric single valued

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,7 @@ dependencies = [
  "bencher_rbac",
  "bencher_schema",
  "diesel",
+ "diesel_migrations",
  "dropshot",
  "futures",
  "http 1.4.1",
@@ -263,6 +264,7 @@ dependencies = [
  "serde_json",
  "slog",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/lib/api_projects/Cargo.toml
+++ b/lib/api_projects/Cargo.toml
@@ -33,8 +33,10 @@ bencher_api_tests.workspace = true
 bencher_json = { workspace = true, features = ["server", "schema", "plus"] }
 bencher_schema.workspace = true
 diesel.workspace = true
+diesel_migrations.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+uuid.workspace = true
 
 [lints]
 workspace = true

--- a/lib/api_projects/src/lib.rs
+++ b/lib/api_projects/src/lib.rs
@@ -2,9 +2,13 @@
 #[cfg(test)]
 use bencher_api_tests as _;
 #[cfg(test)]
+use diesel_migrations as _;
+#[cfg(test)]
 use serde_json as _;
 #[cfg(test)]
 use tokio as _;
+#[cfg(test)]
+use uuid as _;
 
 pub mod alerts;
 mod allowed;

--- a/lib/api_projects/src/metrics.rs
+++ b/lib/api_projects/src/metrics.rs
@@ -222,7 +222,6 @@ fn metric_query_json(
     let (threshold, alert) = threshold_model_alert(project, tma);
     let (metric, boundary) = QueryMetricBoundary::split(query_metric_boundary);
     let metric_uuid = metric.uuid;
-    let metric = metric.into_json();
     let boundary = boundary.map(QueryBoundary::into_json);
 
     Ok(JsonOneMetric {

--- a/lib/api_projects/src/perf/mod.rs
+++ b/lib/api_projects/src/perf/mod.rs
@@ -513,7 +513,6 @@ fn new_perf_metric(
 
     let (threshold, alert) = threshold_model_alert(project, tma);
     let (metric, boundary) = QueryMetricBoundary::split(query_metric_boundary);
-    let metric = metric.into_json();
     let boundary = boundary.map(QueryBoundary::into_json);
 
     JsonPerfMetric {

--- a/lib/api_projects/tests/metric_migration.rs
+++ b/lib/api_projects/tests/metric_migration.rs
@@ -277,9 +277,8 @@ async fn migration_explodes_the_metric_triple_into_named_rows() {
     }
 
     // The minted uuids are v7 shaped: a millisecond prefix taken once for the whole
-    // migration, random thereafter. At production volume that is what keeps the new
-    // rows appending to the right edge of the uuid index instead of scattering across
-    // every page of it.
+    // migration, random thereafter, so every row minted by one run of the migration
+    // carries the instant that run happened at.
     let minted: Vec<String> = schema::metric::table
         .filter(schema::metric::name.ne(MetricName::value()))
         .select(schema::metric::uuid)
@@ -362,8 +361,8 @@ async fn migration_down_and_up_round_trips_the_metric_triple() {
     assert_eq!(
         sql_names(&mut conn, METRIC_INDEXES_SQL),
         vec![
-            "sqlite_autoindex_metric_1".to_owned(),
-            "sqlite_autoindex_metric_2".to_owned()
+            "index_metric_report_benchmark_measure_name".to_owned(),
+            "index_metric_uuid".to_owned()
         ],
         "the metric table's unique indexes are back"
     );
@@ -714,7 +713,8 @@ const VIEW_COLUMNS: [&str; 14] = [
     "upper_limit",
 ];
 
-/// The indexes on `metric`. Both are implicit, minted by its unique constraints.
+/// The indexes on `metric`. Both are named, built by the migration once its rows
+/// are in place rather than declared as constraints on the table.
 const METRIC_INDEXES_SQL: &str =
     "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'metric' ORDER BY name";
 /// The rebuilt view's columns, in declaration order.

--- a/lib/api_projects/tests/metric_migration.rs
+++ b/lib/api_projects/tests/metric_migration.rs
@@ -30,7 +30,7 @@ use bencher_schema::{MIGRATIONS, context::DbConnection, schema};
 use diesel::{
     ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _,
     connection::SimpleConnection as _,
-    sql_types::{Double, Integer, Nullable, Text},
+    sql_types::{BigInt, Double, Integer, Nullable, Text},
 };
 use diesel_migrations::MigrationHarness as _;
 use http::StatusCode;
@@ -95,6 +95,14 @@ const FIXTURE_METRICS: [LegacyMetric; 4] = [
     },
 ];
 
+/// The ids the fixture metrics are seeded with, deliberately not contiguous.
+///
+/// Real metric ids have gaps in them, because deleting a report cascades its
+/// metrics away. A fixture numbered from one cannot tell a migration that keeps
+/// every id from one that reassigns them, since `INSERT ... SELECT` into an empty
+/// table hands back the same numbering either way.
+const FIXTURE_METRIC_IDS: [i32; 4] = [10, 20, 30, 40];
+
 // Every response that reads a metric is byte identical across the migration.
 #[tokio::test]
 async fn responses_are_byte_identical_across_the_migration() {
@@ -132,7 +140,7 @@ async fn responses_are_byte_identical_across_the_migration() {
 #[tokio::test]
 async fn migration_explodes_the_metric_triple_into_named_rows() {
     let server = TestServer::new().await;
-    let _fixture = seed_legacy_project(&server, "explode").await;
+    let fixture = seed_legacy_project(&server, "explode").await;
 
     let mut conn = server.db_conn();
     let legacy_ids: Vec<(i32, String)> = schema::metric::table
@@ -140,6 +148,15 @@ async fn migration_explodes_the_metric_triple_into_named_rows() {
         .select((schema::metric::id, schema::metric::uuid))
         .load(&mut conn)
         .expect("Failed to read the legacy metric rows");
+    assert_eq!(
+        legacy_ids
+            .iter()
+            .map(|(id, _)| *id)
+            .collect::<Vec<_>>()
+            .as_slice(),
+        FIXTURE_METRIC_IDS.as_slice(),
+        "the fixture is seeded with the gaps that make the identity check bite"
+    );
     let boundary_metric_ids: Vec<i32> = schema::boundary::table
         .order(schema::boundary::id)
         .select(schema::boundary::metric_id)
@@ -211,6 +228,35 @@ async fn migration_explodes_the_metric_triple_into_named_rows() {
         "no boundary row is rewritten: it already points at the value row"
     );
 
+    // An unrewritten `metric_id` is only worth something if it still resolves to the
+    // measurement the boundary was computed against. Renumbering the rows would leave
+    // this pointer intact and silently move it onto a different metric.
+    let first_metric_uuid = fixture
+        .metric_uuids
+        .first()
+        .expect("the fixture seeds at least one metric");
+    let first_metric = FIXTURE_METRICS[0];
+    for metric_id in &remapped {
+        let (uuid, name, value): (String, MetricName, f64) = schema::metric::table
+            .filter(schema::metric::id.eq(metric_id))
+            .select((
+                schema::metric::uuid,
+                schema::metric::name,
+                schema::metric::value,
+            ))
+            .first(&mut conn)
+            .expect("Failed to resolve the boundary's metric");
+        assert_eq!(
+            (uuid.as_str(), &name, value),
+            (
+                first_metric_uuid.to_string().as_str(),
+                &MetricName::value(),
+                first_metric.value
+            ),
+            "the boundary still resolves to the measurement it was created against"
+        );
+    }
+
     let named_uuids: Vec<String> = schema::metric::table
         .select(schema::metric::uuid)
         .load(&mut conn)
@@ -229,28 +275,178 @@ async fn migration_explodes_the_metric_triple_into_named_rows() {
             "minted uuid {uuid} is a uuid"
         );
     }
+
+    // The minted uuids are v7 shaped: a millisecond prefix taken once for the whole
+    // migration, random thereafter. At production volume that is what keeps the new
+    // rows appending to the right edge of the uuid index instead of scattering across
+    // every page of it.
+    let minted: Vec<String> = schema::metric::table
+        .filter(schema::metric::name.ne(MetricName::value()))
+        .select(schema::metric::uuid)
+        .load(&mut conn)
+        .expect("Failed to read the minted uuids");
+    assert!(!minted.is_empty(), "the fixture mints bound rows");
+    for uuid in &minted {
+        let parsed = uuid.parse::<uuid::Uuid>().expect("minted uuid is a uuid");
+        assert_eq!(parsed.get_version_num(), 7, "minted uuid {uuid} is v7");
+        assert_eq!(
+            parsed.get_variant(),
+            uuid::Variant::RFC4122,
+            "minted uuid {uuid} carries the RFC 4122 variant"
+        );
+    }
+
+    let prefixes: Vec<&str> = {
+        let mut prefixes: Vec<&str> = minted
+            .iter()
+            .map(|uuid| uuid.get(..13).expect("a uuid is longer than its prefix"))
+            .collect();
+        prefixes.sort_unstable();
+        prefixes.dedup();
+        prefixes
+    };
+    let [prefix] = prefixes.as_slice() else {
+        panic!("every minted uuid shares one millisecond prefix, got {prefixes:?}");
+    };
+    let millis = u64::from_str_radix(&prefix.replace('-', ""), 16)
+        .expect("the millisecond prefix is hexadecimal");
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("the clock is after the epoch")
+        .as_millis();
+    assert!(
+        (1_700_000_000_000..=u64::try_from(now).expect("now fits")).contains(&millis),
+        "the prefix is the migration's own millisecond, got {millis}"
+    );
 }
 
 // Reverting and re-applying the migration is a round trip: the metric triple that
 // goes down comes back up unchanged.
+//
+// Every capture is anchored against the pre-migration one rather than against its
+// predecessor, so an error that the revert and the re-apply make symmetrically
+// cannot cancel itself out.
 #[tokio::test]
 async fn migration_down_and_up_round_trips_the_metric_triple() {
     let server = TestServer::new().await;
     let fixture = seed_legacy_project(&server, "roundtrip").await;
-    apply_migration(&server);
 
+    let before = capture(&server, &fixture).await;
+    apply_migration(&server);
     let after_first = capture(&server, &fixture).await;
+    assert_eq!(
+        before, after_first,
+        "applying the migration leaves every response unchanged"
+    );
 
     let mut conn = server.db_conn();
     revert_migration(&mut conn);
     drop(conn);
-    apply_migration(&server);
 
+    let after_revert = capture(&server, &fixture).await;
+    assert_eq!(
+        before, after_revert,
+        "reverting the migration leaves every response unchanged"
+    );
+
+    apply_migration(&server);
     let after_round_trip = capture(&server, &fixture).await;
     assert_eq!(
-        after_first, after_round_trip,
+        before, after_round_trip,
         "a down and up round trip leaves every response unchanged"
     );
+
+    // The responses can only be trusted if the schema they were served from is the
+    // schema the code compiles against, so the round trip also has to land back on it.
+    let mut conn = server.db_conn();
+    assert_eq!(
+        sql_names(&mut conn, METRIC_INDEXES_SQL),
+        vec![
+            "sqlite_autoindex_metric_1".to_owned(),
+            "sqlite_autoindex_metric_2".to_owned()
+        ],
+        "the metric table's unique indexes are back"
+    );
+    assert_eq!(
+        sql_names(&mut conn, VIEW_COLUMNS_SQL),
+        VIEW_COLUMNS,
+        "the rebuilt view has the column list view.rs declares"
+    );
+    let foreign_key_check: Vec<SqlCount> =
+        diesel::sql_query("SELECT count(*) AS count FROM pragma_foreign_key_check()")
+            .load(&mut conn)
+            .expect("Failed to run the foreign key check");
+    assert_eq!(
+        foreign_key_check.first().map(|row| row.count),
+        Some(0),
+        "no foreign key is left dangling"
+    );
+    let integrity_check: Vec<IntegrityCheck> =
+        diesel::sql_query("SELECT * FROM pragma_integrity_check()")
+            .load(&mut conn)
+            .expect("Failed to run the integrity check");
+    assert_eq!(
+        integrity_check
+            .iter()
+            .map(|row| row.integrity_check.as_str())
+            .collect::<Vec<_>>(),
+        vec!["ok"],
+        "the database is intact"
+    );
+}
+
+// Two named rows under one measurement coexist; the same name twice collides.
+#[tokio::test]
+async fn named_rows_are_unique_per_measurement() {
+    let server = TestServer::new().await;
+    let fixture = seed_legacy_project(&server, "unique").await;
+    apply_migration(&server);
+
+    let mut conn = server.db_conn();
+    // The last fixture metric carries neither bound, so both bound names are free.
+    let last_metric_uuid = fixture
+        .metric_uuids
+        .last()
+        .expect("the fixture seeds at least one metric");
+    let (report_benchmark_id, measure_id): (i32, i32) = schema::metric::table
+        .filter(schema::metric::uuid.eq(last_metric_uuid))
+        .select((
+            schema::metric::report_benchmark_id,
+            schema::metric::measure_id,
+        ))
+        .first(&mut conn)
+        .expect("Failed to read the unbounded metric");
+
+    let mut insert = |name: MetricName| {
+        diesel::insert_into(schema::metric::table)
+            .values((
+                schema::metric::uuid.eq(MetricUuid::new()),
+                schema::metric::report_benchmark_id.eq(report_benchmark_id),
+                schema::metric::measure_id.eq(measure_id),
+                schema::metric::name.eq(name),
+                schema::metric::value.eq(1.0),
+            ))
+            .execute(&mut conn)
+    };
+
+    let p50: MetricName = "p50".parse().expect("p50 is a metric name");
+    let p99: MetricName = "p99".parse().expect("p99 is a metric name");
+    insert(p50.clone()).expect("a named row lands beside the point estimate");
+    insert(p99.clone()).expect("a second name lands beside the first");
+
+    for name in [p99, MetricName::value()] {
+        let collision = insert(name.clone()).expect_err("the same name twice collides");
+        assert!(
+            matches!(
+                collision,
+                diesel::result::Error::DatabaseError(
+                    diesel::result::DatabaseErrorKind::UniqueViolation,
+                    _
+                )
+            ),
+            "{name} collides on the unique constraint, got {collision:?}"
+        );
+    }
 }
 
 // Ingest writes the metric triple as named rows, and the report it answers with is
@@ -326,6 +522,154 @@ async fn ingest_writes_the_metric_triple_as_named_rows() {
     );
 }
 
+/// The point estimates a threshold's sample is built from.
+const HISTORY: [f64; 5] = [10.0, 11.0, 12.0, 13.0, 14.0];
+/// The bounds carried alongside them, nowhere near the estimates on purpose: a
+/// sample that swept them in could not possibly compute the same limits.
+const HISTORY_LOWER: f64 = 1_000.0;
+const HISTORY_UPPER: f64 = 2_000.0;
+/// The value of the report the boundary is read from, mid history and bare.
+const HISTORY_FINAL: f64 = 12.0;
+
+// Threshold detection samples the point estimates and nothing else.
+//
+// `lower_value` and `upper_value` are ordinary named rows under the same measure
+// now, so a sample taken without a name filter would take its mean and standard
+// deviation over a mixture of measurements and previously computed limits, and
+// would fill a bounded sample size with a third of the history it was asked for.
+// Two projects with the same point estimates must produce the same boundary,
+// whether or not their history carries bounds.
+#[tokio::test]
+async fn detection_samples_only_the_point_estimates() {
+    let server = TestServer::new().await;
+
+    let bare = detection_boundary(&server, "bare", false).await;
+    let bounded = detection_boundary(&server, "bounded", true).await;
+
+    assert!(
+        bare.get("lower_limit")
+            .is_some_and(|limit| !limit.is_null())
+            && bare
+                .get("upper_limit")
+                .is_some_and(|limit| !limit.is_null()),
+        "the fixture computes a boundary with both limits, got {bare}"
+    );
+    assert_eq!(
+        bare, bounded,
+        "the bound rows do not reach the threshold's sample"
+    );
+}
+
+/// Seed a project with a threshold and a history of `HISTORY`, then return the
+/// boundary computed for one more report of the same measurement.
+///
+/// With `bounded`, every historical metric carries the conventional bounds, which
+/// land as their own named rows. The final report is bare either way, so the only
+/// thing that differs between the two projects is the history the detector reads.
+async fn detection_boundary(server: &TestServer, label: &str, bounded: bool) -> serde_json::Value {
+    let user = server
+        .signup("Test User", &format!("detect{label}@example.com"))
+        .await;
+    let org = server
+        .create_org(&user, &format!("Detect Org {label}"))
+        .await;
+    let project = server
+        .create_project(&user, &org, &format!("Detect Project {label}"))
+        .await;
+    let project_slug = project.slug.to_string();
+
+    let post = async |path: String, body: serde_json::Value| {
+        server
+            .client
+            .post(server.api_url(&path))
+            .header(
+                bencher_json::AUTHORIZATION,
+                bencher_json::bearer_header(&user.token),
+            )
+            .json(&body)
+            .send()
+            .await
+            .expect("Request failed")
+    };
+
+    // The threshold names its branch, testbed, and measure, so they exist before it.
+    for (resource, body) in [
+        (
+            "branches",
+            serde_json::json!({ "name": "detect-branch", "slug": "detect-branch" }),
+        ),
+        (
+            "testbeds",
+            serde_json::json!({ "name": "detect-testbed", "slug": "detect-testbed" }),
+        ),
+        (
+            "measures",
+            serde_json::json!({ "name": "latency", "slug": "latency", "units": "ns" }),
+        ),
+    ] {
+        let resp = post(
+            format!("/v0/projects/{project_slug}/{resource}"),
+            body.clone(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CREATED, "POST {resource}");
+    }
+
+    let resp = post(
+        format!("/v0/projects/{project_slug}/thresholds"),
+        serde_json::json!({
+            "branch": "detect-branch",
+            "testbed": "detect-testbed",
+            "measure": "latency",
+            "test": "t_test",
+            "min_sample_size": 2,
+            "max_sample_size": 64,
+            "lower_boundary": 0.98,
+            "upper_boundary": 0.98,
+        }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::CREATED, "POST thresholds");
+
+    let report = async |day: usize, metric: serde_json::Value| {
+        let results = serde_json::json!({ "detect-benchmark": { "latency": metric } });
+        let body = serde_json::json!({
+            "branch": "detect-branch",
+            "testbed": "detect-testbed",
+            "start_time": format!("2024-01-{day:02}T00:00:00Z"),
+            "end_time": format!("2024-01-{day:02}T00:01:00Z"),
+            "results": [serde_json::to_string(&results).expect("the results serialize")],
+        });
+        let resp = post(format!("/v0/projects/{project_slug}/reports"), body).await;
+        assert_eq!(resp.status(), StatusCode::CREATED, "POST report {day}");
+        resp.json::<serde_json::Value>()
+            .await
+            .expect("Failed to parse the report")
+    };
+
+    for (day, value) in HISTORY.into_iter().enumerate() {
+        let metric = if bounded {
+            serde_json::json!({
+                "value": value,
+                "lower_value": HISTORY_LOWER,
+                "upper_value": HISTORY_UPPER,
+            })
+        } else {
+            serde_json::json!({ "value": value })
+        };
+        report(day + 1, metric).await;
+    }
+
+    let last = report(
+        HISTORY.len() + 1,
+        serde_json::json!({ "value": HISTORY_FINAL }),
+    )
+    .await;
+    last.pointer("/results/0/0/measures/0/boundary")
+        .expect("the report echoes its boundary")
+        .clone()
+}
+
 /// Run the single valued metric migration on the test server's database.
 ///
 /// Foreign keys cannot be toggled inside a transaction and Diesel runs each
@@ -350,6 +694,58 @@ fn revert_migration(conn: &mut DbConnection) {
         .expect("Failed to revert the single valued metric migration");
     conn.batch_execute("PRAGMA foreign_keys = ON")
         .expect("Failed to enable foreign keys");
+}
+
+/// The `metric_boundary` column list, in the order `view.rs` declares it.
+const VIEW_COLUMNS: [&str; 14] = [
+    "metric_id",
+    "metric_uuid",
+    "report_benchmark_id",
+    "measure_id",
+    "value",
+    "lower_value",
+    "upper_value",
+    "boundary_id",
+    "boundary_uuid",
+    "threshold_id",
+    "model_id",
+    "baseline",
+    "lower_limit",
+    "upper_limit",
+];
+
+/// The indexes on `metric`. Both are implicit, minted by its unique constraints.
+const METRIC_INDEXES_SQL: &str =
+    "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'metric' ORDER BY name";
+/// The rebuilt view's columns, in declaration order.
+const VIEW_COLUMNS_SQL: &str = "SELECT name FROM pragma_table_info('metric_boundary') ORDER BY cid";
+
+#[derive(diesel::QueryableByName)]
+struct SqlName {
+    #[diesel(sql_type = Text)]
+    name: String,
+}
+
+#[derive(diesel::QueryableByName)]
+struct SqlCount {
+    #[diesel(sql_type = BigInt)]
+    count: i64,
+}
+
+#[derive(diesel::QueryableByName)]
+struct IntegrityCheck {
+    #[diesel(sql_type = Text)]
+    integrity_check: String,
+}
+
+/// Run a query that returns one `name` column and collect it.
+fn sql_names(conn: &mut DbConnection, query: &str) -> Vec<String> {
+    diesel::sql_query(query)
+        .load::<SqlName>(conn)
+        .expect("Failed to read the schema")
+        .into_iter()
+        .map(|row| row.name)
+        .collect()
 }
 
 /// Seed a project whose metrics are stored in the pre-migration shape.
@@ -550,12 +946,19 @@ async fn seed_legacy_project(server: &TestServer, label: &str) -> Fixture {
 
     // The metrics go in through raw SQL: the columns they are written to are the
     // columns the pre-migration table had, which the compiled schema no longer names.
+    // The ids are given explicitly and with gaps, so that a migration that renumbers
+    // the rows it carries over is visible rather than accidentally right.
     let mut metric_uuids = Vec::new();
-    for ((report_benchmark_id, measure_id), metric) in grid.into_iter().zip(FIXTURE_METRICS) {
+    for (((report_benchmark_id, measure_id), metric), metric_id) in grid
+        .into_iter()
+        .zip(FIXTURE_METRICS)
+        .zip(FIXTURE_METRIC_IDS)
+    {
         let metric_uuid = MetricUuid::new();
         diesel::sql_query(
-            "INSERT INTO metric (uuid, report_benchmark_id, measure_id, value, lower_value, upper_value) VALUES (?, ?, ?, ?, ?, ?)",
+            "INSERT INTO metric (id, uuid, report_benchmark_id, measure_id, value, lower_value, upper_value) VALUES (?, ?, ?, ?, ?, ?, ?)",
         )
+        .bind::<Integer, _>(metric_id)
         .bind::<Text, _>(metric_uuid.to_string())
         .bind::<Integer, _>(report_benchmark_id)
         .bind::<Integer, _>(measure_id)

--- a/lib/api_projects/tests/metric_migration.rs
+++ b/lib/api_projects/tests/metric_migration.rs
@@ -326,46 +326,6 @@ async fn ingest_writes_the_metric_triple_as_named_rows() {
     );
 }
 
-// A bounded metric is one measurement, not three: the billable count does not move
-// when the triple becomes three rows.
-#[tokio::test]
-async fn usage_counts_a_bounded_metric_once() {
-    let server = TestServer::new().await;
-    let fixture = seed_legacy_project(&server, "usage").await;
-    apply_migration(&server);
-
-    let resp = server
-        .client
-        .get(server.api_url(&format!(
-            "/v0/projects/{}/metrics/{}",
-            fixture.project_slug,
-            fixture
-                .metric_uuids
-                .first()
-                .expect("the fixture seeds at least one metric")
-        )))
-        .header(
-            bencher_json::AUTHORIZATION,
-            bencher_json::bearer_header(&fixture.token),
-        )
-        .send()
-        .await
-        .expect("Request failed");
-    assert_eq!(resp.status(), StatusCode::OK);
-
-    let mut conn = server.db_conn();
-    let value_rows: i64 = schema::metric::table
-        .filter(schema::metric::name.eq(MetricName::value()))
-        .count()
-        .get_result(&mut conn)
-        .expect("Failed to count the value rows");
-    assert_eq!(
-        usize::try_from(value_rows).expect("row count fits"),
-        FIXTURE_METRICS.len(),
-        "usage counts one row per measurement, whatever its bounds"
-    );
-}
-
 /// Run the single valued metric migration on the test server's database.
 ///
 /// Foreign keys cannot be toggled inside a transaction and Diesel runs each

--- a/lib/api_projects/tests/metric_migration.rs
+++ b/lib/api_projects/tests/metric_migration.rs
@@ -1,0 +1,803 @@
+#![cfg(feature = "plus")]
+#![expect(
+    unused_crate_dependencies,
+    clippy::expect_used,
+    clippy::tests_outside_test_module,
+    clippy::too_many_lines,
+    reason = "integration test file"
+)]
+//! The single-valued metric migration, pinned by captured response bytes.
+//!
+//! A migration that rebuilds the metric table is only safe if it is invisible from
+//! the outside. That is not a claim to assert, it is a thing to demonstrate: these
+//! tests seed a database in the shape the migration finds, capture the raw bytes of
+//! every response that reads a metric, run the migration, and capture them again.
+//! The two captures must be equal byte for byte.
+//!
+//! The same binary serves both captures because every reader goes through the
+//! `metric_boundary` view, whose column list the migration holds unchanged.
+
+use bencher_api_tests::{
+    TestServer,
+    helpers::{base_timestamp, create_empty_parameter, get_project_id},
+};
+use bencher_json::{
+    AlertUuid, BenchmarkUuid, BoundaryUuid, BranchUuid, HeadUuid, MeasureUuid, MetricName,
+    MetricUuid, ModelUuid, ReportBenchmarkUuid, ReportUuid, TestbedUuid, ThresholdUuid,
+    VersionUuid, project::alert::AlertStatus, project::boundary::BoundaryLimit,
+};
+use bencher_schema::{MIGRATIONS, context::DbConnection, schema};
+use diesel::{
+    ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _,
+    connection::SimpleConnection as _,
+    sql_types::{Double, Integer, Nullable, Text},
+};
+use diesel_migrations::MigrationHarness as _;
+use http::StatusCode;
+
+/// A metric as the pre-migration table held it: one row, three columns.
+#[derive(Debug, Clone, Copy)]
+struct LegacyMetric {
+    value: f64,
+    lower_value: Option<f64>,
+    upper_value: Option<f64>,
+}
+
+/// The seeded project, and every handle a request needs to reach its metrics.
+struct Fixture {
+    project_slug: String,
+    token: String,
+    branch_uuid: BranchUuid,
+    testbed_uuid: TestbedUuid,
+    benchmark_uuid: BenchmarkUuid,
+    measure_uuids: Vec<MeasureUuid>,
+    report_uuid: ReportUuid,
+    metric_uuids: Vec<MetricUuid>,
+}
+
+/// The raw bytes of every response that reads a metric.
+#[derive(Debug, PartialEq, Eq)]
+struct Captured {
+    perf: String,
+    metrics: Vec<String>,
+    report: String,
+    alerts: String,
+}
+
+/// The fixture rows, chosen to reach every branch of the explosion and the pivot.
+///
+/// Both bounds, lower only, upper only, and neither all appear, spread over two
+/// measures and two report benchmarks so that a pivot joining on the wrong key
+/// leaks a bound across a row and fails. The floats are the ones that expose
+/// formatting drift: a value with no exact binary representation, a value that
+/// only survives a round trip with full precision, a subnormal-adjacent exponent,
+/// and negative zero, whose sign is invisible to `==` but not to `to_string`.
+const FIXTURE_METRICS: [LegacyMetric; 4] = [
+    LegacyMetric {
+        value: 42.0,
+        lower_value: Some(40.5),
+        upper_value: Some(44.25),
+    },
+    LegacyMetric {
+        value: 0.1,
+        lower_value: None,
+        upper_value: Some(0.300_000_000_000_000_04),
+    },
+    LegacyMetric {
+        value: 1e-7,
+        lower_value: Some(5.000_000_000_000_001e-8),
+        upper_value: None,
+    },
+    LegacyMetric {
+        value: -0.0,
+        lower_value: None,
+        upper_value: None,
+    },
+];
+
+// Every response that reads a metric is byte identical across the migration.
+#[tokio::test]
+async fn responses_are_byte_identical_across_the_migration() {
+    let server = TestServer::new().await;
+    let fixture = seed_legacy_project(&server, "equiv").await;
+
+    let before = capture(&server, &fixture).await;
+    assert!(
+        before.perf.contains("44.25") && before.alerts.contains("40.5"),
+        "the fixture reaches the perf and alert responses before anything is compared"
+    );
+    apply_migration(&server);
+    let after = capture(&server, &fixture).await;
+
+    assert_eq!(
+        before.perf, after.perf,
+        "the perf response changed across the migration"
+    );
+    assert_eq!(
+        before.metrics, after.metrics,
+        "a metric response changed across the migration"
+    );
+    assert_eq!(
+        before.report, after.report,
+        "the report response changed across the migration"
+    );
+    assert_eq!(
+        before.alerts, after.alerts,
+        "the alerts response changed across the migration"
+    );
+}
+
+// The migration explodes each metric into its named rows, keeping the point
+// estimate's identity so that no boundary row has to be rewritten.
+#[tokio::test]
+async fn migration_explodes_the_metric_triple_into_named_rows() {
+    let server = TestServer::new().await;
+    let _fixture = seed_legacy_project(&server, "explode").await;
+
+    let mut conn = server.db_conn();
+    let legacy_ids: Vec<(i32, String)> = schema::metric::table
+        .order(schema::metric::id)
+        .select((schema::metric::id, schema::metric::uuid))
+        .load(&mut conn)
+        .expect("Failed to read the legacy metric rows");
+    let boundary_metric_ids: Vec<i32> = schema::boundary::table
+        .order(schema::boundary::id)
+        .select(schema::boundary::metric_id)
+        .load(&mut conn)
+        .expect("Failed to read the boundary rows");
+    drop(conn);
+
+    apply_migration(&server);
+
+    let mut conn = server.db_conn();
+    let value_ids: Vec<(i32, String)> = schema::metric::table
+        .filter(schema::metric::name.eq(MetricName::value()))
+        .order(schema::metric::id)
+        .select((schema::metric::id, schema::metric::uuid))
+        .load(&mut conn)
+        .expect("Failed to read the value rows");
+    assert_eq!(
+        value_ids, legacy_ids,
+        "every value row keeps the id and uuid of the row it came from"
+    );
+
+    let expected_rows = FIXTURE_METRICS
+        .iter()
+        .map(|metric| {
+            1 + usize::from(metric.lower_value.is_some())
+                + usize::from(metric.upper_value.is_some())
+        })
+        .sum::<usize>();
+    let rows: i64 = schema::metric::table
+        .count()
+        .get_result(&mut conn)
+        .expect("Failed to count the metric rows");
+    assert_eq!(
+        usize::try_from(rows).expect("row count fits"),
+        expected_rows,
+        "each stored bound becomes its own row and nothing else does"
+    );
+
+    for (name, bound) in [
+        (MetricName::lower_value(), 0),
+        (MetricName::upper_value(), 1),
+    ] {
+        let values: Vec<f64> = schema::metric::table
+            .filter(schema::metric::name.eq(name.clone()))
+            .order(schema::metric::id)
+            .select(schema::metric::value)
+            .load(&mut conn)
+            .expect("Failed to read the bound rows");
+        let expected: Vec<f64> = FIXTURE_METRICS
+            .iter()
+            .filter_map(|metric| {
+                if bound == 0 {
+                    metric.lower_value
+                } else {
+                    metric.upper_value
+                }
+            })
+            .collect();
+        assert_eq!(values, expected, "the {name} rows carry the stored bounds");
+    }
+
+    let remapped: Vec<i32> = schema::boundary::table
+        .order(schema::boundary::id)
+        .select(schema::boundary::metric_id)
+        .load(&mut conn)
+        .expect("Failed to read the boundary rows");
+    assert_eq!(
+        remapped, boundary_metric_ids,
+        "no boundary row is rewritten: it already points at the value row"
+    );
+
+    let named_uuids: Vec<String> = schema::metric::table
+        .select(schema::metric::uuid)
+        .load(&mut conn)
+        .expect("Failed to read the metric uuids");
+    let mut unique = named_uuids.clone();
+    unique.sort_unstable();
+    unique.dedup();
+    assert_eq!(
+        unique.len(),
+        named_uuids.len(),
+        "every minted uuid is distinct"
+    );
+    for uuid in &named_uuids {
+        assert!(
+            uuid.parse::<uuid::Uuid>().is_ok(),
+            "minted uuid {uuid} is a uuid"
+        );
+    }
+}
+
+// Reverting and re-applying the migration is a round trip: the metric triple that
+// goes down comes back up unchanged.
+#[tokio::test]
+async fn migration_down_and_up_round_trips_the_metric_triple() {
+    let server = TestServer::new().await;
+    let fixture = seed_legacy_project(&server, "roundtrip").await;
+    apply_migration(&server);
+
+    let after_first = capture(&server, &fixture).await;
+
+    let mut conn = server.db_conn();
+    revert_migration(&mut conn);
+    drop(conn);
+    apply_migration(&server);
+
+    let after_round_trip = capture(&server, &fixture).await;
+    assert_eq!(
+        after_first, after_round_trip,
+        "a down and up round trip leaves every response unchanged"
+    );
+}
+
+// Ingest writes the metric triple as named rows, and the report it answers with is
+// the report the single row shape answered with.
+#[tokio::test]
+async fn ingest_writes_the_metric_triple_as_named_rows() {
+    let server = TestServer::new().await;
+    let user = server.signup("Test User", "metricingest@example.com").await;
+    let org = server.create_org(&user, "Metric Ingest Org").await;
+    let project = server
+        .create_project(&user, &org, "Metric Ingest Project")
+        .await;
+    let project_slug: &str = project.slug.as_ref();
+
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{project_slug}/reports")))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&user.token),
+        )
+        .json(&serde_json::json!({
+            "branch": "main",
+            "testbed": "localhost",
+            "start_time": "2024-01-01T00:00:00Z",
+            "end_time": "2024-01-01T00:01:00Z",
+            "results": [
+                "{\"bench_one\": {\"latency\": {\"value\": 100.0, \"lower_value\": 90.5, \"upper_value\": 110.25}}, \"bench_two\": {\"latency\": {\"value\": 200.0}}}"
+            ]
+        }))
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let report: serde_json::Value = resp.json().await.expect("Failed to parse the report");
+
+    let bounded = report
+        .pointer("/results/0/0/measures/0/metric")
+        .expect("the report echoes its metric");
+    assert_eq!(
+        bounded
+            .get("lower_value")
+            .and_then(serde_json::Value::as_f64),
+        Some(90.5),
+        "the ingested lower bound comes back on the report"
+    );
+    assert_eq!(
+        bounded
+            .get("upper_value")
+            .and_then(serde_json::Value::as_f64),
+        Some(110.25),
+        "the ingested upper bound comes back on the report"
+    );
+
+    let mut conn = server.db_conn();
+    let mut named: Vec<(String, f64)> = schema::metric::table
+        .select((schema::metric::name, schema::metric::value))
+        .load::<(MetricName, f64)>(&mut conn)
+        .expect("Failed to read the metric rows")
+        .into_iter()
+        .map(|(name, value)| (name.as_ref().to_owned(), value))
+        .collect();
+    named.sort_by(|left, right| left.partial_cmp(right).expect("fixture floats are ordered"));
+    assert_eq!(
+        named,
+        vec![
+            ("lower_value".to_owned(), 90.5),
+            ("upper_value".to_owned(), 110.25),
+            ("value".to_owned(), 100.0),
+            ("value".to_owned(), 200.0),
+        ],
+        "the bounded metric writes three rows and the bare metric writes one"
+    );
+}
+
+// A bounded metric is one measurement, not three: the billable count does not move
+// when the triple becomes three rows.
+#[tokio::test]
+async fn usage_counts_a_bounded_metric_once() {
+    let server = TestServer::new().await;
+    let fixture = seed_legacy_project(&server, "usage").await;
+    apply_migration(&server);
+
+    let resp = server
+        .client
+        .get(server.api_url(&format!(
+            "/v0/projects/{}/metrics/{}",
+            fixture.project_slug,
+            fixture
+                .metric_uuids
+                .first()
+                .expect("the fixture seeds at least one metric")
+        )))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&fixture.token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let mut conn = server.db_conn();
+    let value_rows: i64 = schema::metric::table
+        .filter(schema::metric::name.eq(MetricName::value()))
+        .count()
+        .get_result(&mut conn)
+        .expect("Failed to count the value rows");
+    assert_eq!(
+        usize::try_from(value_rows).expect("row count fits"),
+        FIXTURE_METRICS.len(),
+        "usage counts one row per measurement, whatever its bounds"
+    );
+}
+
+/// Run the single valued metric migration on the test server's database.
+///
+/// Foreign keys cannot be toggled inside a transaction and Diesel runs each
+/// migration in one, so they are disabled around it, exactly as the API server
+/// disables them around startup migrations. Without that, recreating `metric`
+/// would cascade its boundaries away.
+fn apply_migration(server: &TestServer) {
+    let mut conn = server.db_conn();
+    conn.batch_execute("PRAGMA foreign_keys = OFF")
+        .expect("Failed to disable foreign keys");
+    conn.run_pending_migrations(MIGRATIONS)
+        .expect("Failed to apply the single valued metric migration");
+    conn.batch_execute("PRAGMA foreign_keys = ON")
+        .expect("Failed to enable foreign keys");
+}
+
+/// Revert the single valued metric migration on the test server's database.
+fn revert_migration(conn: &mut DbConnection) {
+    conn.batch_execute("PRAGMA foreign_keys = OFF")
+        .expect("Failed to disable foreign keys");
+    conn.revert_last_migration(MIGRATIONS)
+        .expect("Failed to revert the single valued metric migration");
+    conn.batch_execute("PRAGMA foreign_keys = ON")
+        .expect("Failed to enable foreign keys");
+}
+
+/// Seed a project whose metrics are stored in the pre-migration shape.
+///
+/// The migration is reverted before the metric rows go in, so they are written
+/// through raw SQL against the columns that shape had. Everything above the metric
+/// table is untouched by this migration and is seeded normally.
+async fn seed_legacy_project(server: &TestServer, label: &str) -> Fixture {
+    let user = server
+        .signup("Test User", &format!("metric{label}@example.com"))
+        .await;
+    let org = server
+        .create_org(&user, &format!("Metric Org {label}"))
+        .await;
+    let project = server
+        .create_project(&user, &org, &format!("Metric Project {label}"))
+        .await;
+    let project_slug = project.slug.to_string();
+    let project_id = get_project_id(server, &project_slug);
+
+    let mut conn = server.db_conn();
+    revert_migration(&mut conn);
+
+    let now = base_timestamp();
+
+    let testbed_uuid = TestbedUuid::new();
+    diesel::insert_into(schema::testbed::table)
+        .values((
+            schema::testbed::uuid.eq(&testbed_uuid),
+            schema::testbed::project_id.eq(project_id),
+            schema::testbed::name.eq("metric-testbed"),
+            schema::testbed::slug.eq(format!("metric-testbed-{testbed_uuid}")),
+            schema::testbed::created.eq(&now),
+            schema::testbed::modified.eq(&now),
+        ))
+        .execute(&mut conn)
+        .expect("Failed to insert the testbed");
+    let testbed_id: i32 = schema::testbed::table
+        .filter(schema::testbed::uuid.eq(&testbed_uuid))
+        .select(schema::testbed::id)
+        .first(&mut conn)
+        .expect("Failed to get the testbed id");
+
+    let version_uuid = VersionUuid::new();
+    diesel::insert_into(schema::version::table)
+        .values((
+            schema::version::uuid.eq(&version_uuid),
+            schema::version::project_id.eq(project_id),
+            schema::version::number.eq(1),
+        ))
+        .execute(&mut conn)
+        .expect("Failed to insert the version");
+    let version_id: i32 = schema::version::table
+        .filter(schema::version::uuid.eq(&version_uuid))
+        .select(schema::version::id)
+        .first(&mut conn)
+        .expect("Failed to get the version id");
+
+    let branch_uuid = BranchUuid::new();
+    diesel::insert_into(schema::branch::table)
+        .values((
+            schema::branch::uuid.eq(&branch_uuid),
+            schema::branch::project_id.eq(project_id),
+            schema::branch::name.eq("metric-main"),
+            schema::branch::slug.eq(format!("metric-main-{branch_uuid}")),
+            schema::branch::created.eq(&now),
+            schema::branch::modified.eq(&now),
+        ))
+        .execute(&mut conn)
+        .expect("Failed to insert the branch");
+    let branch_id: i32 = schema::branch::table
+        .filter(schema::branch::uuid.eq(&branch_uuid))
+        .select(schema::branch::id)
+        .first(&mut conn)
+        .expect("Failed to get the branch id");
+
+    let head_uuid = HeadUuid::new();
+    diesel::insert_into(schema::head::table)
+        .values((
+            schema::head::uuid.eq(&head_uuid),
+            schema::head::branch_id.eq(branch_id),
+            schema::head::created.eq(&now),
+        ))
+        .execute(&mut conn)
+        .expect("Failed to insert the head");
+    let head_id: i32 = schema::head::table
+        .filter(schema::head::uuid.eq(&head_uuid))
+        .select(schema::head::id)
+        .first(&mut conn)
+        .expect("Failed to get the head id");
+
+    // The perf query, given no explicit head, filters on the branch's current head.
+    diesel::update(schema::branch::table.filter(schema::branch::id.eq(branch_id)))
+        .set(schema::branch::head_id.eq(head_id))
+        .execute(&mut conn)
+        .expect("Failed to set the branch head");
+
+    diesel::insert_into(schema::head_version::table)
+        .values((
+            schema::head_version::head_id.eq(head_id),
+            schema::head_version::version_id.eq(version_id),
+        ))
+        .execute(&mut conn)
+        .expect("Failed to link the head to the version");
+
+    let report_uuid = ReportUuid::new();
+    diesel::insert_into(schema::report::table)
+        .values((
+            schema::report::uuid.eq(&report_uuid),
+            schema::report::project_id.eq(project_id),
+            schema::report::head_id.eq(head_id),
+            schema::report::version_id.eq(version_id),
+            schema::report::testbed_id.eq(testbed_id),
+            schema::report::adapter.eq(0),
+            schema::report::start_time.eq(&now),
+            schema::report::end_time.eq(&now),
+            schema::report::created.eq(&now),
+        ))
+        .execute(&mut conn)
+        .expect("Failed to insert the report");
+    let report_id: i32 = schema::report::table
+        .filter(schema::report::uuid.eq(&report_uuid))
+        .select(schema::report::id)
+        .first(&mut conn)
+        .expect("Failed to get the report id");
+
+    let benchmark_uuid = BenchmarkUuid::new();
+    diesel::insert_into(schema::benchmark::table)
+        .values((
+            schema::benchmark::uuid.eq(&benchmark_uuid),
+            schema::benchmark::project_id.eq(project_id),
+            schema::benchmark::name.eq("metric-benchmark"),
+            schema::benchmark::slug.eq(format!("metric-benchmark-{benchmark_uuid}")),
+            schema::benchmark::created.eq(&now),
+            schema::benchmark::modified.eq(&now),
+        ))
+        .execute(&mut conn)
+        .expect("Failed to insert the benchmark");
+    let benchmark_id: i32 = schema::benchmark::table
+        .filter(schema::benchmark::uuid.eq(&benchmark_uuid))
+        .select(schema::benchmark::id)
+        .first(&mut conn)
+        .expect("Failed to get the benchmark id");
+    let parameter_id = create_empty_parameter(&mut conn, benchmark_id);
+
+    // Two measures, so a pivot that joins on the report benchmark alone pulls a
+    // bound across measures and fails.
+    let mut measure_uuids = Vec::new();
+    let mut measure_ids = Vec::new();
+    for (name, units) in [("metric-latency", "ns"), ("metric-throughput", "ops")] {
+        let measure_uuid = MeasureUuid::new();
+        diesel::insert_into(schema::measure::table)
+            .values((
+                schema::measure::uuid.eq(&measure_uuid),
+                schema::measure::project_id.eq(project_id),
+                schema::measure::name.eq(name),
+                schema::measure::slug.eq(format!("{name}-{measure_uuid}")),
+                schema::measure::units.eq(units),
+                schema::measure::created.eq(&now),
+                schema::measure::modified.eq(&now),
+            ))
+            .execute(&mut conn)
+            .expect("Failed to insert the measure");
+        let measure_id: i32 = schema::measure::table
+            .filter(schema::measure::uuid.eq(&measure_uuid))
+            .select(schema::measure::id)
+            .first(&mut conn)
+            .expect("Failed to get the measure id");
+        measure_uuids.push(measure_uuid);
+        measure_ids.push(measure_id);
+    }
+
+    // Two report benchmarks, so a pivot that joins on the measure alone pulls a
+    // bound across iterations and fails. Every (report benchmark, measure) pair
+    // takes one fixture metric, in order.
+    let mut grid = Vec::new();
+    for iteration in 0..2 {
+        let report_benchmark_uuid = ReportBenchmarkUuid::new();
+        diesel::insert_into(schema::report_benchmark::table)
+            .values((
+                schema::report_benchmark::uuid.eq(&report_benchmark_uuid),
+                schema::report_benchmark::report_id.eq(report_id),
+                schema::report_benchmark::iteration.eq(iteration),
+                schema::report_benchmark::benchmark_id.eq(benchmark_id),
+                schema::report_benchmark::parameter_id.eq(parameter_id),
+            ))
+            .execute(&mut conn)
+            .expect("Failed to insert the report benchmark");
+        let report_benchmark_id: i32 = schema::report_benchmark::table
+            .filter(schema::report_benchmark::uuid.eq(&report_benchmark_uuid))
+            .select(schema::report_benchmark::id)
+            .first(&mut conn)
+            .expect("Failed to get the report benchmark id");
+        for measure_id in &measure_ids {
+            grid.push((report_benchmark_id, *measure_id));
+        }
+    }
+
+    // The metrics go in through raw SQL: the columns they are written to are the
+    // columns the pre-migration table had, which the compiled schema no longer names.
+    let mut metric_uuids = Vec::new();
+    for ((report_benchmark_id, measure_id), metric) in grid.into_iter().zip(FIXTURE_METRICS) {
+        let metric_uuid = MetricUuid::new();
+        diesel::sql_query(
+            "INSERT INTO metric (uuid, report_benchmark_id, measure_id, value, lower_value, upper_value) VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind::<Text, _>(metric_uuid.to_string())
+        .bind::<Integer, _>(report_benchmark_id)
+        .bind::<Integer, _>(measure_id)
+        .bind::<Double, _>(metric.value)
+        .bind::<Nullable<Double>, _>(metric.lower_value)
+        .bind::<Nullable<Double>, _>(metric.upper_value)
+        .execute(&mut conn)
+        .expect("Failed to insert the legacy metric");
+        metric_uuids.push(metric_uuid);
+    }
+
+    // The first fixture metric, the bounded one, gets the boundary and the alert.
+    let (first_measure_id, first_metric_uuid) = measure_ids
+        .first()
+        .copied()
+        .zip(metric_uuids.first())
+        .expect("the fixture seeds at least one metric");
+    seed_threshold_and_alert(
+        &mut conn,
+        project_id,
+        branch_id,
+        testbed_id,
+        first_measure_id,
+        first_metric_uuid,
+        now,
+    );
+
+    Fixture {
+        project_slug,
+        token: user.token,
+        branch_uuid,
+        testbed_uuid,
+        benchmark_uuid,
+        measure_uuids,
+        report_uuid,
+        metric_uuids,
+    }
+}
+
+/// Attach a threshold, model, boundary, and alert to the first seeded metric, so
+/// that the boundary remap and the alert response are both exercised.
+fn seed_threshold_and_alert(
+    conn: &mut DbConnection,
+    project_id: i32,
+    branch_id: i32,
+    testbed_id: i32,
+    measure_id: i32,
+    metric_uuid: &MetricUuid,
+    now: bencher_json::DateTime,
+) {
+    let threshold_uuid = ThresholdUuid::new();
+    diesel::insert_into(schema::threshold::table)
+        .values((
+            schema::threshold::uuid.eq(&threshold_uuid),
+            schema::threshold::project_id.eq(project_id),
+            schema::threshold::branch_id.eq(branch_id),
+            schema::threshold::testbed_id.eq(testbed_id),
+            schema::threshold::measure_id.eq(measure_id),
+            schema::threshold::created.eq(&now),
+            schema::threshold::modified.eq(&now),
+        ))
+        .execute(&mut *conn)
+        .expect("Failed to insert the threshold");
+    let threshold_id: i32 = schema::threshold::table
+        .filter(schema::threshold::uuid.eq(&threshold_uuid))
+        .select(schema::threshold::id)
+        .first(&mut *conn)
+        .expect("Failed to get the threshold id");
+
+    let model_uuid = ModelUuid::new();
+    diesel::insert_into(schema::model::table)
+        .values((
+            schema::model::uuid.eq(&model_uuid),
+            schema::model::threshold_id.eq(threshold_id),
+            schema::model::test.eq(0),
+            schema::model::created.eq(&now),
+        ))
+        .execute(&mut *conn)
+        .expect("Failed to insert the model");
+    let model_id: i32 = schema::model::table
+        .filter(schema::model::uuid.eq(&model_uuid))
+        .select(schema::model::id)
+        .first(&mut *conn)
+        .expect("Failed to get the model id");
+    diesel::update(schema::threshold::table.filter(schema::threshold::id.eq(threshold_id)))
+        .set(schema::threshold::model_id.eq(model_id))
+        .execute(&mut *conn)
+        .expect("Failed to set the threshold model");
+
+    let metric_id: i32 = schema::metric::table
+        .filter(schema::metric::uuid.eq(metric_uuid))
+        .select(schema::metric::id)
+        .first(&mut *conn)
+        .expect("Failed to get the metric id");
+
+    let boundary_uuid = BoundaryUuid::new();
+    diesel::insert_into(schema::boundary::table)
+        .values((
+            schema::boundary::uuid.eq(&boundary_uuid),
+            schema::boundary::metric_id.eq(metric_id),
+            schema::boundary::threshold_id.eq(threshold_id),
+            schema::boundary::model_id.eq(model_id),
+            schema::boundary::baseline.eq(Some(41.0)),
+            schema::boundary::lower_limit.eq(Some(39.0)),
+            schema::boundary::upper_limit.eq(Some(43.0)),
+        ))
+        .execute(&mut *conn)
+        .expect("Failed to insert the boundary");
+    let boundary_id: i32 = schema::boundary::table
+        .filter(schema::boundary::uuid.eq(&boundary_uuid))
+        .select(schema::boundary::id)
+        .first(&mut *conn)
+        .expect("Failed to get the boundary id");
+
+    let alert_uuid = AlertUuid::new();
+    diesel::insert_into(schema::alert::table)
+        .values((
+            schema::alert::uuid.eq(&alert_uuid),
+            schema::alert::boundary_id.eq(boundary_id),
+            schema::alert::boundary_limit.eq(BoundaryLimit::Upper),
+            schema::alert::status.eq(AlertStatus::Active),
+            schema::alert::modified.eq(&now),
+        ))
+        .execute(&mut *conn)
+        .expect("Failed to insert the alert");
+}
+
+/// Capture the raw bytes of every response that reads a metric.
+///
+/// The bytes are compared, not parsed values: parsing and re-serializing would
+/// hide exactly the float formatting drift this migration has to rule out.
+async fn capture(server: &TestServer, fixture: &Fixture) -> Captured {
+    let Fixture {
+        project_slug,
+        token,
+        branch_uuid,
+        testbed_uuid,
+        benchmark_uuid,
+        measure_uuids,
+        report_uuid,
+        metric_uuids,
+    } = fixture;
+
+    let measures = measure_uuids
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(",");
+    let perf = get(
+        server,
+        token,
+        &format!(
+            "/v0/projects/{project_slug}/perf?branches={branch_uuid}&testbeds={testbed_uuid}&benchmarks={benchmark_uuid}&measures={measures}"
+        ),
+    )
+    .await;
+
+    let mut metrics = Vec::new();
+    for metric_uuid in metric_uuids {
+        metrics.push(
+            get(
+                server,
+                token,
+                &format!("/v0/projects/{project_slug}/metrics/{metric_uuid}"),
+            )
+            .await,
+        );
+    }
+
+    let report = get(
+        server,
+        token,
+        &format!("/v0/projects/{project_slug}/reports/{report_uuid}"),
+    )
+    .await;
+    let alerts = get(
+        server,
+        token,
+        &format!("/v0/projects/{project_slug}/alerts"),
+    )
+    .await;
+
+    Captured {
+        perf,
+        metrics,
+        report,
+        alerts,
+    }
+}
+
+/// GET a path and return its body, asserting that it was served.
+async fn get(server: &TestServer, token: &str, path: &str) -> String {
+    let resp = server
+        .client
+        .get(server.api_url(path))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(resp.status(), StatusCode::OK, "GET {path}");
+    resp.text().await.expect("Failed to read the response body")
+}

--- a/lib/api_projects/tests/metrics.rs
+++ b/lib/api_projects/tests/metrics.rs
@@ -13,7 +13,9 @@ use bencher_api_tests::{
     TestServer,
     helpers::{base_timestamp, create_empty_parameter, create_test_report, get_project_id},
 };
-use bencher_json::{BenchmarkUuid, JsonOneMetric, MeasureUuid, MetricUuid, ReportBenchmarkUuid};
+use bencher_json::{
+    BenchmarkUuid, JsonOneMetric, MeasureUuid, MetricName, MetricUuid, ReportBenchmarkUuid,
+};
 use bencher_schema::{
     model::project::report::{ReportId, upsert_metric_count},
     schema,
@@ -93,6 +95,7 @@ fn create_test_metric(server: &TestServer, project_id: i32, report_id: i32) -> M
             schema::metric::uuid.eq(&metric_uuid),
             schema::metric::report_benchmark_id.eq(report_benchmark_id),
             schema::metric::measure_id.eq(measure_id),
+            schema::metric::name.eq(MetricName::value()),
             schema::metric::value.eq(42.0),
         ))
         .execute(&mut conn)

--- a/lib/api_projects/tests/perf.rs
+++ b/lib/api_projects/tests/perf.rs
@@ -11,12 +11,12 @@
 
 use bencher_api_tests::{
     TestServer,
-    helpers::{base_timestamp, create_empty_parameter, get_project_id},
+    helpers::{base_timestamp, create_empty_parameter, create_metric, get_project_id},
 };
 use bencher_json::{
     AlertUuid, BenchmarkUuid, BoundaryUuid, BranchUuid, HeadUuid, JobStatus, JobUuid, JsonPerf,
-    MeasureUuid, MetricUuid, Priority, ReportBenchmarkUuid, ReportUuid, SpecUuid, TestbedUuid,
-    VersionUuid,
+    MeasureUuid, MetricName, MetricUuid, Priority, ReportBenchmarkUuid, ReportUuid, SpecUuid,
+    TestbedUuid, VersionUuid,
     project::{alert::AlertStatus, boundary::BoundaryLimit},
 };
 use bencher_schema::{
@@ -275,29 +275,15 @@ fn create_perf_data_with_options(
 
     // Metric
     let metric_uuid = MetricUuid::new();
-    if opts.lower_value.is_some() || opts.upper_value.is_some() {
-        diesel::insert_into(schema::metric::table)
-            .values((
-                schema::metric::uuid.eq(&metric_uuid),
-                schema::metric::report_benchmark_id.eq(report_benchmark_id),
-                schema::metric::measure_id.eq(measure_id),
-                schema::metric::value.eq(opts.metric_value),
-                schema::metric::lower_value.eq(opts.lower_value),
-                schema::metric::upper_value.eq(opts.upper_value),
-            ))
-            .execute(&mut conn)
-            .expect("insert metric with bounds");
-    } else {
-        diesel::insert_into(schema::metric::table)
-            .values((
-                schema::metric::uuid.eq(&metric_uuid),
-                schema::metric::report_benchmark_id.eq(report_benchmark_id),
-                schema::metric::measure_id.eq(measure_id),
-                schema::metric::value.eq(opts.metric_value),
-            ))
-            .execute(&mut conn)
-            .expect("insert metric");
-    }
+    create_metric(
+        &mut conn,
+        &metric_uuid,
+        report_benchmark_id,
+        measure_id,
+        opts.metric_value,
+        opts.lower_value,
+        opts.upper_value,
+    );
 
     // Keep metric_count_by_report in sync (1 metric inserted)
     let report_id_typed = ReportId::try_from_raw(report_id).expect("valid report ID");
@@ -759,15 +745,15 @@ async fn perf_get_multiple_metrics_same_permutation() {
         .expect("get rb2 id");
 
     let metric2_uuid = MetricUuid::new();
-    diesel::insert_into(schema::metric::table)
-        .values((
-            schema::metric::uuid.eq(&metric2_uuid),
-            schema::metric::report_benchmark_id.eq(rb2_id),
-            schema::metric::measure_id.eq(data.measure_id),
-            schema::metric::value.eq(99.0),
-        ))
-        .execute(&mut conn)
-        .expect("insert metric2");
+    create_metric(
+        &mut conn,
+        &metric2_uuid,
+        rb2_id,
+        data.measure_id,
+        99.0,
+        None,
+        None,
+    );
 
     // Query perf
     let url = build_perf_url(
@@ -1070,15 +1056,15 @@ async fn perf_multi_measure_query() {
         .expect("get measure2 id");
 
     let metric2_uuid = MetricUuid::new();
-    diesel::insert_into(schema::metric::table)
-        .values((
-            schema::metric::uuid.eq(&metric2_uuid),
-            schema::metric::report_benchmark_id.eq(data.report_benchmark_id),
-            schema::metric::measure_id.eq(measure2_id),
-            schema::metric::value.eq(1024.0),
-        ))
-        .execute(&mut conn)
-        .expect("insert metric2");
+    create_metric(
+        &mut conn,
+        &metric2_uuid,
+        data.report_benchmark_id,
+        measure2_id,
+        1024.0,
+        None,
+        None,
+    );
 
     // Query with both measures
     let url = build_perf_url(
@@ -1159,15 +1145,15 @@ async fn perf_multi_benchmark_query() {
         .expect("get report_benchmark2 id");
 
     let metric2_uuid = MetricUuid::new();
-    diesel::insert_into(schema::metric::table)
-        .values((
-            schema::metric::uuid.eq(&metric2_uuid),
-            schema::metric::report_benchmark_id.eq(report_benchmark2_id),
-            schema::metric::measure_id.eq(data.measure_id),
-            schema::metric::value.eq(99.0),
-        ))
-        .execute(&mut conn)
-        .expect("insert metric2");
+    create_metric(
+        &mut conn,
+        &metric2_uuid,
+        report_benchmark2_id,
+        data.measure_id,
+        99.0,
+        None,
+        None,
+    );
 
     // Query with both benchmarks
     let url = build_perf_url(
@@ -1604,6 +1590,7 @@ async fn perf_permutation_limit_exact_255() {
                 schema::metric::uuid.eq(&metric_uuid),
                 schema::metric::report_benchmark_id.eq(data.report_benchmark_id),
                 schema::metric::measure_id.eq(m_id),
+                schema::metric::name.eq(MetricName::value()),
                 schema::metric::value.eq(1.0),
             ))
             .execute(&mut conn)
@@ -1677,6 +1664,7 @@ async fn perf_permutation_limit_truncated_256() {
                 schema::metric::uuid.eq(&metric_uuid),
                 schema::metric::report_benchmark_id.eq(data.report_benchmark_id),
                 schema::metric::measure_id.eq(m_id),
+                schema::metric::name.eq(MetricName::value()),
                 schema::metric::value.eq(1.0),
             ))
             .execute(&mut conn)
@@ -1944,6 +1932,7 @@ async fn perf_ordered_by_version_number() {
             schema::metric::uuid.eq(&m_uuid),
             schema::metric::report_benchmark_id.eq(rb_v1_id),
             schema::metric::measure_id.eq(data_v2.measure_id),
+            schema::metric::name.eq(MetricName::value()),
             schema::metric::value.eq(100.0),
         ))
         .execute(&mut conn)
@@ -2076,6 +2065,7 @@ async fn perf_ordered_by_start_time_within_version() {
             schema::metric::uuid.eq(&m_uuid),
             schema::metric::report_benchmark_id.eq(rb_id),
             schema::metric::measure_id.eq(data.measure_id),
+            schema::metric::name.eq(MetricName::value()),
             schema::metric::value.eq(100.0),
         ))
         .execute(&mut conn)
@@ -2565,6 +2555,7 @@ async fn perf_multiple_iterations() {
             schema::metric::uuid.eq(&m2_uuid),
             schema::metric::report_benchmark_id.eq(rb2_id),
             schema::metric::measure_id.eq(data.measure_id),
+            schema::metric::name.eq(MetricName::value()),
             schema::metric::value.eq(20.0),
         ))
         .execute(&mut conn)
@@ -2887,6 +2878,7 @@ async fn perf_spec_filters_results() {
             schema::metric::uuid.eq(&metric2_uuid),
             schema::metric::report_benchmark_id.eq(rb2_id),
             schema::metric::measure_id.eq(data1.measure_id),
+            schema::metric::name.eq(MetricName::value()),
             schema::metric::value.eq(99.0),
         ))
         .execute(&mut conn)

--- a/lib/api_projects/tests/reports.rs
+++ b/lib/api_projects/tests/reports.rs
@@ -16,8 +16,8 @@ use bencher_api_tests::{
     },
 };
 use bencher_json::{
-    BenchmarkUuid, BoundaryUuid, JsonParameters, JsonReport, JsonReports, MeasureUuid, MetricUuid,
-    ModelUuid, ReportBenchmarkUuid, ThresholdUuid,
+    BenchmarkUuid, BoundaryUuid, JsonParameters, JsonReport, JsonReports, MeasureUuid, MetricName,
+    MetricUuid, ModelUuid, ReportBenchmarkUuid, ThresholdUuid,
 };
 use bencher_schema::{
     context::DbConnection,
@@ -173,6 +173,7 @@ fn seed_report_results(server: &TestServer, project_id: i32, report_id: i32, cou
                 schema::metric::uuid.eq(MetricUuid::new()),
                 schema::metric::report_benchmark_id.eq(*report_benchmark_id),
                 schema::metric::measure_id.eq(measure_id),
+                schema::metric::name.eq(MetricName::value()),
                 schema::metric::value.eq(42.0),
             )
         })

--- a/lib/bencher_api_tests/src/helpers.rs
+++ b/lib/bencher_api_tests/src/helpers.rs
@@ -3,8 +3,8 @@
 //! These helpers are used by both `api_projects` and `api_runners` integration tests.
 
 use bencher_json::{
-    BranchUuid, DateTime, HeadUuid, JobStatus, JobUuid, JsonParameters, Jwt, ParameterUuid,
-    ReportUuid, ResourceName, TestbedUuid, TokenUuid, VersionUuid,
+    BranchUuid, DateTime, HeadUuid, JobStatus, JobUuid, JsonParameters, Jwt, MetricName,
+    MetricUuid, ParameterUuid, ReportUuid, ResourceName, TestbedUuid, TokenUuid, VersionUuid,
 };
 use bencher_schema::{context::DbConnection, model::user::UserId, schema};
 use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
@@ -209,6 +209,53 @@ pub fn seed_token(server: &TestServer, user: &TestUser, name: &str) -> TestToken
         .expect("Failed to insert token");
 
     TestToken { uuid, token: jwt }
+}
+
+/// Insert a metric as its named rows.
+///
+/// The point estimate carries `metric_uuid` and the name `value`; each bound that
+/// is present becomes its own row under its conventional name. This is the shape
+/// the metric triple takes in storage, so tests seeding metrics by hand write it
+/// the way ingest does.
+#[expect(clippy::expect_used, reason = "test helper inserting metric rows")]
+pub fn create_metric(
+    conn: &mut DbConnection,
+    metric_uuid: &MetricUuid,
+    report_benchmark_id: i32,
+    measure_id: i32,
+    value: f64,
+    lower_value: Option<f64>,
+    upper_value: Option<f64>,
+) {
+    diesel::insert_into(schema::metric::table)
+        .values((
+            schema::metric::uuid.eq(metric_uuid),
+            schema::metric::report_benchmark_id.eq(report_benchmark_id),
+            schema::metric::measure_id.eq(measure_id),
+            schema::metric::name.eq(MetricName::value()),
+            schema::metric::value.eq(value),
+        ))
+        .execute(&mut *conn)
+        .expect("Failed to insert metric value");
+
+    for (name, bound) in [
+        (MetricName::lower_value(), lower_value),
+        (MetricName::upper_value(), upper_value),
+    ] {
+        let Some(bound) = bound else {
+            continue;
+        };
+        diesel::insert_into(schema::metric::table)
+            .values((
+                schema::metric::uuid.eq(MetricUuid::new()),
+                schema::metric::report_benchmark_id.eq(report_benchmark_id),
+                schema::metric::measure_id.eq(measure_id),
+                schema::metric::name.eq(name),
+                schema::metric::value.eq(bound),
+            ))
+            .execute(&mut *conn)
+            .expect("Failed to insert metric bound");
+    }
 }
 
 /// Set job status directly in the database.

--- a/lib/bencher_json/src/lib.rs
+++ b/lib/bencher_json/src/lib.rs
@@ -3,9 +3,9 @@ use std::sync::LazyLock;
 pub use bencher_context::RunContext;
 pub use bencher_valid::{
     BencherKey, BenchmarkName, Boundary, BranchName, CdfBoundary, DateTime, DateTimeMillis, Email,
-    GitHash, Index, IntoResourceId, IqrBoundary, Jwt, Model, ModelTest, NameId, NonEmpty,
-    PercentageBoundary, ProjectKey, ProjectKeyHash, ResourceId, ResourceName, SampleSize, Sanitize,
-    Search, Secret, Slug, Units, Url, UserKey, UserKeyHash, UserName, ValidError, Window,
+    GitHash, Index, IntoResourceId, IqrBoundary, Jwt, MetricName, Model, ModelTest, NameId,
+    NonEmpty, PercentageBoundary, ProjectKey, ProjectKeyHash, ResourceId, ResourceName, SampleSize,
+    Sanitize, Search, Secret, Slug, Units, Url, UserKey, UserKeyHash, UserName, ValidError, Window,
 };
 #[cfg(feature = "plus")]
 pub use bencher_valid::{

--- a/lib/bencher_schema/migrations/2026-08-16-120000_single_valued_metric/down.sql
+++ b/lib/bencher_schema/migrations/2026-08-16-120000_single_valued_metric/down.sql
@@ -1,0 +1,70 @@
+PRAGMA foreign_keys = off;
+-- The view has to be dropped before the table can be recreated.
+DROP VIEW IF EXISTS metric_boundary;
+-- metric
+CREATE TABLE down_metric (
+    id INTEGER PRIMARY KEY NOT NULL,
+    uuid TEXT NOT NULL UNIQUE,
+    report_benchmark_id INTEGER NOT NULL,
+    measure_id INTEGER NOT NULL,
+    value DOUBLE NOT NULL,
+    lower_value DOUBLE,
+    upper_value DOUBLE,
+    FOREIGN KEY (report_benchmark_id) REFERENCES report_benchmark (id) ON DELETE CASCADE,
+    FOREIGN KEY (measure_id) REFERENCES measure (id),
+    UNIQUE(report_benchmark_id, measure_id)
+);
+-- The inverse of the explosion: the `value` row keeps its id and uuid, and the
+-- bound rows collapse back into its columns. Named values that are not part of
+-- the metric triple have no column to land in and are dropped, which is the
+-- price of going back to a shape that cannot hold them.
+INSERT INTO down_metric(
+        id,
+        uuid,
+        report_benchmark_id,
+        measure_id,
+        value,
+        lower_value,
+        upper_value
+    )
+SELECT metric.id,
+    metric.uuid,
+    metric.report_benchmark_id,
+    metric.measure_id,
+    metric.value,
+    lower_metric.value,
+    upper_metric.value
+FROM metric
+    LEFT OUTER JOIN metric AS lower_metric ON (
+        lower_metric.report_benchmark_id = metric.report_benchmark_id
+        AND lower_metric.measure_id = metric.measure_id
+        AND lower_metric.name = 'lower_value'
+    )
+    LEFT OUTER JOIN metric AS upper_metric ON (
+        upper_metric.report_benchmark_id = metric.report_benchmark_id
+        AND upper_metric.measure_id = metric.measure_id
+        AND upper_metric.name = 'upper_value'
+    )
+WHERE metric.name = 'value';
+DROP TABLE metric;
+ALTER TABLE down_metric
+    RENAME TO metric;
+-- metric_boundary
+CREATE VIEW metric_boundary AS
+SELECT metric.id AS metric_id,
+    metric.uuid AS metric_uuid,
+    metric.report_benchmark_id,
+    metric.measure_id,
+    metric.value,
+    metric.lower_value,
+    metric.upper_value,
+    boundary.id AS boundary_id,
+    boundary.uuid AS boundary_uuid,
+    boundary.threshold_id,
+    boundary.model_id,
+    boundary.baseline,
+    boundary.lower_limit,
+    boundary.upper_limit
+FROM metric
+    LEFT OUTER JOIN boundary ON (boundary.metric_id = metric.id);
+PRAGMA foreign_keys = on;

--- a/lib/bencher_schema/migrations/2026-08-16-120000_single_valued_metric/up.sql
+++ b/lib/bencher_schema/migrations/2026-08-16-120000_single_valued_metric/up.sql
@@ -18,9 +18,9 @@ CREATE TABLE up_metric (
     FOREIGN KEY (measure_id) REFERENCES measure (id),
     UNIQUE(report_benchmark_id, measure_id, name)
 );
--- STUB: only the `value` row is carried over, so every stored bound is dropped.
--- The explosion into the `lower_value` and `upper_value` rows lands with the
--- implementation.
+-- Every old row yields a `value` row that keeps the original id and uuid, which
+-- makes the boundary remap a no-op: `boundary.metric_id` already points at that
+-- id, so no `boundary` row is rewritten and its unique constraint is undisturbed.
 INSERT INTO up_metric(
         id,
         uuid,
@@ -36,21 +36,63 @@ SELECT id,
     'value',
     value
 FROM metric;
+-- Each stored bound becomes its own row under its conventional name. The id is
+-- assigned rather than kept, because it is a new row.
+-- Pure SQL has no UUIDv7 function, so the UUID is a v4 minted from `randomblob`:
+-- 16 random bytes with the version nibble set to 4 and the variant nibble drawn
+-- from `89ab`. `random() & 3` is used rather than `abs(random()) % 4` because
+-- `abs(-9223372036854775808)` is an integer overflow error in SQLite.
+INSERT INTO up_metric(
+        uuid,
+        report_benchmark_id,
+        measure_id,
+        name,
+        value
+    )
+SELECT lower(
+        hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || substr(hex(randomblob(2)), 2) || '-' || substr('89ab', (random() & 3) + 1, 1) || substr(hex(randomblob(2)), 2) || '-' || hex(randomblob(6))
+    ),
+    report_benchmark_id,
+    measure_id,
+    'lower_value',
+    lower_value
+FROM metric
+WHERE lower_value IS NOT NULL;
+INSERT INTO up_metric(
+        uuid,
+        report_benchmark_id,
+        measure_id,
+        name,
+        value
+    )
+SELECT lower(
+        hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || substr(hex(randomblob(2)), 2) || '-' || substr('89ab', (random() & 3) + 1, 1) || substr(hex(randomblob(2)), 2) || '-' || hex(randomblob(6))
+    ),
+    report_benchmark_id,
+    measure_id,
+    'upper_value',
+    upper_value
+FROM metric
+WHERE upper_value IS NOT NULL;
 DROP TABLE metric;
 ALTER TABLE up_metric
     RENAME TO metric;
 -- metric_boundary
--- STUB: the bound columns are held in the column list but always NULL, so the
--- view's three readers still compile. The pivot over the named rows lands with
--- the implementation.
+-- The view pivots the named rows back into the columns its readers already know,
+-- so its column list is unchanged and every response it feeds is unchanged with
+-- it. The self joins ride `UNIQUE(report_benchmark_id, measure_id, name)`, and
+-- because that index makes them provably at most one row, SQLite omits them
+-- outright for any query that does not select a bound.
+-- `WHERE metric.name = 'value'` keeps the view one row per measurement, which is
+-- what makes it a drop-in for the table it replaced.
 CREATE VIEW metric_boundary AS
 SELECT metric.id AS metric_id,
     metric.uuid AS metric_uuid,
     metric.report_benchmark_id,
     metric.measure_id,
     metric.value,
-    NULL AS lower_value,
-    NULL AS upper_value,
+    lower_metric.value AS lower_value,
+    upper_metric.value AS upper_value,
     boundary.id AS boundary_id,
     boundary.uuid AS boundary_uuid,
     boundary.threshold_id,
@@ -59,6 +101,16 @@ SELECT metric.id AS metric_id,
     boundary.lower_limit,
     boundary.upper_limit
 FROM metric
+    LEFT OUTER JOIN metric AS lower_metric ON (
+        lower_metric.report_benchmark_id = metric.report_benchmark_id
+        AND lower_metric.measure_id = metric.measure_id
+        AND lower_metric.name = 'lower_value'
+    )
+    LEFT OUTER JOIN metric AS upper_metric ON (
+        upper_metric.report_benchmark_id = metric.report_benchmark_id
+        AND upper_metric.measure_id = metric.measure_id
+        AND upper_metric.name = 'upper_value'
+    )
     LEFT OUTER JOIN boundary ON (boundary.metric_id = metric.id)
 WHERE metric.name = 'value';
 PRAGMA foreign_keys = on;

--- a/lib/bencher_schema/migrations/2026-08-16-120000_single_valued_metric/up.sql
+++ b/lib/bencher_schema/migrations/2026-08-16-120000_single_valued_metric/up.sql
@@ -1,0 +1,64 @@
+PRAGMA foreign_keys = off;
+-- `metric_boundary` is a view over `metric`, so it has to be dropped before
+-- `metric` can be recreated, and rebuilt from the new shape afterwards.
+DROP VIEW IF EXISTS metric_boundary;
+-- metric
+-- `name` sits with the identity columns, above `value`: the name is part of what
+-- the row is, not part of what it measured. `UNIQUE(report_benchmark_id,
+-- measure_id, name)` extends the old `UNIQUE(report_benchmark_id, measure_id)`
+-- and is also the index the pivot below rides.
+CREATE TABLE up_metric (
+    id INTEGER PRIMARY KEY NOT NULL,
+    uuid TEXT NOT NULL UNIQUE,
+    report_benchmark_id INTEGER NOT NULL,
+    measure_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    value DOUBLE NOT NULL,
+    FOREIGN KEY (report_benchmark_id) REFERENCES report_benchmark (id) ON DELETE CASCADE,
+    FOREIGN KEY (measure_id) REFERENCES measure (id),
+    UNIQUE(report_benchmark_id, measure_id, name)
+);
+-- STUB: only the `value` row is carried over, so every stored bound is dropped.
+-- The explosion into the `lower_value` and `upper_value` rows lands with the
+-- implementation.
+INSERT INTO up_metric(
+        id,
+        uuid,
+        report_benchmark_id,
+        measure_id,
+        name,
+        value
+    )
+SELECT id,
+    uuid,
+    report_benchmark_id,
+    measure_id,
+    'value',
+    value
+FROM metric;
+DROP TABLE metric;
+ALTER TABLE up_metric
+    RENAME TO metric;
+-- metric_boundary
+-- STUB: the bound columns are held in the column list but always NULL, so the
+-- view's three readers still compile. The pivot over the named rows lands with
+-- the implementation.
+CREATE VIEW metric_boundary AS
+SELECT metric.id AS metric_id,
+    metric.uuid AS metric_uuid,
+    metric.report_benchmark_id,
+    metric.measure_id,
+    metric.value,
+    NULL AS lower_value,
+    NULL AS upper_value,
+    boundary.id AS boundary_id,
+    boundary.uuid AS boundary_uuid,
+    boundary.threshold_id,
+    boundary.model_id,
+    boundary.baseline,
+    boundary.lower_limit,
+    boundary.upper_limit
+FROM metric
+    LEFT OUTER JOIN boundary ON (boundary.metric_id = metric.id)
+WHERE metric.name = 'value';
+PRAGMA foreign_keys = on;

--- a/lib/bencher_schema/migrations/2026-08-16-120000_single_valued_metric/up.sql
+++ b/lib/bencher_schema/migrations/2026-08-16-120000_single_valued_metric/up.sql
@@ -4,19 +4,22 @@ PRAGMA foreign_keys = off;
 DROP VIEW IF EXISTS metric_boundary;
 -- metric
 -- `name` sits with the identity columns, above `value`: the name is part of what
--- the row is, not part of what it measured. `UNIQUE(report_benchmark_id,
--- measure_id, name)` extends the old `UNIQUE(report_benchmark_id, measure_id)`
--- and is also the index the pivot below rides.
+-- the row is, not part of what it measured. The unique key over
+-- (report_benchmark_id, measure_id, name) extends the old
+-- `UNIQUE(report_benchmark_id, measure_id)` and is also the index the pivot below
+-- rides.
+-- The table is declared without its two unique keys. They are built below, once
+-- every row is in place, as named unique indexes that enforce exactly what the
+-- table constraints enforced.
 CREATE TABLE up_metric (
     id INTEGER PRIMARY KEY NOT NULL,
-    uuid TEXT NOT NULL UNIQUE,
+    uuid TEXT NOT NULL,
     report_benchmark_id INTEGER NOT NULL,
     measure_id INTEGER NOT NULL,
     name TEXT NOT NULL,
     value DOUBLE NOT NULL,
     FOREIGN KEY (report_benchmark_id) REFERENCES report_benchmark (id) ON DELETE CASCADE,
-    FOREIGN KEY (measure_id) REFERENCES measure (id),
-    UNIQUE(report_benchmark_id, measure_id, name)
+    FOREIGN KEY (measure_id) REFERENCES measure (id)
 );
 -- Every old row yields a `value` row that keeps the original id and uuid, which
 -- makes the boundary remap a no-op: `boundary.metric_id` already points at that
@@ -37,9 +40,10 @@ SELECT id,
     value
 FROM metric;
 -- The 48 bit millisecond prefix that every minted uuid shares, computed once for
--- the whole migration rather than per row, so that all of the new rows append to
--- one point on the right edge of the uuid index instead of scattering across every
--- page of it. That is worth the temporary table at this volume.
+-- the whole migration rather than per row, so that every minted uuid is a v7 of
+-- the one instant the migration ran at. That is worth the temporary table at this
+-- volume, and it costs the uuid index nothing either way: the index is built below
+-- by an external sort, which is indifferent to where its keys fall.
 -- `julianday` rather than `unixepoch('now', 'subsec')`, which is newer than the
 -- oldest SQLite that can otherwise run this migration.
 CREATE TEMP TABLE metric_uuid_prefix AS
@@ -87,6 +91,15 @@ SELECT lower(
 FROM metric,
     metric_uuid_prefix
 WHERE metric.upper_value IS NOT NULL;
+-- The two unique keys the table was declared without, built now that every row the
+-- explosion produces is in place. Declared on the table they would be maintained
+-- online across every one of those inserts, two unique B-trees kept dirty a page
+-- split at a time; built here each is one external sort. Measured over the whole
+-- rebuild, deferring them reads 16 times fewer pages and writes 29 times fewer. The
+-- sort is also indifferent to where its keys fall, so the v4 uuids that the
+-- preserved rows carry over cost it nothing.
+CREATE UNIQUE INDEX index_metric_uuid ON up_metric(uuid);
+CREATE UNIQUE INDEX index_metric_report_benchmark_measure_name ON up_metric(report_benchmark_id, measure_id, name);
 DROP TABLE temp.metric_uuid_prefix;
 DROP TABLE metric;
 ALTER TABLE up_metric
@@ -94,7 +107,7 @@ ALTER TABLE up_metric
 -- metric_boundary
 -- The view pivots the named rows back into the columns its readers already know,
 -- so its column list is unchanged and every response it feeds is unchanged with
--- it. The self joins ride `UNIQUE(report_benchmark_id, measure_id, name)`, and
+-- it. The self joins ride `index_metric_report_benchmark_measure_name`, and
 -- because that index makes them provably at most one row, SQLite omits them
 -- outright for any query that does not select a bound.
 -- `WHERE metric.name = 'value'` keeps the view one row per measurement, which is

--- a/lib/bencher_schema/migrations/2026-08-16-120000_single_valued_metric/up.sql
+++ b/lib/bencher_schema/migrations/2026-08-16-120000_single_valued_metric/up.sql
@@ -36,11 +36,22 @@ SELECT id,
     'value',
     value
 FROM metric;
+-- The 48 bit millisecond prefix that every minted uuid shares, computed once for
+-- the whole migration rather than per row, so that all of the new rows append to
+-- one point on the right edge of the uuid index instead of scattering across every
+-- page of it. That is worth the temporary table at this volume.
+-- `julianday` rather than `unixepoch('now', 'subsec')`, which is newer than the
+-- oldest SQLite that can otherwise run this migration.
+CREATE TEMP TABLE metric_uuid_prefix AS
+SELECT printf(
+        '%012x',
+        CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)
+    ) AS prefix;
 -- Each stored bound becomes its own row under its conventional name. The id is
 -- assigned rather than kept, because it is a new row.
--- Pure SQL has no UUIDv7 function, so the UUID is a v4 minted from `randomblob`:
--- 16 random bytes with the version nibble set to 4 and the variant nibble drawn
--- from `89ab`. `random() & 3` is used rather than `abs(random()) % 4` because
+-- The uuid is v7 shaped: the shared millisecond prefix, the version nibble 7, and
+-- `randomblob` for the rest. The variant nibble is drawn from `89ab` by
+-- `random() & 3` rather than `abs(random()) % 4`, because
 -- `abs(-9223372036854775808)` is an integer overflow error in SQLite.
 INSERT INTO up_metric(
         uuid,
@@ -50,14 +61,15 @@ INSERT INTO up_metric(
         value
     )
 SELECT lower(
-        hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || substr(hex(randomblob(2)), 2) || '-' || substr('89ab', (random() & 3) + 1, 1) || substr(hex(randomblob(2)), 2) || '-' || hex(randomblob(6))
+        substr(metric_uuid_prefix.prefix, 1, 8) || '-' || substr(metric_uuid_prefix.prefix, 9, 4) || '-7' || substr(hex(randomblob(2)), 2) || '-' || substr('89ab', (random() & 3) + 1, 1) || substr(hex(randomblob(2)), 2) || '-' || hex(randomblob(6))
     ),
-    report_benchmark_id,
-    measure_id,
+    metric.report_benchmark_id,
+    metric.measure_id,
     'lower_value',
-    lower_value
-FROM metric
-WHERE lower_value IS NOT NULL;
+    metric.lower_value
+FROM metric,
+    metric_uuid_prefix
+WHERE metric.lower_value IS NOT NULL;
 INSERT INTO up_metric(
         uuid,
         report_benchmark_id,
@@ -66,14 +78,16 @@ INSERT INTO up_metric(
         value
     )
 SELECT lower(
-        hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || substr(hex(randomblob(2)), 2) || '-' || substr('89ab', (random() & 3) + 1, 1) || substr(hex(randomblob(2)), 2) || '-' || hex(randomblob(6))
+        substr(metric_uuid_prefix.prefix, 1, 8) || '-' || substr(metric_uuid_prefix.prefix, 9, 4) || '-7' || substr(hex(randomblob(2)), 2) || '-' || substr('89ab', (random() & 3) + 1, 1) || substr(hex(randomblob(2)), 2) || '-' || hex(randomblob(6))
     ),
-    report_benchmark_id,
-    measure_id,
+    metric.report_benchmark_id,
+    metric.measure_id,
     'upper_value',
-    upper_value
-FROM metric
-WHERE upper_value IS NOT NULL;
+    metric.upper_value
+FROM metric,
+    metric_uuid_prefix
+WHERE metric.upper_value IS NOT NULL;
+DROP TABLE temp.metric_uuid_prefix;
 DROP TABLE metric;
 ALTER TABLE up_metric
     RENAME TO metric;

--- a/lib/bencher_schema/src/lib.rs
+++ b/lib/bencher_schema/src/lib.rs
@@ -20,7 +20,12 @@ pub use context::ApiContext;
 #[cfg(feature = "plus")]
 pub use context::{HeaderMap, RateLimiting};
 
-const MIGRATIONS: EmbeddedMigrations = embed_migrations!("./migrations");
+/// The migrations this binary carries.
+///
+/// Public so that tests can drive them with `MigrationHarness` directly: putting a
+/// database back into the shape a migration found it in, and reading it with the
+/// same binary, is how a migration's claim to leave responses unchanged is checked.
+pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("./migrations");
 
 // TODO Custom max TTL
 pub const INVITE_TOKEN_TTL: u32 = u32::MAX;

--- a/lib/bencher_schema/src/model/project/metric.rs
+++ b/lib/bencher_schema/src/model/project/metric.rs
@@ -108,13 +108,27 @@ impl InsertMetric {
 
     /// The bounds, which a metric has zero, one, or two of.
     ///
-    /// STUB: the metric triple does not yet explode into its named rows.
+    /// `lower_value` and `upper_value` are ordinary named rows: the metric triple
+    /// is a convention over three names, not a shape the table knows about.
     pub fn bounds(
-        _report_benchmark_id: ReportBenchmarkId,
-        _measure_id: MeasureId,
-        _metric: JsonNewMetric,
+        report_benchmark_id: ReportBenchmarkId,
+        measure_id: MeasureId,
+        metric: JsonNewMetric,
     ) -> Vec<Self> {
-        Vec::new()
+        let JsonNewMetric {
+            value: _,
+            lower_value,
+            upper_value,
+        } = metric;
+        [
+            (MetricName::lower_value(), lower_value),
+            (MetricName::upper_value(), upper_value),
+        ]
+        .into_iter()
+        .filter_map(|(name, bound)| {
+            bound.map(|bound| Self::new(report_benchmark_id, measure_id, name, bound.into()))
+        })
+        .collect()
     }
 
     fn new(

--- a/lib/bencher_schema/src/model/project/metric.rs
+++ b/lib/bencher_schema/src/model/project/metric.rs
@@ -1,4 +1,4 @@
-use bencher_json::{JsonMetric, JsonNewMetric, MetricUuid};
+use bencher_json::{JsonNewMetric, MetricName, MetricUuid};
 #[cfg(feature = "plus")]
 use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 use dropshot::HttpError;
@@ -27,9 +27,8 @@ pub struct QueryMetric {
     pub uuid: MetricUuid,
     pub report_benchmark_id: ReportBenchmarkId,
     pub measure_id: MeasureId,
+    pub name: MetricName,
     pub value: f64,
-    pub lower_value: Option<f64>,
-    pub upper_value: Option<f64>,
 }
 
 impl QueryMetric {
@@ -56,6 +55,12 @@ impl QueryMetric {
             .filter(schema::project::organization_id.eq(organization_id))
             .filter(schema::report::end_time.ge(start_time))
             .filter(schema::report::end_time.le(end_time))
+            // Named values collapse into their measure's series, so only the point
+            // estimate is counted: a bounded metric is one measurement, not three.
+            // In this shape every measure has exactly one `value` row, which makes
+            // this exactly the count the row-per-measure table produced. The billing
+            // layer revisits it when a payload can name `p99` and never name `value`.
+            .filter(schema::metric::name.eq(MetricName::value()))
             .select(diesel::dsl::count_star())
             .get_result::<i64>(conn)
             .map_err(|e| {
@@ -74,22 +79,6 @@ impl QueryMetric {
                 )
             })
     }
-
-    pub fn into_json(self) -> JsonMetric {
-        let Self {
-            uuid,
-            value,
-            lower_value,
-            upper_value,
-            ..
-        } = self;
-        JsonMetric {
-            uuid,
-            value: value.into(),
-            lower_value: lower_value.map(Into::into),
-            upper_value: upper_value.map(Into::into),
-        }
-    }
 }
 
 #[derive(Debug, diesel::Insertable)]
@@ -98,29 +87,48 @@ pub struct InsertMetric {
     pub uuid: MetricUuid,
     pub report_benchmark_id: ReportBenchmarkId,
     pub measure_id: MeasureId,
+    pub name: MetricName,
     pub value: f64,
-    pub lower_value: Option<f64>,
-    pub upper_value: Option<f64>,
 }
 
 impl InsertMetric {
-    pub fn from_json(
+    /// The point estimate, which every metric has.
+    pub fn value(
         report_benchmark_id: ReportBenchmarkId,
         measure_id: MeasureId,
         metric: JsonNewMetric,
     ) -> Self {
-        let JsonNewMetric {
-            value,
-            lower_value,
-            upper_value,
-        } = metric;
+        Self::new(
+            report_benchmark_id,
+            measure_id,
+            MetricName::value(),
+            metric.value.into(),
+        )
+    }
+
+    /// The bounds, which a metric has zero, one, or two of.
+    ///
+    /// STUB: the metric triple does not yet explode into its named rows.
+    pub fn bounds(
+        _report_benchmark_id: ReportBenchmarkId,
+        _measure_id: MeasureId,
+        _metric: JsonNewMetric,
+    ) -> Vec<Self> {
+        Vec::new()
+    }
+
+    fn new(
+        report_benchmark_id: ReportBenchmarkId,
+        measure_id: MeasureId,
+        name: MetricName,
+        value: f64,
+    ) -> Self {
         Self {
             uuid: MetricUuid::new(),
             report_benchmark_id,
             measure_id,
-            value: value.into(),
-            lower_value: lower_value.map(Into::into),
-            upper_value: upper_value.map(Into::into),
+            name,
+            value,
         }
     }
 }

--- a/lib/bencher_schema/src/model/project/metric.rs
+++ b/lib/bencher_schema/src/model/project/metric.rs
@@ -151,10 +151,10 @@ impl InsertMetric {
 // with the `plus` feature (as the rest of the test target already does).
 #[cfg(test)]
 mod tests {
-    use bencher_json::{DateTime, project::Visibility};
-    use diesel::{ExpressionMethods as _, RunQueryDsl as _};
+    use bencher_json::{DateTime, MetricName, project::Visibility};
+    use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 
-    use super::QueryMetric;
+    use super::{MeasureId, QueryMetric, ReportBenchmarkId};
     use crate::{
         context::DbConnection,
         macros::sql::last_insert_rowid,
@@ -190,7 +190,11 @@ mod tests {
 
     // Seed one metric under `project_id`. `base` namespaces the entity UUIDs and
     // slugs so multiple projects can be seeded into the same database.
-    fn seed_metric(conn: &mut DbConnection, project_id: ProjectId, base: u8) {
+    fn seed_metric(
+        conn: &mut DbConnection,
+        project_id: ProjectId,
+        base: u8,
+    ) -> (ReportBenchmarkId, MeasureId) {
         let uuid = |n: u8| format!("00000000-0000-0000-0000-0000000000{:02x}", base + n);
         let branch = create_branch_with_head(
             conn,
@@ -225,6 +229,34 @@ mod tests {
         );
         let report_benchmark = create_report_benchmark(conn, &uuid(7), report, 0, benchmark);
         create_metric(conn, &uuid(8), report_benchmark, measure, 1.0);
+        (report_benchmark, measure)
+    }
+
+    // Give a seeded metric its bound rows, the way an ingested metric triple has them.
+    fn seed_bounds(
+        conn: &mut DbConnection,
+        report_benchmark: ReportBenchmarkId,
+        measure: MeasureId,
+        base: u8,
+    ) {
+        for (offset, name) in [
+            (0x09, MetricName::lower_value()),
+            (0x0a, MetricName::upper_value()),
+        ] {
+            diesel::insert_into(schema::metric::table)
+                .values((
+                    schema::metric::uuid.eq(format!(
+                        "00000000-0000-0000-0000-0000000000{:02x}",
+                        base + offset
+                    )),
+                    schema::metric::report_benchmark_id.eq(report_benchmark),
+                    schema::metric::measure_id.eq(measure),
+                    schema::metric::name.eq(name),
+                    schema::metric::value.eq(1.0),
+                ))
+                .execute(conn)
+                .expect("Failed to insert metric bound");
+        }
     }
 
     #[test]
@@ -245,5 +277,31 @@ mod tests {
         .unwrap();
 
         assert_eq!(all, 2, "usage counts Public and Private Project metrics");
+    }
+
+    // A bounded metric is one measurement, not three. Named values collapse into
+    // their measure's series, so the bound rows must not reach the billable count.
+    #[test]
+    fn usage_does_not_count_the_bound_rows() {
+        let mut conn = setup_test_db();
+        let base = create_base_entities(&mut conn);
+        let (report_benchmark, measure) = seed_metric(&mut conn, base.project_id, 0x20);
+        seed_bounds(&mut conn, report_benchmark, measure, 0x20);
+
+        let rows: i64 = schema::metric::table
+            .count()
+            .get_result(&mut conn)
+            .expect("Failed to count the metric rows");
+        assert_eq!(rows, 3, "the metric triple is three rows");
+
+        let usage = QueryMetric::usage(
+            &mut conn,
+            base.organization_id,
+            DateTime::TEST,
+            DateTime::TEST,
+        )
+        .unwrap();
+
+        assert_eq!(usage, 1, "the bound rows do not bill");
     }
 }

--- a/lib/bencher_schema/src/model/project/metric_boundary.rs
+++ b/lib/bencher_schema/src/model/project/metric_boundary.rs
@@ -1,10 +1,9 @@
-use bencher_json::{BoundaryUuid, MetricUuid};
+use bencher_json::{BoundaryUuid, JsonMetric, MetricUuid};
 
 use crate::{model::project::metric::MetricId, view::metric_boundary as metric_boundary_table};
 
 use super::{
     measure::{MeasureId, QueryMeasure},
-    metric::QueryMetric,
     report::report_benchmark::{QueryReportBenchmark, ReportBenchmarkId},
     threshold::{
         ThresholdId,
@@ -40,12 +39,18 @@ pub struct QueryMetricBoundary {
 }
 
 impl QueryMetricBoundary {
-    pub fn split(self) -> (QueryMetric, Option<QueryBoundary>) {
+    /// The view pivots the named rows back into the metric triple, so the JSON it
+    /// yields is the same JSON the row-per-measure table yielded.
+    pub fn into_json_metric(self) -> JsonMetric {
+        self.split().0
+    }
+
+    pub fn split(self) -> (JsonMetric, Option<QueryBoundary>) {
         let Self {
             metric_id,
             metric_uuid,
-            report_benchmark_id,
-            measure_id,
+            report_benchmark_id: _,
+            measure_id: _,
             value,
             lower_value,
             upper_value,
@@ -57,14 +62,11 @@ impl QueryMetricBoundary {
             lower_limit,
             upper_limit,
         } = self;
-        let query_metric = QueryMetric {
-            id: metric_id,
+        let json_metric = JsonMetric {
             uuid: metric_uuid,
-            report_benchmark_id,
-            measure_id,
-            value,
-            lower_value,
-            upper_value,
+            value: value.into(),
+            lower_value: lower_value.map(Into::into),
+            upper_value: upper_value.map(Into::into),
         };
         let query_boundary = if let (Some(id), Some(uuid), Some(threshold_id), Some(model_id)) =
             (boundary_id, boundary_uuid, threshold_id, model_id)
@@ -82,6 +84,6 @@ impl QueryMetricBoundary {
         } else {
             None
         };
-        (query_metric, query_boundary)
+        (json_metric, query_boundary)
     }
 }

--- a/lib/bencher_schema/src/model/project/parameter.rs
+++ b/lib/bencher_schema/src/model/project/parameter.rs
@@ -642,6 +642,24 @@ mod tests {
         .expect("Failed to seed legacy rows");
     }
 
+    /// Revert every migration down to and including the parameter migration.
+    ///
+    /// The parameter migration is not the last one any more, so reverting only the
+    /// last one would revert someone else's. Each layer above it is reverted first,
+    /// and `run_pending_migrations` puts them all back.
+    fn revert_to_parameter_migration(conn: &mut SqliteConnection) {
+        const PARAMETER_MIGRATION: &str = "20260815120000";
+
+        loop {
+            let version = conn
+                .revert_last_migration(crate::MIGRATIONS)
+                .expect("Failed to revert a migration");
+            if version.to_string() == PARAMETER_MIGRATION {
+                break;
+            }
+        }
+    }
+
     #[test]
     fn migration_backfills_empty_parameter_sets() {
         let mut conn = setup_test_db();
@@ -650,8 +668,7 @@ mod tests {
         // migration in one, so they are disabled around the revert and re-apply.
         conn.batch_execute("PRAGMA foreign_keys = OFF")
             .expect("Failed to disable foreign keys");
-        conn.revert_last_migration(crate::MIGRATIONS)
-            .expect("Failed to revert the parameter migration");
+        revert_to_parameter_migration(&mut conn);
 
         seed_legacy_rows(&mut conn);
 
@@ -814,8 +831,7 @@ mod tests {
 
         conn.batch_execute("PRAGMA foreign_keys = OFF")
             .expect("Failed to disable foreign keys");
-        conn.revert_last_migration(crate::MIGRATIONS)
-            .expect("Failed to revert the parameter migration");
+        revert_to_parameter_migration(&mut conn);
         conn.run_pending_migrations(crate::MIGRATIONS)
             .expect("Failed to re-apply the parameter migration");
         conn.batch_execute("PRAGMA foreign_keys = ON")

--- a/lib/bencher_schema/src/model/project/report/mod.rs
+++ b/lib/bencher_schema/src/model/project/report/mod.rs
@@ -89,7 +89,6 @@ impl NewRunJob {
 
 use super::{
     branch::{BranchId, QueryBranch, head::HeadId, version::VersionId},
-    metric::QueryMetric,
     metric_boundary::QueryMetricBoundary,
     threshold::{InsertThreshold, boundary::QueryBoundary},
 };
@@ -747,10 +746,10 @@ fn into_report_results_json(
             }
         }
 
-        let (query_metric, query_boundary) = query_metric_boundary.split();
+        let (json_metric, query_boundary) = query_metric_boundary.split();
         let report_measure = JsonReportMeasure {
             measure: query_measure.into_json_for_project(project),
-            metric: query_metric.into_json(),
+            metric: json_metric,
             threshold: threshold_model.map(|(threshold, model)| {
                 threshold.into_threshold_model_json_for_project(project, model)
             }),
@@ -899,7 +898,7 @@ fn get_report_alerts(
     let alerts = schema::alert::table
         .inner_join(
             schema::boundary::table.inner_join(
-                schema::metric::table.inner_join(
+                view::metric_boundary::table.inner_join(
                     schema::report_benchmark::table
                         .inner_join(schema::report::table)
                         .inner_join(schema::benchmark::table),
@@ -914,7 +913,7 @@ fn get_report_alerts(
             schema::report_benchmark::iteration,
             QueryAlert::as_select(),
             QueryBenchmark::as_select(),
-            QueryMetric::as_select(),
+            QueryMetricBoundary::as_select(),
             QueryBoundary::as_select(),
         ))
         .load::<(
@@ -923,7 +922,7 @@ fn get_report_alerts(
             Iteration,
             QueryAlert,
             QueryBenchmark,
-            QueryMetric,
+            QueryMetricBoundary,
             QueryBoundary,
         )>(conn)
         .map_err(resource_not_found_err!(Alert, report_id))?;
@@ -935,7 +934,7 @@ fn get_report_alerts(
         iteration,
         query_alert,
         query_benchmark,
-        query_metric,
+        query_metric_boundary,
         query_boundary,
     ) in alerts
     {
@@ -949,7 +948,7 @@ fn get_report_alerts(
             spec_id,
             iteration,
             query_benchmark,
-            query_metric,
+            query_metric_boundary,
             query_boundary,
         )?;
         report_alerts.push(json_alert);

--- a/lib/bencher_schema/src/model/project/report/results/detector/data.rs
+++ b/lib/bencher_schema/src/model/project/report/results/detector/data.rs
@@ -1,4 +1,5 @@
 use bencher_boundary::MetricsData;
+use bencher_json::MetricName;
 use chrono::offset::Utc;
 use diesel::{ExpressionMethods as _, JoinOnDsl as _, QueryDsl as _, RunQueryDsl as _};
 use dropshot::HttpError;
@@ -35,6 +36,11 @@ pub fn metrics_data(
         .filter(schema::testbed::id.eq(detector.testbed_id))
         .filter(schema::benchmark::id.eq(benchmark_id))
         .filter(schema::metric::measure_id.eq(detector.measure_id))
+        // Detection has only ever gated the `value` scalar, and the sample it is
+        // gated against is the point estimates alone. A measure's bounds are named
+        // rows beside it now, so without this the sample would be a mixture of
+        // measurements and the limits previously computed from them.
+        .filter(schema::metric::name.eq(MetricName::value()))
         .into_boxed();
 
     if let Some(spec_id) = detector.spec_id {

--- a/lib/bencher_schema/src/model/project/report/results/mod.rs
+++ b/lib/bencher_schema/src/model/project/report/results/mod.rs
@@ -211,7 +211,10 @@ impl ReportResults {
                 for prepared_metric in prepared.metrics {
                     #[cfg(feature = "plus")]
                     series_keys.push((benchmark_id, prepared_metric.measure_id));
-                    let insert_metric = InsertMetric::from_json(
+                    // The point estimate goes in first so that `last_insert_rowid`
+                    // still names the row a boundary attaches to. Detection has only
+                    // ever gated the `value` scalar.
+                    let insert_metric = InsertMetric::value(
                         report_benchmark_id,
                         prepared_metric.measure_id,
                         prepared_metric.metric,
@@ -224,6 +227,17 @@ impl ReportResults {
                     if let Some(prepared_detection) = prepared_metric.detection {
                         let metric_id = diesel::select(last_insert_rowid()).get_result(conn)?;
                         prepared_detection.write(conn, metric_id)?;
+                    }
+
+                    let insert_bounds = InsertMetric::bounds(
+                        report_benchmark_id,
+                        prepared_metric.measure_id,
+                        prepared_metric.metric,
+                    );
+                    if !insert_bounds.is_empty() {
+                        diesel::insert_into(schema::metric::table)
+                            .values(&insert_bounds)
+                            .execute(conn)?;
                     }
                 }
             }

--- a/lib/bencher_schema/src/model/project/series.rs
+++ b/lib/bencher_schema/src/model/project/series.rs
@@ -245,7 +245,7 @@ pub(crate) fn oracle_count(
 
 #[cfg(test)]
 mod tests {
-    use bencher_json::{DateTime, project::Visibility};
+    use bencher_json::{DateTime, MetricName, project::Visibility};
     use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
 
     use super::{count_active, count_active_private, oracle_count, upsert_series_last_seen};
@@ -431,6 +431,7 @@ mod tests {
                 schema::metric::uuid.eq(&metric_uuid),
                 schema::metric::report_benchmark_id.eq(report_benchmark),
                 schema::metric::measure_id.eq(measure),
+                schema::metric::name.eq(MetricName::value()),
                 schema::metric::value.eq(1.0f64),
             ))
             .execute(conn)

--- a/lib/bencher_schema/src/model/project/threshold/alert.rs
+++ b/lib/bencher_schema/src/model/project/threshold/alert.rs
@@ -22,11 +22,12 @@ use crate::{
             ProjectId, QueryProject,
             benchmark::QueryBenchmark,
             branch::{head::HeadId, version::VersionId},
-            metric::QueryMetric,
+            metric_boundary::QueryMetricBoundary,
         },
         spec::SpecId,
     },
     schema::{self, alert as alert_table},
+    view,
 };
 
 crate::macros::typed_id::typed_id!(AlertId);
@@ -100,13 +101,13 @@ impl QueryAlert {
             spec_id,
             iteration,
             query_benchmark,
-            query_metric,
+            query_metric_boundary,
             query_boundary,
         ) = schema::alert::table
             .filter(schema::alert::id.eq(self.id))
             .inner_join(
                 schema::boundary::table.inner_join(
-                    schema::metric::table.inner_join(
+                    view::metric_boundary::table.inner_join(
                         schema::report_benchmark::table
                             .inner_join(schema::report::table)
                             .inner_join(schema::benchmark::table),
@@ -121,7 +122,7 @@ impl QueryAlert {
                 schema::report::spec_id,
                 schema::report_benchmark::iteration,
                 QueryBenchmark::as_select(),
-                QueryMetric::as_select(),
+                QueryMetricBoundary::as_select(),
                 QueryBoundary::as_select(),
             ))
             .first::<(
@@ -132,7 +133,7 @@ impl QueryAlert {
                 Option<SpecId>,
                 Iteration,
                 QueryBenchmark,
-                QueryMetric,
+                QueryMetricBoundary,
                 QueryBoundary,
             )>(conn)
             .map_err(resource_not_found_err!(Alert, self))?;
@@ -147,7 +148,7 @@ impl QueryAlert {
             spec_id,
             iteration,
             query_benchmark,
-            query_metric,
+            query_metric_boundary,
             query_boundary,
         )
     }
@@ -167,7 +168,7 @@ impl QueryAlert {
         spec_id: Option<SpecId>,
         iteration: Iteration,
         query_benchmark: QueryBenchmark,
-        query_metric: QueryMetric,
+        query_metric_boundary: QueryMetricBoundary,
         query_boundary: QueryBoundary,
     ) -> Result<JsonAlert, HttpError> {
         let Self {
@@ -190,7 +191,7 @@ impl QueryAlert {
             report: report_uuid,
             iteration,
             benchmark: query_benchmark.into_json_for_project(project),
-            metric: query_metric.into_json(),
+            metric: query_metric_boundary.into_json_metric(),
             threshold,
             boundary: query_boundary.into_json(),
             limit: boundary_limit,

--- a/lib/bencher_schema/src/schema.rs
+++ b/lib/bencher_schema/src/schema.rs
@@ -120,9 +120,8 @@ diesel::table! {
         uuid -> Text,
         report_benchmark_id -> Integer,
         measure_id -> Integer,
+        name -> Text,
         value -> Double,
-        lower_value -> Nullable<Double>,
-        upper_value -> Nullable<Double>,
     }
 }
 

--- a/lib/bencher_schema/src/test_util.rs
+++ b/lib/bencher_schema/src/test_util.rs
@@ -10,7 +10,7 @@
 //! so no concurrent INSERT can interleave between the INSERT and the `last_insert_rowid()` call.
 
 use bencher_json::{
-    DateTime, JsonParameters, ParameterUuid,
+    DateTime, JsonParameters, MetricName, ParameterUuid,
     project::{
         alert::AlertStatus,
         boundary::BoundaryLimit,
@@ -623,6 +623,7 @@ pub fn create_metric(
             schema::metric::uuid.eq(metric_uuid),
             schema::metric::report_benchmark_id.eq(report_benchmark_id),
             schema::metric::measure_id.eq(measure_id),
+            schema::metric::name.eq(MetricName::value()),
             schema::metric::value.eq(value),
         ))
         .execute(conn)

--- a/lib/bencher_schema/src/view.rs
+++ b/lib/bencher_schema/src/view.rs
@@ -22,6 +22,10 @@ diesel::table! {
     }
 }
 
+// A boundary is attached to the `value` row, which is the row the view is keyed
+// on, so an alert can reach its metric through the view rather than the table and
+// get the pivoted metric triple with it.
+diesel::joinable!(boundary -> metric_boundary (metric_id));
 diesel::joinable!(metric_boundary -> measure (measure_id));
 diesel::joinable!(metric_boundary -> report_benchmark (report_benchmark_id));
 diesel::joinable!(metric_boundary -> model (model_id));

--- a/lib/bencher_valid/src/error.rs
+++ b/lib/bencher_valid/src/error.rs
@@ -24,6 +24,8 @@ pub enum ValidError {
     BranchName(String),
     #[error("Failed to validate benchmark name: {0}")]
     BenchmarkName(String),
+    #[error("Failed to validate metric name: {0}")]
+    MetricName(String),
     #[error("Failed to validate name ID: {0:?}")]
     NameId(String),
     #[error("Failed to validate benchmark parameter key: {0}")]

--- a/lib/bencher_valid/src/lib.rs
+++ b/lib/bencher_valid/src/lib.rs
@@ -14,6 +14,7 @@ mod image_digest;
 mod index;
 mod jwt;
 pub mod keys;
+mod metric_name;
 mod model;
 mod name_id;
 mod non_empty;
@@ -43,6 +44,7 @@ pub use error::ValidError;
 pub use index::Index;
 pub use jwt::Jwt;
 pub use keys::{BencherKey, ProjectKey, ProjectKeyHash, UserKey, UserKeyHash};
+pub use metric_name::MetricName;
 pub use model::{
     Model,
     boundary::{Boundary, CdfBoundary, IqrBoundary, PercentageBoundary},

--- a/lib/bencher_valid/src/metric_name.rs
+++ b/lib/bencher_valid/src/metric_name.rs
@@ -1,0 +1,136 @@
+use derive_more::Display;
+#[cfg(feature = "schema")]
+use schemars::JsonSchema;
+use std::str::FromStr;
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::wasm_bindgen;
+
+use serde::{Deserialize, Serialize};
+
+use crate::ValidError;
+
+/// The name of a single scalar inside a metric.
+///
+/// Every name is equal on the wire. `value`, `lower_value`, and `upper_value` are
+/// conventional, not privileged: they are the names the metric triple maps onto,
+/// and the names the console knows well enough to draw a band.
+#[derive(Debug, Display, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(try_from = "String")]
+#[cfg_attr(feature = "db", derive(diesel::FromSqlRow, diesel::AsExpression))]
+#[cfg_attr(feature = "db", diesel(sql_type = diesel::sql_types::Text))]
+pub struct MetricName(String);
+
+#[cfg(feature = "db")]
+crate::typed_string!(MetricName);
+
+impl MetricName {
+    pub const MAX_LEN: usize = crate::MAX_LEN;
+
+    /// The point estimate. A real name like any other, not a sentinel.
+    #[must_use]
+    pub fn value() -> Self {
+        Self(VALUE.to_owned())
+    }
+
+    /// The lower bound of the metric triple.
+    #[must_use]
+    pub fn lower_value() -> Self {
+        Self(LOWER_VALUE.to_owned())
+    }
+
+    /// The upper bound of the metric triple.
+    #[must_use]
+    pub fn upper_value() -> Self {
+        Self(UPPER_VALUE.to_owned())
+    }
+}
+
+/// The conventional name of the point estimate.
+pub const VALUE: &str = "value";
+/// The conventional name of the lower bound.
+pub const LOWER_VALUE: &str = "lower_value";
+/// The conventional name of the upper bound.
+pub const UPPER_VALUE: &str = "upper_value";
+
+impl TryFrom<String> for MetricName {
+    type Error = ValidError;
+
+    fn try_from(metric_name: String) -> Result<Self, Self::Error> {
+        if is_valid_metric_name(&metric_name) {
+            Ok(Self(metric_name))
+        } else {
+            Err(ValidError::MetricName(metric_name))
+        }
+    }
+}
+
+impl FromStr for MetricName {
+    type Err = ValidError;
+
+    fn from_str(metric_name: &str) -> Result<Self, Self::Err> {
+        Self::try_from(metric_name.to_owned())
+    }
+}
+
+impl AsRef<str> for MetricName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<MetricName> for String {
+    fn from(metric_name: MetricName) -> Self {
+        metric_name.0
+    }
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+pub fn is_valid_metric_name(metric_name: &str) -> bool {
+    crate::is_valid_non_empty(metric_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::{LEN_0_STR, LEN_64_STR, LEN_65_STR};
+
+    use super::{MetricName, is_valid_metric_name};
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn is_valid_metric_name_true() {
+        for value in [
+            "value",
+            "lower_value",
+            "upper_value",
+            "p99",
+            "p50",
+            LEN_64_STR,
+            LEN_65_STR,
+        ] {
+            assert_eq!(true, is_valid_metric_name(value), "{value}");
+        }
+    }
+
+    #[test]
+    fn is_valid_metric_name_false() {
+        assert_eq!(false, is_valid_metric_name(LEN_0_STR));
+    }
+
+    #[test]
+    fn conventional_names() {
+        assert_eq!(MetricName::value().as_ref(), "value");
+        assert_eq!(MetricName::lower_value().as_ref(), "lower_value");
+        assert_eq!(MetricName::upper_value().as_ref(), "upper_value");
+    }
+
+    #[test]
+    fn metric_name_serde_roundtrip() {
+        let metric_name: MetricName = serde_json::from_str("\"p99\"").unwrap();
+        assert_eq!(metric_name.as_ref(), "p99");
+        let json = serde_json::to_string(&metric_name).unwrap();
+        assert_eq!(json, "\"p99\"");
+
+        serde_json::from_str::<MetricName>("\"\"").unwrap_err();
+    }
+}

--- a/lib/bencher_valid/src/metric_name.rs
+++ b/lib/bencher_valid/src/metric_name.rs
@@ -106,7 +106,6 @@ mod tests {
             "p99",
             "p50",
             LEN_64_STR,
-            LEN_65_STR,
         ] {
             assert_eq!(true, is_valid_metric_name(value), "{value}");
         }
@@ -114,7 +113,9 @@ mod tests {
 
     #[test]
     fn is_valid_metric_name_false() {
-        assert_eq!(false, is_valid_metric_name(LEN_0_STR));
+        for value in [LEN_0_STR, LEN_65_STR] {
+            assert_eq!(false, is_valid_metric_name(value), "{value}");
+        }
     }
 
     #[test]

--- a/lib/bencher_valid/src/metric_name.rs
+++ b/lib/bencher_valid/src/metric_name.rs
@@ -7,7 +7,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 
 use serde::{Deserialize, Serialize};
 
-use crate::ValidError;
+use crate::{ValidError, is_valid_len};
 
 /// The name of a single scalar inside a metric.
 ///
@@ -87,7 +87,7 @@ impl From<MetricName> for String {
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub fn is_valid_metric_name(metric_name: &str) -> bool {
-    crate::is_valid_non_empty(metric_name)
+    is_valid_len(metric_name)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Layer 2 of the benchmark parameters stack. Stacked on #988. Targets `u/ep/benchmark-parameters/parameter-table` and retargets `devel` when that merges.

A metric row is now one named scalar. `metric` becomes `(report_benchmark_id, measure_id, name, value)`, with `name` sitting among the identity columns and the `lower_value` and `upper_value` columns dropped. Uniqueness extends to `(report_benchmark_id, measure_id, name)`. The metric triple is not a shape the table knows about any more. It is a convention over three names, `value`, `lower_value`, and `upper_value`, each an ordinary row. Nothing about this reaches the wire, and nothing about it is meant to be visible.

## Nothing changes for anyone

Every response that reads a metric is byte identical across the migration, and the tests prove it with captured bytes rather than an assertion. `metric_migration.rs` seeds a database in the shape the migration finds, captures the raw bodies of the perf query, the metric endpoint, the report, and the alerts, runs the migration, and captures them again. The two captures must be equal byte for byte, not equal after parsing. Parsing and re-serializing would hide exactly the float formatting drift this layer exists to rule out.

The fixtures are chosen to break a careless implementation. Metrics with both bounds, the lower bound only, the upper bound only, and neither, spread over two measures and two report benchmarks, so a pivot that joins on the wrong key leaks a bound across a row and fails. The floats are the ones that expose formatting drift, not round numbers. The rows are seeded with explicit, non-contiguous ids, because real metric ids have gaps in them. Deleting a report cascades its metrics away. A fixture numbered from one cannot tell a migration that keeps every id from one that reassigns them, since `INSERT ... SELECT` into an empty table hands back the same numbering either way.

One binary serves both captures because every reader goes through the `metric_boundary` view, whose column list the migration holds unchanged. That is the whole trick of this layer. The view pivots the named rows back into the three columns its readers know, so the perf query, the metric endpoint, the report, and the alerts are untouched. The two alert queries that read the `metric` table directly move onto the view, which is what makes them read either shape.

## Detection samples the point estimates

A threshold's sample is read straight off the `metric` table, filtered by measure. A bound is a named row under that same measure now, so the filter has to name the point estimate too. Without it the sample becomes a mixture of measurements and the limits previously computed from them, the mean and standard deviation are taken over that mixture, and a bounded `max_sample_size` fills with a fraction of the history it asked for. Detection has only ever gated the `value` scalar, and the sample it is gated against is the point estimates alone.

`detection_samples_only_the_point_estimates` pins it end to end: two projects with the same point-estimate history, one of which also carries bounds, must produce the same boundary for the same next report. Before the filter, the same fixture computed a baseline of `12.0` in one and `1004.0` in the other.

## The migration

Each old row explodes into up to three. The `value` row keeps the original id and uuid, which makes the boundary remap a no-op: `boundary.metric_id` already points at that id, so no `boundary` row is rewritten and its unique constraint is undisturbed. Each stored bound becomes a new row with a minted uuid.

The minted uuids are v7 shaped. The 48 bit millisecond prefix is computed once into a temporary table and cross joined into both bound inserts, so every uuid the migration mints is a v7 of the one instant the migration ran at. The rest of the uuid is `randomblob`, with the version nibble set to 7 and the variant nibble drawn from `89ab` by `random() & 3` rather than `abs(random()) % 4`, because `abs(-9223372036854775808)` is an integer overflow error in SQLite. The prefix comes from `julianday` rather than `unixepoch('now', 'subsec')`, which is newer than the oldest SQLite that can otherwise run this migration. An earlier revision of this description argued the shared prefix for index locality, and that argument is retracted. The uuid index is now built after the rows land, by an external sort that is indifferent to where its keys fall, so neither the shared prefix nor the v4 uuids the preserved rows carry over cost the build anything. The timings that argument cited were measured against the online build and no longer describe this migration. The prefix stays because it is what makes a minted uuid a v7, not because of what it costs.

`down.sql` is a true inverse: the bound rows fold back into the columns they came from. Names outside the triple have no column to land in and are dropped, which is the price of going back to a shape that cannot hold them.

### One known gap

A `lower_value` or `upper_value` row's own uuid does not resolve through the pivoted view, so `GET /v0/projects/{project}/metrics/{uuid}` on one of them is a 404. This is acceptable and is not fixed here. No uuid that existed before the migration is affected, because the `value` row keeps its own, and the uuids the migration mints have never been exposed anywhere. Nothing reads them, nothing returns them, and no client has ever seen one. When a payload can name its own scalars, the endpoint gets a shape that can address them.

### The unique keys are built after the rows land

`up_metric` is created without its two unique constraints, and they arrive after the third insert as named unique indexes on the same table, which the rename then carries over:

```sql
CREATE UNIQUE INDEX index_metric_uuid ON up_metric(uuid);
CREATE UNIQUE INDEX index_metric_report_benchmark_measure_name ON up_metric(report_benchmark_id, measure_id, name);
```

Declared on the table, the two indexes are maintained online across every insert the explosion produces, two unique B-trees held dirty a page split at a time, and the `value` rows carry their original uuids, which are v4, so each one lands on a random page of the uuid index. Built after the rows land, each is one external sort. Measured over the whole rebuild on a synthetic database at production's page size and cache ratio, deferring them takes page reads from 179,939 to 11,222 and page writes from 181,037 to 6,146: 16 times fewer reads and 29 times fewer writes.

What is enforced does not move. A named unique index and a table constraint are the same index to SQLite, down to the `UNIQUE constraint failed: metric.uuid` it reports on a collision, so the pivot rides the same key and the query plan above is the same plan. `down.sql` needs no change. It recreates the pre-migration table with its own constraints, and its `DROP TABLE metric` takes the named indexes with it. The round trip test asserts the two index names it finds after a down and up.

### Query plan

The view's self joins ride `index_metric_report_benchmark_measure_name`. Because that index makes them at most one row, SQLite omits them outright for any query that does not select a bound. Measured with `EXPLAIN QUERY PLAN` on an `ANALYZE`d database before and after the migration, the pivot adds exactly two fully bound index seeks and no scan:

```
-- selecting the bounds
SEARCH metric USING INDEX index_metric_report_benchmark_measure_name (report_benchmark_id=? AND measure_id=? AND name=?)
SEARCH lower_metric USING INDEX index_metric_report_benchmark_measure_name (report_benchmark_id=? AND measure_id=? AND name=?) LEFT-JOIN
SEARCH upper_metric USING INDEX index_metric_report_benchmark_measure_name (report_benchmark_id=? AND measure_id=? AND name=?) LEFT-JOIN
SEARCH boundary USING INDEX sqlite_autoindex_boundary_2 (metric_id=?) LEFT-JOIN

-- not selecting the bounds
SEARCH metric USING INDEX index_metric_report_benchmark_measure_name (report_benchmark_id=? AND measure_id=? AND name=?)
```

Everything else in the plan is unchanged, and the driving `metric` step tightens from two bound columns to three.

## Synthetic fixture run

A throwaway database built by applying every earlier migration to an empty file and seeding 3 branches, 2 testbeds, 100 benchmarks, 3 measures, 300 versions, 600 reports, 120,000 report benchmarks, 360,000 metrics, 72,000 boundaries and 18,000 alerts. Bounds are spread across all four cases: half the metrics carry both, a tenth the lower only, a tenth the upper only, and the rest neither.

| | |
| --- | --- |
| Rows before | 360,000 |
| Rows after | 792,000 (360,000 `value`, 216,000 `lower_value`, 216,000 `upper_value`) |
| Ratio | 2.20 |
| Apply | 2.79s in one transaction |
| Revert | 0.71s |
| Re-apply | 2.85s |
| `PRAGMA foreign_key_check` | empty, 0.12s |
| `PRAGMA integrity_check` | `ok`, 1.33s |
| File before / write-ahead log at commit / file after | 73 MiB / 109 MiB / 181 MiB |

Every check held: the `boundary` table dump is byte identical before and after, the full 14 column `metric_boundary` dump is byte identical before and after and again after a down and up round trip, `count(DISTINCT uuid)` equals `count(*)`, the `sqlite_master` diff shows only the `metric` table and the view, and all 432,000 minted uuids carry version nibble 7, a variant nibble uniformly drawn from `89ab`, and exactly one shared millisecond prefix.

The write-ahead log growing larger than the database it started from is the thing to plan around. This is one write transaction that holds the old table, the new table and the log at once.

## Billing does not move

`QueryMetric::usage` counts the point estimate only. Named values collapse into their measure's series, so a bounded metric bills as one measurement, exactly as it did when it was one row. In this shape every measure has exactly one `value` row, which makes the count identical by construction. The billing layer revisits this when a payload can name `p99` and never name `value`.

`usage_does_not_count_the_bound_rows` holds that. It seeds a metric with both bounds and asserts three rows still bill as one. Removing the filter fails it.

## Draft until the dry run

This rebuilds the whole metric table, so it stays a draft until a timed migration dry run against production scale data comes back clean. It is not to be marked ready before then. Results go here when it runs.

The dry run works on a copy, never in place. Foreign keys must be off on the connection and outside any transaction before anything else, because `PRAGMA foreign_keys` is a no-op inside a transaction and `boundary.metric_id REFERENCES metric (id) ON DELETE CASCADE`. If they are enforced when `DROP TABLE metric` runs, then every boundary and every alert hanging off it goes with it. The API server already does this around startup migrations.

```
cp snapshot.db dryrun.db
MIG=lib/bencher_schema/migrations/2026-08-16-120000_single_valued_metric
{ echo "PRAGMA foreign_keys=off;"; echo "BEGIN;"; cat $MIG/up.sql;   echo "COMMIT;"; } > apply.sql
{ echo "PRAGMA foreign_keys=off;"; echo "BEGIN;"; cat $MIG/down.sql; echo "COMMIT;"; } > revert.sql

VIEW="SELECT metric_id,metric_uuid,report_benchmark_id,measure_id,value,
  coalesce(lower_value,'~'),coalesce(upper_value,'~'),coalesce(boundary_id,'~'),
  coalesce(boundary_uuid,'~'),coalesce(threshold_id,'~'),coalesce(model_id,'~'),
  coalesce(baseline,'~'),coalesce(lower_limit,'~'),coalesce(upper_limit,'~')
  FROM metric_boundary ORDER BY metric_id;"
BOUNDARY="SELECT id,uuid,metric_id,threshold_id,model_id,baseline,lower_limit,upper_limit
  FROM boundary ORDER BY id;"
MASTER="SELECT type,name,tbl_name,coalesce(sql,'') FROM sqlite_master ORDER BY type,name;"

sqlite3 dryrun.db "SELECT 'metric',count(*) FROM metric
  UNION ALL SELECT 'with_lower',count(*) FROM metric WHERE lower_value IS NOT NULL
  UNION ALL SELECT 'with_upper',count(*) FROM metric WHERE upper_value IS NOT NULL
  UNION ALL SELECT 'boundary',count(*) FROM boundary
  UNION ALL SELECT 'alert',count(*) FROM alert;"
sqlite3 dryrun.db "$VIEW" > view_pre.txt
sqlite3 dryrun.db "$BOUNDARY" > boundary_pre.txt
sqlite3 dryrun.db "$MASTER" > master_pre.txt

time sqlite3 -bail dryrun.db < apply.sql

sqlite3 dryrun.db "SELECT name,count(*) FROM metric GROUP BY name;
  SELECT 'total',count(*) FROM metric;
  SELECT 'distinct_uuid',count(DISTINCT uuid) FROM metric;"
sqlite3 dryrun.db "$VIEW" > view_post.txt;         cmp view_pre.txt view_post.txt
sqlite3 dryrun.db "$BOUNDARY" > boundary_post.txt; cmp boundary_pre.txt boundary_post.txt
sqlite3 dryrun.db "$MASTER" > master_post.txt;     diff master_pre.txt master_post.txt
sqlite3 dryrun.db "PRAGMA foreign_key_check;"
sqlite3 dryrun.db "PRAGMA integrity_check;"

time sqlite3 -bail dryrun.db < revert.sql
sqlite3 dryrun.db "$VIEW" > view_reverted.txt;  cmp view_pre.txt view_reverted.txt
time sqlite3 -bail dryrun.db < apply.sql
sqlite3 dryrun.db "$VIEW" > view_roundtrip.txt; cmp view_pre.txt view_roundtrip.txt
sqlite3 dryrun.db "PRAGMA foreign_key_check;"; sqlite3 dryrun.db "PRAGMA integrity_check;"
```

Expected: `value` rows equal the metric count before, `lower_value` rows equal the `with_lower` count, `upper_value` rows equal the `with_upper` count, so the ratio is `1 + (with_lower + with_upper) / metric` and is bounded above by 3. Every `cmp` is silent. The `sqlite_master` diff shows the `metric` `CREATE TABLE`, the `metric_boundary` `CREATE VIEW`, and the index rows: `metric` carries `index_metric_uuid` and `index_metric_report_benchmark_measure_name` and no autoindex at all, where before it carried `sqlite_autoindex_metric_1` and `_2` and no named index. `foreign_key_check` returns nothing, `integrity_check` returns `ok`, and `count(DISTINCT uuid)` equals `count(*)`.

A failure is any of: a non-silent `cmp`, a `sqlite_master` difference beyond those two objects, any row from `foreign_key_check`, anything but `ok` from `integrity_check`, a `value` row count that does not equal the metric count before, `count(DISTINCT uuid)` below `count(*)`, an error from either script, or a wall clock beyond the maintenance window budgeted for it.

| | |
| --- | --- |
| Wall clock | |
| Rows before / after | |
| Bound rows created | |
| Boundary rows rewritten | expected 0 |
| `PRAGMA foreign_key_check` | expected empty |
| `PRAGMA integrity_check` | expected `ok` |
| Response equivalence spot check | |

## Tests

Tests are committed first and fail there. `536d408` carried the first round: the equivalence test failed on the perf response, the explosion test on its row count, and the ingest test on the bound that never came back. `perf_lower_upper_values` went red alongside them and green with the implementation.

`afe70b7` carries the second round. `detection_samples_only_the_point_estimates` failed on the boundary, `12.0` against `1004.0` at the baseline, and `migration_explodes_the_metric_triple_into_named_rows` failed on the uuid version nibble, 4 against 7. The rest of that commit hardens tests that already passed against mutations they should have caught and did not: the fixture's non-contiguous ids, following the boundary through to the measurement it was created against rather than observing that it was not rewritten, anchoring the round trip against the pre-migration capture so a symmetric error cannot cancel itself out, asserting the indexes and the view's column list and both integrity pragmas after the round trip, and asserting that a duplicate name under one measurement collides.

The mutation those were written for is deleting `id` from the value row insert so the migration renumbers what it carries over. Before, nothing caught it. Now three tests do: the explosion test, the byte equivalence test, and the round trip.

The parameter migration is no longer the last one, so its tests revert down to it by version rather than reverting whatever happens to be on top.

## CI

The gate counts below predate the commit that defers the index build.

The workflow only runs for pull requests based on `main`, `cloud`, or `devel`, so a stacked pull request gets no run until it retargets `devel`. Every gate was run locally in the meantime: `cargo fmt --check`, `cargo clippy --no-deps --all-targets --all-features -- -Dwarnings`, `cargo check --no-default-features`, `cargo nextest run --workspace --all-features` (2017 passed, 3 skipped), `cargo nextest run -p bencher_schema --features plus` (190 passed), `cargo test --doc --workspace --all-features`, `cargo deny check`, the `bencher_valid` WASM build, and `cargo gen-types`, which produces no diff because nothing here reaches the wire.



