### PR TITLE
Run the migrations in a window sized cache, and say which one is running

### DIFF
--- a/lib/bencher_schema/src/lib.rs
+++ b/lib/bencher_schema/src/lib.rs
@@ -1,7 +1,9 @@
 #[cfg(test)]
 use criterion as _;
-use diesel::connection::SimpleConnection as _;
-use diesel_migrations::{EmbeddedMigrations, MigrationHarness as _, embed_migrations};
+use diesel::{RunQueryDsl as _, connection::SimpleConnection as _};
+use diesel_migrations::{
+    EmbeddedMigrations, HarnessWithOutput, MigrationHarness as _, embed_migrations,
+};
 
 pub mod context;
 pub mod error;
@@ -22,6 +24,17 @@ const MIGRATIONS: EmbeddedMigrations = embed_migrations!("./migrations");
 pub const INVITE_TOKEN_TTL: u32 = u32::MAX;
 pub const CLAIM_TOKEN_TTL: u32 = 60;
 
+/// The page cache the migrations run with, in `SQLite`'s negative kibibyte form:
+/// 256 MiB.
+///
+/// A migration that rebuilds a table walks it through this cache, and the cache
+/// the connection serves from is sized for serving. Measured on the
+/// `report_benchmark` rebuild over 4 million synthetic rows, against production's
+/// 8.8 million, 64 MiB costs 3,022,663 page reads and writes and 41.7s where
+/// 256 MiB costs 385,721 and 18.2s. The window is attended and nothing else is
+/// running, so the memory is there to spend and it is given back below.
+const MIGRATION_CACHE_SIZE: i64 = -256 * 1024;
+
 #[derive(Debug, thiserror::Error)]
 pub enum MigrationError {
     #[error("Failed to run database migrations: {0}")]
@@ -30,6 +43,33 @@ pub enum MigrationError {
     PragmaOff(diesel::result::Error),
     #[error("Failed to run database pragma on: {0}")]
     PragmaOn(diesel::result::Error),
+    #[error("Failed to read the database cache size: {0}")]
+    CacheSize(diesel::result::Error),
+    #[error("Failed to set the database cache size: {0}")]
+    SetCacheSize(diesel::result::Error),
+}
+
+#[derive(diesel::QueryableByName)]
+struct CacheSize {
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    cache_size: i64,
+}
+
+/// The connection's current `cache_size`, in whatever form it was set in.
+fn cache_size(database: &mut context::DbConnection) -> Result<i64, MigrationError> {
+    diesel::sql_query("PRAGMA cache_size")
+        .get_result::<CacheSize>(database)
+        .map(|pragma| pragma.cache_size)
+        .map_err(MigrationError::CacheSize)
+}
+
+fn set_cache_size(
+    database: &mut context::DbConnection,
+    cache_size: i64,
+) -> Result<(), MigrationError> {
+    database
+        .batch_execute(&format!("PRAGMA cache_size = {cache_size}"))
+        .map_err(MigrationError::SetCacheSize)
 }
 
 pub fn run_migrations(database: &mut context::DbConnection) -> Result<(), MigrationError> {
@@ -42,13 +82,54 @@ pub fn run_migrations(database: &mut context::DbConnection) -> Result<(), Migrat
     database
         .batch_execute("PRAGMA foreign_keys = OFF")
         .map_err(MigrationError::PragmaOff)?;
-    database
+
+    // The serving cache size is read before it is replaced, so that whatever the
+    // connection was configured with is what it goes back to, on the way out and on
+    // the way out of a failure alike.
+    let serving_cache_size = cache_size(database)?;
+    set_cache_size(database, MIGRATION_CACHE_SIZE)?;
+
+    // `HarnessWithOutput` writes "Running migration <name>" as each one starts. A
+    // migration that rebuilds a table can hold the window for a long time, and a
+    // line per migration is the difference between watching it and guessing at it.
+    let migrated = HarnessWithOutput::write_to_stdout(database)
         .run_pending_migrations(MIGRATIONS)
         .map(|_| ())
-        .map_err(MigrationError::Migrations)?;
+        .map_err(MigrationError::Migrations);
+    // Restored before the migration result is unwrapped, so a failed migration does
+    // not leave the connection serving from the migration window's cache.
+    let restored = set_cache_size(database, serving_cache_size);
+    migrated?;
+    restored?;
+
     database
         .batch_execute("PRAGMA foreign_keys = ON")
         .map_err(MigrationError::PragmaOn)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use diesel::{Connection as _, connection::SimpleConnection as _};
+
+    use super::{cache_size, run_migrations};
+
+    // The connection that runs the migrations is the connection the API then serves
+    // from, so the window's cache size has to be handed back when the window closes.
+    #[test]
+    fn migrations_leave_the_cache_size_where_they_found_it() {
+        let mut conn = diesel::SqliteConnection::establish(":memory:")
+            .expect("Failed to create an in-memory database");
+        conn.batch_execute("PRAGMA cache_size = -8192")
+            .expect("Failed to set the serving cache size");
+
+        run_migrations(&mut conn).expect("Failed to run migrations");
+
+        assert_eq!(
+            cache_size(&mut conn).expect("Failed to read the cache size"),
+            -8192,
+            "the migrations give back the cache size they were handed"
+        );
+    }
 }


### PR DESCRIPTION
The migration window is attended, single tenant, and can run for hours. Two things it needs that it does not have: a page cache sized for the work, and some sign of life while it runs.

**This has to be in the deployed image before or with the parameter stack's migrations.** If it lands in a later image, those migrations run with the serving cache size and the window this was written for gets none of the benefit.

## A cache sized for the window

`run_migrations` now raises `cache_size` to 256 MiB for the duration of the run and puts the serving value back afterwards.

A migration that rebuilds a table walks the table through the writer's page cache, and that cache is sized for serving: `cache_size = -65536`, 64 MiB, set once at startup and never meant for a table rebuild.

The study is the `report_benchmark` rebuild, run on a synthetic database at the page size the server runs with, over a production-shaped row count. Across the whole rebuild, counting the copy's cache misses and spills, the drop of the old table, and the index builds:

| cache | page reads and writes | wall clock |
|---|---|---|
| 64 MiB | 3,022,663 | 41.7s |
| 256 MiB | 385,721 | 18.2s |

That is 7.8 times the page IO and 2.3 times the wall clock, and the cliff sits between the two: 128 MiB still costs 926,904. The ratio of cache to table only worsens as a table grows, so the measured gap is a floor rather than a ceiling. The window has the machine to itself, so the memory is there to spend.

The prior value is read rather than assumed, so the connection goes back to whatever it was configured with. The restore runs before the migration result is unwrapped, which means a failed migration leaves the connection serving from its own cache size rather than the window's. A unit test pins that: a connection set to a cache size of its own runs the migrations and comes back to it.

## A line per migration

The harness is wrapped in `HarnessWithOutput`, so each migration writes `Running migration <name>` as it starts.

Nothing listens on the API port for the whole run: the listener is created after migrations return. Until now that meant an attended window of hours was a process that had said nothing since `Running database migrations`, with no way to tell which migration was running or whether one was stuck.

The line goes to stdout rather than through slog. The harness owns its writer, and the process's stdout is collected the same way its log stream is, so the lines land where they are needed without threading a logger through a function that takes a connection and nothing else.

## Blast radius

Every test in the tree that touches the database runs migrations through this function, so the change is exercised by the whole suite rather than only by the test written for it.

## Gates

- `cargo fmt -- --check`: clean.
- `cargo clippy -p bencher_schema -p bencher_config --all-features --all-targets -- -Dwarnings`: clean.
- `cargo nextest run -p bencher_schema --all-features`: green, 183 tests.
- `cargo nextest run -p api_projects --all-features`: green, 182 tests.

