### PR TITLE
Deploy the console artifact built earlier in the same CI run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,15 +30,31 @@ on:
       deploy-only:
         type: boolean
         required: true
+      # The Cloudflare adapter bakes the Wrangler environment into the console
+      # build, so the environment is chosen here, not on the deploy.
+      # `dev` builds the `dev-console` Worker; empty builds the top-level one.
+      cloudflare-env:
+        type: string
+        required: true
+      sentry-upload:
+        type: boolean
+        required: true
     secrets:
       R2_ACCESS_KEY_ID:
         required: false
       R2_SECRET_ACCESS_KEY:
         required: false
+      # Fork pull requests do not receive secrets, so this is optional.
+      # It is only read when `sentry-upload` is true.
+      SENTRY_AUTH_TOKEN:
+        required: false
     outputs:
       wasm-artifact-name:
         description: "WASM artifact name"
         value: "bencher-valid-pkg"
+      console-artifact-name:
+        description: "Console UI artifact name"
+        value: "bencher-console"
 
 env:
   CARGO_TERM_COLOR: always
@@ -47,6 +63,7 @@ env:
   # Use head_ref for PRs (avoids `/merge` suffix), otherwise use ref_name
   CACHE_NAME: ${{ github.head_ref || github.ref_name }}
   WASM_BENCHER_VALID: bencher-valid-pkg
+  BENCHER_CONSOLE: bencher-console
 
 jobs:
   build_github_action:
@@ -144,7 +161,9 @@ jobs:
     name: Build Console UI
     runs-on: ubuntu-22.04
     needs: build_wasm
-    if: ${{ !startsWith(github.ref, 'refs/tags/') && !inputs.deploy-only }}
+    # Runs even on deploy-only (cloud) runs: the deploy consumes this job's
+    # artifact rather than rebuilding the console itself.
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -160,7 +179,31 @@ jobs:
           path: ./lib/bencher_valid/pkg
       - name: Build Console UI
         working-directory: ./services/console
+        env:
+          # An empty value selects the top level (production) configuration,
+          # exactly as leaving it unset does.
+          CLOUDFLARE_ENV: ${{ inputs.cloudflare-env }}
+          SENTRY_UPLOAD: ${{ inputs.sentry-upload }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: npm run cloudflare
+      - name: Verify Deploy Target
+        working-directory: ./services/console
+        env:
+          DEPLOY_TARGET: ${{ inputs.cloudflare-env == 'dev' && 'dev-console' || 'console' }}
+        run: npm run deploy-target "$DEPLOY_TARGET"
+      # The deploy jobs download this instead of rebuilding the console.
+      # `wrangler deploy` finds the built config through `.wrangler/deploy/config.json`,
+      # and `upload-artifact` omits hidden files unless told otherwise, so without
+      # `include-hidden-files` the deploy would fall back to `wrangler.jsonc`.
+      - name: Upload Artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ env.BENCHER_CONSOLE }}
+          path: |
+            ./services/console/dist
+            ./services/console/.wrangler
+          include-hidden-files: true
+          if-no-files-found: error
 
   build_api_docker:
     name: Build API Docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,9 +215,17 @@ jobs:
       build-action: ${{ needs.changes.outputs.action == 'true' || github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/cloud' || startsWith(github.ref, 'refs/tags/') }}
       build-docker: ${{ !startsWith(github.ref, 'refs/tags/') && (needs.changes.outputs.docker == 'true' || github.ref == 'refs/heads/devel' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy'))) }}
       deploy-only: ${{ github.ref == 'refs/heads/cloud' }}
+      # The console build is environment-specific, so it has to match the deploy
+      # this run will perform. Anything that does not deploy dev builds the
+      # top-level (production) configuration.
+      cloudflare-env: ${{ (github.ref == 'refs/heads/devel' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy'))) && 'dev' || '' }}
+      # Only runs that deploy upload sourcemaps, and only from this repository:
+      # fork pull requests get no secrets, and uploading without a token fails the build.
+      sentry-upload: ${{ github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/cloud' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'deploy')) }}
     secrets:
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
   docker:
     name: Docker
@@ -261,7 +269,6 @@ jobs:
       deploy-prod: ${{ github.ref == 'refs/heads/cloud' }}
     secrets:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       BENCHER_USER_AGENT: ${{ secrets.BENCHER_USER_AGENT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,8 +21,6 @@ on:
     secrets:
       FLY_API_TOKEN:
         required: true
-      SENTRY_AUTH_TOKEN:
-        required: true
       CLOUDFLARE_ACCOUNT_ID:
         required: true
       CLOUDFLARE_API_TOKEN:
@@ -38,7 +36,7 @@ env:
   GITHUB_REGISTRY: ghcr.io
   API_DOCKER_IMAGE: bencher-api
   FLY_REGISTRY: registry.fly.io
-  WASM_BENCHER_VALID: bencher-valid-pkg
+  BENCHER_CONSOLE: bencher-console
 
 jobs:
   deploy_api_fly_dev:
@@ -122,20 +120,16 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "24"
-      - name: Download `bencher_valid` Artifact
+      - name: Download Console UI Artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.WASM_BENCHER_VALID }}
-          path: ./lib/bencher_valid/pkg
-      - name: Build Console UI
+          name: ${{ env.BENCHER_CONSOLE }}
+          path: ./services/console
+      # `wrangler` is a dev dependency of the console. It used to arrive as part
+      # of `npm run cloudflare`, which the build job now runs instead.
+      - name: Install Dependencies
         working-directory: ./services/console
-        env:
-          # The Cloudflare adapter bakes the Wrangler environment into the build,
-          # so this, not `--env` on the deploy, is what selects it.
-          CLOUDFLARE_ENV: dev
-          SENTRY_UPLOAD: true
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        run: npm run cloudflare
+        run: npm ci
       - name: Verify Deploy Target
         working-directory: ./services/console
         run: npm run deploy-target dev-console
@@ -234,17 +228,16 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "24"
-      - name: Download `bencher_valid` Artifact
+      - name: Download Console UI Artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ env.WASM_BENCHER_VALID }}
-          path: ./lib/bencher_valid/pkg
-      - name: Build Console UI
+          name: ${{ env.BENCHER_CONSOLE }}
+          path: ./services/console
+      # `wrangler` is a dev dependency of the console. It used to arrive as part
+      # of `npm run cloudflare`, which the build job now runs instead.
+      - name: Install Dependencies
         working-directory: ./services/console
-        env:
-          SENTRY_UPLOAD: true
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        run: npm run cloudflare
+        run: npm ci
       - name: Verify Deploy Target
         working-directory: ./services/console
         run: npm run deploy-target console

--- a/services/console/CLAUDE.md
+++ b/services/console/CLAUDE.md
@@ -92,9 +92,14 @@ CLOUDFLARE_ENV=dev npm run cloudflare && npm run deploy-target dev-console && np
 ```
 
 `npm run deploy-target <worker-name>` asserts that the built
-`dist/server/wrangler.json` really is the Worker you mean to deploy. Both deploy
-jobs run it, and so should any manual deploy: it is the only thing standing
-between a forgotten `CLOUDFLARE_ENV` and a production overwrite.
+`dist/server/wrangler.json` really is the Worker you mean to deploy, and that
+`.wrangler/deploy/config.json` still exists and points at it. The redirect is
+checked because it is hidden, so it is the piece most easily lost in transit:
+artifact uploads skip hidden files unless told otherwise, and without it
+`wrangler deploy` falls back to the source `wrangler.jsonc` and says nothing.
+The build job and both deploy jobs run it, and so should any manual deploy: it
+is the only thing standing between a forgotten `CLOUDFLARE_ENV` and a
+production overwrite.
 
 Local `wrangler dev` currently refuses to start: the pinned `workerd` supports
 compatibility dates only through 2026-08-08 and `wrangler.jsonc` asks for

--- a/services/console/deploy_target.js
+++ b/services/console/deploy_target.js
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as path from "node:path";
 
 // The Cloudflare adapter resolves `wrangler.jsonc` at build time and writes the
 // deployable config here. `wrangler deploy` reads it through
@@ -7,6 +8,12 @@ import * as fs from "node:fs";
 // A build that forgets `CLOUDFLARE_ENV` silently produces the production
 // config, and nothing downstream would notice. Check before deploying.
 const CONFIG = "./dist/server/wrangler.json";
+// The redirect that sends `wrangler deploy` to CONFIG. It is a hidden file, so
+// it is the part of the build most easily lost in transit: artifact uploads skip
+// hidden files unless told otherwise. Losing it is silent rather than loud,
+// because wrangler then falls back to the source `wrangler.jsonc` and deploys
+// whatever `--env` says, which is exactly the mismatch this script prevents.
+const DEPLOY_CONFIG = "./.wrangler/deploy/config.json";
 
 const expected = process.argv[2];
 
@@ -18,6 +25,29 @@ if (!expected) {
 if (!fs.existsSync(CONFIG)) {
 	console.error(
 		`No ${CONFIG}. Build the site before deploying: \`npm run cloudflare\`.`,
+	);
+	process.exit(1);
+}
+
+if (!fs.existsSync(DEPLOY_CONFIG)) {
+	console.error(
+		`No ${DEPLOY_CONFIG}. Without it \`wrangler deploy\` ignores ${CONFIG} and falls back to \`wrangler.jsonc\`.`,
+	);
+	process.exit(1);
+}
+
+// Resolved the way wrangler resolves it: relative to the redirect's own directory.
+const { configPath } = JSON.parse(fs.readFileSync(DEPLOY_CONFIG, "utf8"));
+const redirected =
+	configPath && path.resolve(path.dirname(DEPLOY_CONFIG), configPath);
+
+if (redirected !== path.resolve(CONFIG)) {
+	const target = redirected ? path.relative(".", redirected) : "nothing";
+	console.error(
+		`${DEPLOY_CONFIG} points at ${target}, not ${path.relative(".", CONFIG)}.`,
+	);
+	console.error(
+		"The build output and the deploy redirect disagree. Rebuild the site: `npm run cloudflare`.",
 	);
 	process.exit(1);
 }


### PR DESCRIPTION
A deploy run built the console twice: `build_console` ran `npm run cloudflare` as a check and threw the output away, then each Cloudflare deploy job ran the same build again before `wrangler deploy`. The bytes that reached production were never the bytes CI checked. This change builds the console once and deploys that artifact.

## How it works now

- `build_console` builds the console, verifies the deploy target, and uploads `services/console/dist` plus `services/console/.wrangler` as the `bencher-console` artifact.
- The deploy jobs download the artifact, run `npm ci` (for `wrangler`), verify the deploy target again, and deploy. The deploy commands are unchanged.
- The Cloudflare adapter bakes the Wrangler environment into the build, so the build must know which environment the run deploys. The new `cloudflare-env` input carries it: `dev` on devel pushes and `deploy`-labeled PRs, empty (production) everywhere else. This mirrors the `deploy-dev` / `deploy-prod` conditions exactly, so the baked environment can never diverge from the deploy.
- Sourcemap upload moves into the build behind the new `sentry-upload` input. It is on only for runs that deploy, and off for fork PRs, which have no token.
- `deploy-target` now also asserts that the `.wrangler/deploy/config.json` redirect exists and points at the built config. The redirect is a hidden file, and artifact uploads skip hidden files unless told otherwise. Without the redirect, `wrangler deploy` silently falls back to the source `wrangler.jsonc`. The check resolves the redirect the same way `wrangler` does.

## Behavior by trigger

| Trigger | `build_console` | Environment | Sentry upload | Deploy |
|---|---|---|---|---|
| devel push | builds + uploads artifact | dev | yes | dev, from the artifact |
| cloud push | builds + uploads artifact (no longer skipped by `deploy-only`) | prod | yes | prod, from the artifact |
| PR with `deploy` label | builds + uploads artifact | dev | same-repo only | dev, from the artifact |
| plain PR / fork PR | check build, as today | prod | no | none |
| tag push | skipped, as today | - | - | - |

`test_wasm` and `vitest` still skip on cloud pushes.

## Behavioral deltas

- Devel runs no longer exercise the production-config build. The production config is still built on every plain PR and on the cloud run itself, and `deploy-target` guards a mismatch at both ends.
- On cloud pushes the console build now runs in the build phase, before the API prod deploy, instead of after it. Total wall clock is roughly flat, but the API deploy starts a bit later.

## Verification

YAML parse on all workflows; zizmor 1.25.2 offline (matching the CI pin) reports zero findings before and after; Biome 2.5.7 (`biome ci`) is clean on `deploy_target.js`; the new `deploy-target` guard was exercised against fixtures for the pass case (real adapter layout, relative `configPath`), missing redirect, mismatched redirect, absent `configPath`, and wrong Worker name. The redirect resolution was checked against the pinned `@cloudflare/vite-plugin` 1.51.1 (writer) and `wrangler` 4.120.0 (reader) sources. The end-to-end proof of the artifact path is the first devel push after merge; CI on this PR exercises the check build but not the deploy.
