### PR TITLE
Read the first report boundary off the report measure

### DIFF
--- a/services/console/src/components/console/perf/PerfPanel.tsx
+++ b/services/console/src/components/console/perf/PerfPanel.tsx
@@ -28,7 +28,6 @@ import {
 	addToArray,
 	arrayFromString,
 	arrayToString,
-	dateTimeMillis,
 	dateToTime,
 	isBoolParam,
 	removeFromArray,
@@ -50,6 +49,12 @@ import PerfFrame from "./PerfFrame";
 import PerfHeader from "./header/PerfHeader";
 import type { TabList } from "./plot/tab/PlotTab";
 import PlotTab from "./plot/tab/PlotTab";
+import {
+	CLEAR_PARAM,
+	PLOT_PARAM,
+	REPORT_PARAM,
+	firstReportParams,
+} from "./util";
 
 // Perf query params
 const BRANCHES_PARAM = PerfQueryKey.Branches;
@@ -62,9 +67,6 @@ const START_TIME_PARAM = PerfQueryKey.StartTime;
 const END_TIME_PARAM = PerfQueryKey.EndTime;
 
 // Console UI state query params
-const REPORT_PARAM = "report";
-const PLOT_PARAM = "plot";
-
 const REPORTS_PER_PAGE_PARAM = "reports_per_page";
 const BRANCHES_PER_PAGE_PARAM = "branches_per_page";
 const TESTBEDS_PER_PAGE_PARAM = "testbeds_per_page";
@@ -94,7 +96,6 @@ const X_AXIS_PARAM = PlotKey.XAxis;
 const Y_AXIS_PARAM = PlotKey.YAxis;
 // TODO remove in due time
 const RANGE_PARAM = "range";
-const CLEAR_PARAM = "clear";
 
 // These are currently for internal use only
 // TODO add a way to set these in the Share modal
@@ -177,9 +178,6 @@ const DEFAULT_EMBED_KEY = true;
 export const DEFAULT_PER_PAGE = 8;
 export const REPORTS_PER_PAGE = 4;
 export const DEFAULT_PAGE = 1;
-
-// 30 days
-const DEFAULT_REPORT_HISTORY = 30 * 24 * 60 * 60 * 1000;
 
 export interface Props {
 	apiUrl: string;
@@ -881,7 +879,6 @@ const PerfPanel = (props: Props) => {
 		if (data) {
 			setReportsTab(resourcesToCheckable(data, [report()]));
 		}
-		const first = 0;
 		const first_report = first_report_data();
 		if (
 			!clear() &&
@@ -892,37 +889,7 @@ const PerfPanel = (props: Props) => {
 			measuresIsEmpty() &&
 			tab() === DEFAULT_PERF_TAB
 		) {
-			const benchmarks = first_report?.results?.[first]
-				?.map((iteration) => iteration?.benchmark?.uuid)
-				.slice(0, 10);
-			const first_measure =
-				first_report?.results?.[first]?.[first]?.measures?.[first]?.measure
-					?.uuid;
-			const start_time = dateTimeMillis(first_report?.start_time);
-			setSearchParams(
-				{
-					[REPORT_PARAM]: first_report?.uuid,
-					[BRANCHES_PARAM]: first_report?.branch?.uuid,
-					[HEADS_PARAM]: first_report?.branch?.head?.uuid,
-					[TESTBEDS_PARAM]: first_report?.testbed?.uuid,
-					[SPECS_PARAM]: first_report?.testbed?.spec?.uuid,
-					[BENCHMARKS_PARAM]: arrayToString(benchmarks ?? []),
-					[MEASURES_PARAM]: first_measure,
-					[PLOT_PARAM]: null,
-					[START_TIME_PARAM]: start_time
-						? start_time - DEFAULT_REPORT_HISTORY
-						: null,
-					[END_TIME_PARAM]: dateTimeMillis(first_report?.end_time),
-					[LOWER_VALUE_PARAM]: null,
-					[UPPER_VALUE_PARAM]: null,
-					[LOWER_BOUNDARY_PARAM]:
-						typeof first_measure?.boundary?.lower_limit === "number",
-					[UPPER_BOUNDARY_PARAM]:
-						typeof first_measure?.boundary?.upper_limit === "number",
-					[CLEAR_PARAM]: true,
-				},
-				{ replace: true },
-			);
+			setSearchParams(firstReportParams(first_report), { replace: true });
 		}
 	});
 

--- a/services/console/src/components/console/perf/util.test.ts
+++ b/services/console/src/components/console/perf/util.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "vitest";
+import {
+	type JsonBoundary,
+	type JsonReport,
+	type JsonReportMeasure,
+	PerfQueryKey,
+	PlotKey,
+} from "../../../types/bencher";
+import {
+	CLEAR_PARAM,
+	DEFAULT_REPORT_HISTORY,
+	PLOT_PARAM,
+	REPORT_PARAM,
+	firstReportParams,
+} from "./util";
+
+const REPORT_UUID = "a1a1a1a1-0000-4000-8000-000000000001";
+const BRANCH_UUID = "b2b2b2b2-0000-4000-8000-000000000002";
+const HEAD_UUID = "c3c3c3c3-0000-4000-8000-000000000003";
+const TESTBED_UUID = "d4d4d4d4-0000-4000-8000-000000000004";
+const SPEC_UUID = "e5e5e5e5-0000-4000-8000-000000000005";
+const BENCHMARK_UUID = "f6f6f6f6-0000-4000-8000-000000000006";
+const OTHER_BENCHMARK_UUID = "07070707-0000-4000-8000-000000000007";
+const MEASURE_UUID = "18181818-0000-4000-8000-000000000008";
+const OTHER_MEASURE_UUID = "29292929-0000-4000-8000-000000000009";
+
+const START_TIME = "2026-08-20T12:00:00Z";
+const END_TIME = "2026-08-20T12:05:00Z";
+const START_TIME_MS = Date.parse(START_TIME);
+const END_TIME_MS = Date.parse(END_TIME);
+
+const reportMeasure = (
+	uuid: string,
+	boundary?: JsonBoundary,
+): JsonReportMeasure =>
+	({
+		measure: { uuid, name: "Latency", slug: "latency", units: "nanoseconds" },
+		metric: { uuid, value: 1.0 },
+		boundary,
+	}) as unknown as JsonReportMeasure;
+
+const report = (measures: JsonReportMeasure[]): JsonReport =>
+	({
+		uuid: REPORT_UUID,
+		branch: { uuid: BRANCH_UUID, head: { uuid: HEAD_UUID } },
+		testbed: { uuid: TESTBED_UUID, spec: { uuid: SPEC_UUID } },
+		start_time: START_TIME,
+		end_time: END_TIME,
+		results: [
+			[
+				{ iteration: 0, benchmark: { uuid: BENCHMARK_UUID }, measures },
+				{
+					iteration: 0,
+					benchmark: { uuid: OTHER_BENCHMARK_UUID },
+					measures: [reportMeasure(OTHER_MEASURE_UUID)],
+				},
+			],
+		],
+	}) as unknown as JsonReport;
+
+describe("firstReportParams", () => {
+	test("selects the first measure of the first result of the first iteration", () => {
+		const params = firstReportParams(report([reportMeasure(MEASURE_UUID)]));
+		expect(params[PerfQueryKey.Measures]).toBe(MEASURE_UUID);
+	});
+
+	test("plots every benchmark in the first iteration", () => {
+		const params = firstReportParams(report([reportMeasure(MEASURE_UUID)]));
+		expect(params[PerfQueryKey.Benchmarks]).toBe(
+			`${BENCHMARK_UUID},${OTHER_BENCHMARK_UUID}`,
+		);
+	});
+
+	test("a lower limit turns on the lower boundary only", () => {
+		const params = firstReportParams(
+			report([reportMeasure(MEASURE_UUID, { lower_limit: 1.0 })]),
+		);
+		expect(params[PlotKey.LowerBoundary]).toBe(true);
+		expect(params[PlotKey.UpperBoundary]).toBe(false);
+	});
+
+	test("an upper limit turns on the upper boundary only", () => {
+		const params = firstReportParams(
+			report([reportMeasure(MEASURE_UUID, { upper_limit: 9.0 })]),
+		);
+		expect(params[PlotKey.LowerBoundary]).toBe(false);
+		expect(params[PlotKey.UpperBoundary]).toBe(true);
+	});
+
+	test("both limits turn on both boundaries", () => {
+		const params = firstReportParams(
+			report([
+				reportMeasure(MEASURE_UUID, { lower_limit: 1.0, upper_limit: 9.0 }),
+			]),
+		);
+		expect(params[PlotKey.LowerBoundary]).toBe(true);
+		expect(params[PlotKey.UpperBoundary]).toBe(true);
+	});
+
+	test("a boundary with only a baseline turns on neither boundary", () => {
+		const params = firstReportParams(
+			report([reportMeasure(MEASURE_UUID, { baseline: 5.0 })]),
+		);
+		expect(params[PlotKey.LowerBoundary]).toBe(false);
+		expect(params[PlotKey.UpperBoundary]).toBe(false);
+	});
+
+	test("no boundary at all turns on neither boundary", () => {
+		const params = firstReportParams(report([reportMeasure(MEASURE_UUID)]));
+		expect(params[PlotKey.LowerBoundary]).toBe(false);
+		expect(params[PlotKey.UpperBoundary]).toBe(false);
+	});
+
+	test("only the first measure decides the boundaries", () => {
+		const params = firstReportParams(
+			report([
+				reportMeasure(MEASURE_UUID),
+				reportMeasure(OTHER_MEASURE_UUID, { upper_limit: 9.0 }),
+			]),
+		);
+		expect(params[PerfQueryKey.Measures]).toBe(MEASURE_UUID);
+		expect(params[PlotKey.UpperBoundary]).toBe(false);
+	});
+
+	test("the plot window ends at the report and reaches back the default history", () => {
+		const params = firstReportParams(report([reportMeasure(MEASURE_UUID)]));
+		expect(params[REPORT_PARAM]).toBe(REPORT_UUID);
+		expect(params[PerfQueryKey.Branches]).toBe(BRANCH_UUID);
+		expect(params[PerfQueryKey.Heads]).toBe(HEAD_UUID);
+		expect(params[PerfQueryKey.Testbeds]).toBe(TESTBED_UUID);
+		expect(params[PerfQueryKey.Specs]).toBe(SPEC_UUID);
+		expect(params[PerfQueryKey.StartTime]).toBe(
+			START_TIME_MS - DEFAULT_REPORT_HISTORY,
+		);
+		expect(params[PerfQueryKey.EndTime]).toBe(END_TIME_MS);
+		expect(params[PLOT_PARAM]).toBe(null);
+		expect(params[PlotKey.LowerValue]).toBe(null);
+		expect(params[PlotKey.UpperValue]).toBe(null);
+		expect(params[CLEAR_PARAM]).toBe(true);
+	});
+});

--- a/services/console/src/components/console/perf/util.ts
+++ b/services/console/src/components/console/perf/util.ts
@@ -18,8 +18,9 @@ export const firstReportParams = (first_report: JsonReport): SetParams => {
 	const benchmarks = first_report?.results?.[first]
 		?.map((iteration) => iteration?.benchmark?.uuid)
 		.slice(0, DEFAULT_REPORT_BENCHMARKS);
-	const first_measure =
-		first_report?.results?.[first]?.[first]?.measures?.[first]?.measure?.uuid;
+	// The boundary limits live on the report measure, not on the measure itself.
+	const first_report_measure =
+		first_report?.results?.[first]?.[first]?.measures?.[first];
 	const start_time = dateTimeMillis(first_report?.start_time);
 	return {
 		[REPORT_PARAM]: first_report?.uuid,
@@ -28,7 +29,7 @@ export const firstReportParams = (first_report: JsonReport): SetParams => {
 		[PerfQueryKey.Testbeds]: first_report?.testbed?.uuid,
 		[PerfQueryKey.Specs]: first_report?.testbed?.spec?.uuid,
 		[PerfQueryKey.Benchmarks]: arrayToString(benchmarks ?? []),
-		[PerfQueryKey.Measures]: first_measure,
+		[PerfQueryKey.Measures]: first_report_measure?.measure?.uuid,
 		[PLOT_PARAM]: null,
 		[PerfQueryKey.StartTime]: start_time
 			? start_time - DEFAULT_REPORT_HISTORY
@@ -37,9 +38,9 @@ export const firstReportParams = (first_report: JsonReport): SetParams => {
 		[PlotKey.LowerValue]: null,
 		[PlotKey.UpperValue]: null,
 		[PlotKey.LowerBoundary]:
-			typeof first_measure?.boundary?.lower_limit === "number",
+			typeof first_report_measure?.boundary?.lower_limit === "number",
 		[PlotKey.UpperBoundary]:
-			typeof first_measure?.boundary?.upper_limit === "number",
+			typeof first_report_measure?.boundary?.upper_limit === "number",
 		[CLEAR_PARAM]: true,
 	};
 };

--- a/services/console/src/components/console/perf/util.ts
+++ b/services/console/src/components/console/perf/util.ts
@@ -1,0 +1,45 @@
+import { type JsonReport, PerfQueryKey, PlotKey } from "../../../types/bencher";
+import { arrayToString, dateTimeMillis } from "../../../util/convert";
+import type { SetParams } from "../../../util/url";
+
+// Console UI state query params
+export const REPORT_PARAM = "report";
+export const PLOT_PARAM = "plot";
+export const CLEAR_PARAM = "clear";
+
+// The most benchmarks to plot by default
+const DEFAULT_REPORT_BENCHMARKS = 10;
+// 30 days
+export const DEFAULT_REPORT_HISTORY = 30 * 24 * 60 * 60 * 1000;
+
+// The query params for the default perf plot, bootstrapped from the first report.
+export const firstReportParams = (first_report: JsonReport): SetParams => {
+	const first = 0;
+	const benchmarks = first_report?.results?.[first]
+		?.map((iteration) => iteration?.benchmark?.uuid)
+		.slice(0, DEFAULT_REPORT_BENCHMARKS);
+	const first_measure =
+		first_report?.results?.[first]?.[first]?.measures?.[first]?.measure?.uuid;
+	const start_time = dateTimeMillis(first_report?.start_time);
+	return {
+		[REPORT_PARAM]: first_report?.uuid,
+		[PerfQueryKey.Branches]: first_report?.branch?.uuid,
+		[PerfQueryKey.Heads]: first_report?.branch?.head?.uuid,
+		[PerfQueryKey.Testbeds]: first_report?.testbed?.uuid,
+		[PerfQueryKey.Specs]: first_report?.testbed?.spec?.uuid,
+		[PerfQueryKey.Benchmarks]: arrayToString(benchmarks ?? []),
+		[PerfQueryKey.Measures]: first_measure,
+		[PLOT_PARAM]: null,
+		[PerfQueryKey.StartTime]: start_time
+			? start_time - DEFAULT_REPORT_HISTORY
+			: null,
+		[PerfQueryKey.EndTime]: dateTimeMillis(first_report?.end_time),
+		[PlotKey.LowerValue]: null,
+		[PlotKey.UpperValue]: null,
+		[PlotKey.LowerBoundary]:
+			typeof first_measure?.boundary?.lower_limit === "number",
+		[PlotKey.UpperBoundary]:
+			typeof first_measure?.boundary?.upper_limit === "number",
+		[CLEAR_PARAM]: true,
+	};
+};


### PR DESCRIPTION
The default perf plot asked a measure UUID for its boundary. A UUID is a
string, so `first_measure?.boundary?.lower_limit` was always `undefined` and
both boundary params were unconditionally off.

The limits hang off the report measure, one level up. `JsonReportMeasure` is
`{ measure; metric; threshold?; boundary? }`, so the UUID comes from
`.measure.uuid` while `boundary` sits beside it. `ReportCard` already reads it
that way.

## Why the type checker never caught it

`first_report_data()` was typed `JsonReport | NonNullable<T>`, from a
`createResource` call whose source type argument was missing. That made
`first_report?.results` an error on its own, and the rest of the chain degraded
to `any`, which swallowed a property access on a string. Pinning that generic
landed separately, and extracting this code into a function that takes a real
`JsonReport` is what finally surfaced the bug as
`Property 'boundary' does not exist on type 'string'`.

## The extraction

The bootstrap sits inside a large effect, where the query param math cannot be
reached from a test. The first commit moves it to a pure `firstReportParams` in
`perf/util.ts`, matching `plots/util.ts` and its test file, and carries the
buggy expressions over unchanged so the failing test proves the bug rather than
the move. The second commit fixes the lookup.

## What changes for a reader

Only on the bootstrap path: a project perf page opened with no perf query
params, on the reports tab, with nothing selected. When the first measure of the
first result carries a threshold boundary, the matching boundary lines are now
on in the default plot. A measure with no threshold, or a boundary carrying only
a baseline, still yields both off. Any shared or bookmarked URL already carries
params and is unaffected.

## Verification

- The three limit-carrying tests fail against the extracted-but-unfixed code and
  pass after the fix. The six cases that already passed are not vacuous: the
  baseline-only case is what catches reading `baseline` instead of a limit.
- `astro check` 754 to 752.
- `vitest` 317 passed, up exactly the 9 added.
- `biome ci` exits 0 at the same 39 warnings.

One known test gap: no case covers a report with a missing or unparseable
`start_time`, so the guard that keeps `start_time` null rather than a negative
number is untested.
