### PR TITLE
Tune the API machine memory, restart retries, and prod deploy wait

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -204,7 +204,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
       - name: Deploy API to Fly.io Prod
         working-directory: ./services/api
-        run: flyctl deploy --local-only --config fly/fly.toml --wait-timeout 300
+        run: flyctl deploy --local-only --config fly/fly.toml --wait-timeout 3600
       - name: Rebase main on cloud
         run: |
           set -euo pipefail

--- a/services/api/fly/fly.toml
+++ b/services/api/fly/fly.toml
@@ -49,8 +49,8 @@ protocol = "http"
 [[vm]]
 cpu_kind = "shared"
 cpus = 8
-memory_mb = 2048
+memory_mb = 4096
 
 [[restart]]
 policy = "on-failure"
-retries = 6
+retries = 3


### PR DESCRIPTION
Three operational settings move to values that fit what the service does now. This is permanent configuration, not a change staged for any particular deploy.

## Memory: 2 GiB to 4 GiB

`[[vm]] memory_mb = 4096`. The machine class does not move. `cpu_kind` stays `shared` and `cpus` stays `8`, because nothing the API does is CPU parallel and there is no evidence a different class buys anything.

The headroom is for Litestream. It replicates after a commit, and a large commit hands it a large burst to ship; at 2 GiB there is nothing above the working set for that burst to live in. Doubling the memory is the cheapest way to keep a replication flood away from the rest of the process.

## Restart retries: 6 to 3

`[[restart]] retries = 3`, with `policy = "on-failure"` unchanged. The self healing that matters is the first retry or two: a process that dies once overnight comes back on its own, and that behavior stays exactly as it is.

What changes is the tail. A deterministic failure fails deterministically, so attempts four through six are the same crash three more times. Halving the count halves that churn without touching the case the policy exists for.

## Prod deploy wait: 5 minutes to 1 hour

`--wait-timeout 3600` on the prod deploy step. flyctl treats the wait timeout as a deploy failure, so a deploy that carries a real migration comes back red on a 5 minute wait even though the machine it deployed is healthy and serving. A pipeline should tolerate the work the service actually does.

An hour is still a bound: a deploy that is genuinely hung fails within the hour rather than sitting there, and an hour sits well inside the GitHub job ceiling. The dev and test deploy steps keep their 5 minutes, since neither carries a data migration.

## Validation

- `fly.toml` parses (`tomllib`): `vm = [{cpu_kind = "shared", cpus = 8, memory_mb = 4096}]`, `restart = [{policy = "on-failure", retries = 3}]`. Mounts, services, and both check blocks are unchanged. 4096 MB is within what 8 shared vCPUs allow, at 2048 MB per shared vCPU.
- `deploy.yml` parses (Psych, 5 jobs). Of the three `flyctl deploy` steps, only the prod one moves: dev and test still read `--wait-timeout 300`.
- `fly.dev.toml`, `fly.test.toml`, and `fly_config.sh` have no diff against `devel`.

The whole change is three lines.
