### PR TITLE
Give createResource the source type it needs

### DIFF
--- a/services/console/src/components/auth/AuthOAuth.tsx
+++ b/services/console/src/components/auth/AuthOAuth.tsx
@@ -81,7 +81,11 @@ const AuthOAuth = (props: Props) => {
 				);
 			});
 	};
-	const [_jsonAuthUser] = createResource<JsonAuthUser>(fetcher, getAuthUser);
+	const [_jsonAuthUser] = createResource<
+		// biome-ignore lint/suspicious/noConfusingVoidType: getAuthUser navigates and returns nothing
+		void | null,
+		ReturnType<typeof fetcher>
+	>(fetcher, getAuthUser);
 
 	return <></>;
 };

--- a/services/console/src/components/auth/AuthRedirect.tsx
+++ b/services/console/src/components/auth/AuthRedirect.tsx
@@ -1,11 +1,6 @@
 import * as Sentry from "@sentry/astro";
 import { Show, createMemo, createResource } from "solid-js";
-import type {
-	JsonAccept,
-	JsonAuthAck,
-	JsonAuthUser,
-	JsonOrganization,
-} from "../../types/bencher";
+import type { JsonAccept, JsonAuthUser } from "../../types/bencher";
 import { authUser } from "../../util/auth";
 import { httpPost } from "../../util/http";
 import { NotifyKind, navigateNotify } from "../../util/notify";
@@ -57,7 +52,11 @@ const AuthRedirect = (props: { apiUrl?: string; path: string }) => {
 				);
 			});
 	};
-	const [_jsonAuth] = createResource<JsonAuthAck>(acceptFetcher, acceptInvite);
+	const [_jsonAuth] = createResource<
+		// biome-ignore lint/suspicious/noConfusingVoidType: acceptInvite navigates and returns nothing
+		void | null,
+		ReturnType<typeof acceptFetcher>
+	>(acceptFetcher, acceptInvite);
 
 	const claimFetcher = createMemo(() => {
 		return {
@@ -97,10 +96,11 @@ const AuthRedirect = (props: { apiUrl?: string; path: string }) => {
 				);
 			});
 	};
-	const [_jsonOrganization] = createResource<JsonOrganization>(
-		claimFetcher,
-		claimProject,
-	);
+	const [_jsonOrganization] = createResource<
+		// biome-ignore lint/suspicious/noConfusingVoidType: claimProject navigates and returns nothing
+		void | null,
+		ReturnType<typeof claimFetcher>
+	>(claimFetcher, claimProject);
 
 	return (
 		<Show

--- a/services/console/src/components/console/billing/BillingPanel.tsx
+++ b/services/console/src/components/console/billing/BillingPanel.tsx
@@ -100,10 +100,10 @@ const BillingPanel = (props: Props) => {
 				return null;
 			});
 	};
-	const [usage, { refetch }] = createResource<null | JsonUsage>(
-		fetcher,
-		fetchPlan,
-	);
+	const [usage, { refetch }] = createResource<
+		null | JsonUsage,
+		ReturnType<typeof fetcher>
+	>(fetcher, fetchPlan);
 
 	return (
 		<Show

--- a/services/console/src/components/console/onboard/OnboardInvite.tsx
+++ b/services/console/src/components/console/onboard/OnboardInvite.tsx
@@ -87,10 +87,10 @@ const OnboardInvite = (props: Props) => {
 				return;
 			});
 	};
-	const [organizations] = createResource<undefined | JsonOrganization[]>(
-		orgsFetcher,
-		getOrganizations,
-	);
+	const [organizations] = createResource<
+		undefined | JsonOrganization[],
+		ReturnType<typeof orgsFetcher>
+	>(orgsFetcher, getOrganizations);
 
 	const organization = createMemo(() => {
 		const orgs = organizations();
@@ -178,10 +178,10 @@ const OnboardInvite = (props: Props) => {
 				return null;
 			});
 	};
-	const [_invite] = createResource<undefined | JsonAuthAck>(
-		inviteFetcher,
-		postInvite,
-	);
+	const [_invite] = createResource<
+		undefined | JsonAuthAck,
+		ReturnType<typeof inviteFetcher>
+	>(inviteFetcher, postInvite);
 
 	return (
 		<>

--- a/services/console/src/components/console/onboard/OnboardKey.tsx
+++ b/services/console/src/components/console/onboard/OnboardKey.tsx
@@ -83,10 +83,10 @@ const OnboardKey = (props: Props) => {
 				return;
 			});
 	};
-	const [organizations] = createResource<undefined | JsonOrganization[]>(
-		orgsFetcher,
-		getOrganizations,
-	);
+	const [organizations] = createResource<
+		undefined | JsonOrganization[],
+		ReturnType<typeof orgsFetcher>
+	>(orgsFetcher, getOrganizations);
 
 	const organization = createMemo(() => {
 		const orgs = organizations();
@@ -129,10 +129,10 @@ const OnboardKey = (props: Props) => {
 				return;
 			});
 	};
-	const [projects] = createResource<undefined | JsonProject[]>(
-		projectsFetcher,
-		getProjects,
-	);
+	const [projects] = createResource<
+		undefined | JsonProject[],
+		ReturnType<typeof projectsFetcher>
+	>(projectsFetcher, getProjects);
 
 	const project = createMemo(() => {
 		const orgProjects = projects();
@@ -174,10 +174,10 @@ const OnboardKey = (props: Props) => {
 				return;
 			});
 	};
-	const [apiKeys] = createResource<undefined | JsonProjectKey[]>(
-		keysFetcher,
-		getKeys,
-	);
+	const [apiKeys] = createResource<
+		undefined | JsonProjectKey[],
+		ReturnType<typeof keysFetcher>
+	>(keysFetcher, getKeys);
 
 	const keyFetcher = createMemo(() => {
 		return {

--- a/services/console/src/components/console/onboard/OnboardKey.tsx
+++ b/services/console/src/components/console/onboard/OnboardKey.tsx
@@ -225,7 +225,9 @@ const OnboardKey = (props: Props) => {
 			});
 	};
 	const [apiKey] = createResource<
-		undefined | JsonProjectKey | JsonProjectKeyCreated
+		// biome-ignore lint/suspicious/noConfusingVoidType: getKey returns early without a value
+		void | JsonProjectKey | JsonProjectKeyCreated,
+		ReturnType<typeof keyFetcher>
 	>(keyFetcher, getKey);
 
 	const keyValue = createMemo(() => {

--- a/services/console/src/components/console/onboard/OnboardPlan.tsx
+++ b/services/console/src/components/console/onboard/OnboardPlan.tsx
@@ -73,10 +73,10 @@ const OnboardPlan = (props: Props) => {
 				return;
 			});
 	};
-	const [organizations] = createResource<undefined | JsonOrganization[]>(
-		orgsFetcher,
-		getOrganizations,
-	);
+	const [organizations] = createResource<
+		undefined | JsonOrganization[],
+		ReturnType<typeof orgsFetcher>
+	>(orgsFetcher, getOrganizations);
 
 	const organization = createMemo(() => {
 		const orgs = organizations();

--- a/services/console/src/components/console/onboard/OnboardProject.tsx
+++ b/services/console/src/components/console/onboard/OnboardProject.tsx
@@ -86,10 +86,10 @@ const OnboardProject = (props: Props) => {
 				return;
 			});
 	};
-	const [organizations] = createResource<undefined | JsonOrganization[]>(
-		orgsFetcher,
-		getOrganizations,
-	);
+	const [organizations] = createResource<
+		undefined | JsonOrganization[],
+		ReturnType<typeof orgsFetcher>
+	>(orgsFetcher, getOrganizations);
 
 	const organization = createMemo(() => {
 		const orgs = organizations();
@@ -133,7 +133,8 @@ const OnboardProject = (props: Props) => {
 			});
 	};
 	const [projects, { refetch: refetchProjects }] = createResource<
-		undefined | JsonProject[]
+		undefined | JsonProject[],
+		ReturnType<typeof projectsFetcher>
 	>(projectsFetcher, getProjects);
 
 	const organizationProject = createMemo(() => {
@@ -186,10 +187,10 @@ const OnboardProject = (props: Props) => {
 				return;
 			});
 	};
-	const [project] = createResource<undefined | JsonProject>(
-		projectFetcher,
-		getProject,
-	);
+	const [project] = createResource<
+		undefined | JsonProject,
+		ReturnType<typeof projectFetcher>
+	>(projectFetcher, getProject);
 
 	const [renameProject, setRenameProject] = createSignal<null | string>(null);
 	const [renameValid, setRenameValid] = createSignal<null | boolean>(null);
@@ -255,10 +256,10 @@ const OnboardProject = (props: Props) => {
 				return;
 			});
 	};
-	const [_updatedProject] = createResource<undefined | JsonProject>(
-		updateProjectFetcher,
-		updateProject,
-	);
+	const [_updatedProject] = createResource<
+		undefined | JsonProject,
+		ReturnType<typeof updateProjectFetcher>
+	>(updateProjectFetcher, updateProject);
 
 	return (
 		<>

--- a/services/console/src/components/console/onboard/OnboardRun.tsx
+++ b/services/console/src/components/console/onboard/OnboardRun.tsx
@@ -79,10 +79,10 @@ const OnboardRun = (props: Props) => {
 				return null;
 			});
 	};
-	const [organizations] = createResource<null | JsonOrganization[]>(
-		orgsFetcher,
-		getOrganizations,
-	);
+	const [organizations] = createResource<
+		null | JsonOrganization[],
+		ReturnType<typeof orgsFetcher>
+	>(orgsFetcher, getOrganizations);
 
 	const organization = createMemo(() => {
 		const orgs = organizations();
@@ -134,10 +134,10 @@ const OnboardRun = (props: Props) => {
 				return null;
 			});
 	};
-	const [projects] = createResource<null | JsonProject[]>(
-		projectsFetcher,
-		getProjects,
-	);
+	const [projects] = createResource<
+		null | JsonProject[],
+		ReturnType<typeof projectsFetcher>
+	>(projectsFetcher, getProjects);
 
 	const runCode = createMemo(() => {
 		const orgProjects = projects();

--- a/services/console/src/components/console/perf/PerfPanel.tsx
+++ b/services/console/src/components/console/perf/PerfPanel.tsx
@@ -746,29 +746,29 @@ const PerfPanel = (props: Props) => {
 			token: user?.token,
 		};
 	});
-	const [plot_selected] = createResource<JsonPlot[]>(
-		selectedPlotFetcher,
-		async (fetcher) => {
-			if (
-				!fetcher.bencher_valid ||
-				!fetcher.plot ||
-				!fetcher.project_slug ||
-				fetcher.project_slug === "undefined" ||
-				(props.isConsole && !validJwt(fetcher.token)) ||
-				props.isEmbed === true
-			) {
+	const [plot_selected] = createResource<
+		JsonPlot[],
+		ReturnType<typeof selectedPlotFetcher>
+	>(selectedPlotFetcher, async (fetcher) => {
+		if (
+			!fetcher.bencher_valid ||
+			!fetcher.plot ||
+			!fetcher.project_slug ||
+			fetcher.project_slug === "undefined" ||
+			(props.isConsole && !validJwt(fetcher.token)) ||
+			props.isEmbed === true
+		) {
+			return [];
+		}
+		const path = `/v0/projects/${fetcher.project_slug}/plots/${fetcher.plot}`;
+		return await httpGet(props.apiUrl, path, fetcher.token)
+			.then((resp) => [resp?.data as JsonPlot])
+			.catch((error) => {
+				console.error(error);
+				Sentry.captureException(error);
 				return [];
-			}
-			const path = `/v0/projects/${fetcher.project_slug}/plots/${fetcher.plot}`;
-			return await httpGet(props.apiUrl, path, fetcher.token)
-				.then((resp) => [resp?.data as JsonPlot])
-				.catch((error) => {
-					console.error(error);
-					Sentry.captureException(error);
-					return [];
-				});
-		},
-	);
+			});
+	});
 	// Drop only the pinned plot association; the rest of the view is untouched.
 	const handlePlotSelected = () => {
 		setSearchParams({
@@ -863,19 +863,19 @@ const PerfPanel = (props: Props) => {
 		}
 		return undefined;
 	});
-	const [first_report_data] = createResource<undefined | JsonReport>(
-		first_report_fetcher,
-		async (uuid) => {
-			const path = `/v0/projects/${project_slug()}/reports/${uuid}`;
-			return await httpGet(props.apiUrl, path, user?.token)
-				.then((resp) => resp?.data)
-				.catch((error) => {
-					console.error(error);
-					Sentry.captureException(error);
-					return undefined;
-				});
-		},
-	);
+	const [first_report_data] = createResource<
+		undefined | JsonReport,
+		ReturnType<typeof first_report_fetcher>
+	>(first_report_fetcher, async (uuid) => {
+		const path = `/v0/projects/${project_slug()}/reports/${uuid}`;
+		return await httpGet(props.apiUrl, path, user?.token)
+			.then((resp) => resp?.data)
+			.catch((error) => {
+				console.error(error);
+				Sentry.captureException(error);
+				return undefined;
+			});
+	});
 	createEffect(() => {
 		const data = reports_data();
 		if (data) {

--- a/services/console/src/components/console/perf/header/UpdateModal.tsx
+++ b/services/console/src/components/console/perf/header/UpdateModal.tsx
@@ -74,25 +74,25 @@ const UpdateModal = (props: Props) => {
 			token: props.user?.token,
 		};
 	});
-	const [plots_list] = createResource<JsonPlot[]>(
-		plotsFetcher,
-		async (fetcher) => {
-			if (!fetcher.project || !fetcher.plot) {
+	const [plots_list] = createResource<
+		JsonPlot[],
+		ReturnType<typeof plotsFetcher>
+	>(plotsFetcher, async (fetcher) => {
+		if (!fetcher.project || !fetcher.plot) {
+			return [];
+		}
+		return await httpGet(
+			props.apiUrl,
+			`/v0/projects/${fetcher.project}/plots?per_page=${MAX_PLOTS}`,
+			fetcher.token,
+		)
+			.then((resp) => resp?.data as JsonPlot[])
+			.catch((error) => {
+				console.error(error);
+				Sentry.captureException(error);
 				return [];
-			}
-			return await httpGet(
-				props.apiUrl,
-				`/v0/projects/${fetcher.project}/plots?per_page=${MAX_PLOTS}`,
-				fetcher.token,
-			)
-				.then((resp) => resp?.data as JsonPlot[])
-				.catch((error) => {
-					console.error(error);
-					Sentry.captureException(error);
-					return [];
-				});
-		},
-	);
+			});
+	});
 	const position = createMemo(() => {
 		const index = (plots_list() ?? []).findIndex(
 			(list_plot) => list_plot.uuid === props.plot(),

--- a/services/console/src/components/console/plots/Pinned.tsx
+++ b/services/console/src/components/console/plots/Pinned.tsx
@@ -79,7 +79,10 @@ const Pinned = (props: {
 				return fetcher.plot;
 			});
 	};
-	const [plot] = createResource<JsonPlot>(plotFetcher, getPlot);
+	const [plot] = createResource<JsonPlot, ReturnType<typeof plotFetcher>>(
+		plotFetcher,
+		getPlot,
+	);
 
 	return (
 		<PinnedFrame
@@ -189,7 +192,10 @@ const PinnedButtons = (props: {
 				return;
 			});
 	};
-	const [_rank] = createResource<JsonPlot>(rankFetcher, patchRank);
+	const [_rank] = createResource<JsonPlot, ReturnType<typeof rankFetcher>>(
+		rankFetcher,
+		patchRank,
+	);
 
 	return (
 		<nav class="level is-mobile">
@@ -359,7 +365,10 @@ const PinnedRank = (props: {
 				return;
 			});
 	};
-	const [_rank] = createResource<JsonPlot>(rankFetcher, patchRank);
+	const [_rank] = createResource<JsonPlot, ReturnType<typeof rankFetcher>>(
+		rankFetcher,
+		patchRank,
+	);
 
 	return (
 		<form

--- a/services/console/src/components/console/redirects/ConsoleRedirect.tsx
+++ b/services/console/src/components/console/redirects/ConsoleRedirect.tsx
@@ -113,10 +113,10 @@ const ConsoleRedirect = (props: Props) => {
 				return;
 			});
 	};
-	const [organizations] = createResource<undefined | JsonOrganization[]>(
-		orgsFetcher,
-		getOrganizations,
-	);
+	const [organizations] = createResource<
+		undefined | JsonOrganization[],
+		ReturnType<typeof orgsFetcher>
+	>(orgsFetcher, getOrganizations);
 
 	const organization = createMemo(() => {
 		const orgs = organizations();
@@ -180,10 +180,10 @@ const ConsoleRedirect = (props: Props) => {
 				return;
 			});
 	};
-	const [_projects] = createResource<undefined | JsonProject[]>(
-		projectsFetcher,
-		getProjects,
-	);
+	const [_projects] = createResource<
+		undefined | JsonProject[],
+		ReturnType<typeof projectsFetcher>
+	>(projectsFetcher, getProjects);
 
 	return <></>;
 };

--- a/services/console/src/components/perf/PublicProjects.tsx
+++ b/services/console/src/components/perf/PublicProjects.tsx
@@ -97,7 +97,10 @@ const PublicProjects = (props: Props) => {
 				return EMPTY_ARRAY;
 			});
 	};
-	const [projects] = createResource<JsonProject[]>(fetcher, fetchProjects);
+	const [projects] = createResource<JsonProject[], ReturnType<typeof fetcher>>(
+		fetcher,
+		fetchProjects,
+	);
 	const projectsLength = createMemo(() => projects()?.length);
 
 	const handlePage = (page: number) => {


### PR DESCRIPTION
`astro check` reports 806 errors. This takes it to 754, below the 758 it sat at
before the Astro 7 upgrade.

## What was actually wrong

`createResource` is called in two shapes. The `(source, fetcher)` shape was
being given a single explicit type argument:

```ts
const [usage, { refetch }] = createResource<null | JsonUsage>(fetcher, fetchPlan);
```

That call has always been wrong. It reproduces under the pre-upgrade toolchain,
so the upgrade did not break these call sites; it changed what happens after
they fail. solid-js 1.9.14 added `I = T` to the `(fetcher, options)` overload,
whose return type became `InitializedResourceReturn<T | I, R>`. When resolution
falls through to it, `T` is left unresolved and leaks into the resource type, so
a single bad call now also produces errors at every consumer of that resource.
That cascade is what this removes.

The fix names the source type as well, which lets the intended overload match:

```ts
const [usage, { refetch }] = createResource<
  null | JsonUsage,
  ReturnType<typeof fetcher>
>(fetcher, fetchPlan);
```

`ReturnType<typeof fetcher>` rather than the object type spelled out, because it
stays in step with the source memo and supplies a contextual type at sites whose
fetcher is an inline arrow with nothing to copy from.

## Why not just drop the type argument

Removing the explicit type argument also silences the errors, and it is the
wrong fix. These fetchers end in `httpGet(...).then((resp) => resp?.data)`, and
`.data` is `any`, so inference resolves the whole resource to `any`. Both
approaches reach zero errors, so error counts cannot tell them apart. Two
independent probes confirmed the difference: under inference the resource
assigns to a deliberately incompatible type with no complaint, which only `any`
does, while naming the source type yields `JsonUsage | null | undefined`.

Trading a loud error for a silent `any` would have made this worse, not better.

## Four resources that were declared as something they never return

`getAuthUser`, `acceptInvite`, and `claimProject` navigate; they return
`void | null`, never `JsonAuthUser`, `JsonAuthAck`, or `JsonOrganization`. All
three resources are discarded at the binding. `getKey` has a bare `return`, so
it is `void`, not `undefined`. Naming the source type is not enough at these
four, because the declared `T` was the lie. Each carries a suppression naming
the function, matching the convention already used in 24 other files.

## Verification

- `astro check` 806 to 754. 58 errors removed, 6 added.
- The 6 added are not regressions: 3 are the same diagnostics at the same
  positions, relabelled because the resource finally resolves, and the other 3
  are latent problems that correct resolution stops masking.
- No new `any`. All 26 edited sites resolve to concrete types, and the
  implicit-any count drops from 219 to 214.
- Types only. Every one of the 13 changed files compiles to byte-identical
  JavaScript, so the reindentation carries no behavior.
- `biome ci` exits 0 at the same 39 warnings as before, `vitest` passes, and the
  Cloudflare build path succeeds.

## Left alone

15 call sites still fail. Each needs a real typing decision rather than a type
argument: 11 where the source memo is genuinely looser than the fetcher's
parameter annotation, and 4 where the declared type is wrong but the resource is
consumed, so an honest type would push errors into consumers. Those are runtime
changes and do not belong in a types-only change.
