### PR TITLE
Prune and persist the rate limiters on an hourly timer

### DIFF
--- a/lib/bencher_api_tests/src/context.rs
+++ b/lib/bencher_api_tests/src/context.rs
@@ -132,6 +132,8 @@ impl TestServer {
             messenger: Messenger::default(),
             database,
             rate_limiting: Arc::new(bencher_schema::context::RateLimiting::max()),
+            // The test server never spawns the periodic prune, so the slot stays empty.
+            rate_limiting_prune: bencher_schema::context::RateLimitingPruneTask::default(),
             github_client: None,
             google_client: None,
             indexer: None,

--- a/lib/bencher_config/src/config_tx.rs
+++ b/lib/bencher_config/src/config_tx.rs
@@ -332,6 +332,19 @@ async fn into_context(
         slog::error!(log, "Failed to restore rate limiting state: {e}");
     }
 
+    // Tripped on graceful shutdown, so the long-lived handlers and the periodic rate limiting task
+    // below both wind down instead of running on past the server.
+    #[cfg(feature = "plus")]
+    let shutdown = bencher_schema::context::CancellationToken::new();
+
+    #[cfg(feature = "plus")]
+    RateLimiting::spawn_prune(
+        Arc::clone(&rate_limiting),
+        database.path.clone(),
+        log.clone(),
+        shutdown.clone(),
+    );
+
     debug!(log, "Creating API context");
     Ok(ApiContext {
         console_url,
@@ -372,7 +385,7 @@ async fn into_context(
         #[cfg(feature = "plus")]
         runner_update: bencher_schema::context::RunnerUpdate::new(runner_update_base_url),
         #[cfg(feature = "plus")]
-        shutdown: bencher_schema::context::CancellationToken::new(),
+        shutdown,
     })
 }
 

--- a/lib/bencher_config/src/config_tx.rs
+++ b/lib/bencher_config/src/config_tx.rs
@@ -338,12 +338,13 @@ async fn into_context(
     let shutdown = bencher_schema::context::CancellationToken::new();
 
     #[cfg(feature = "plus")]
-    RateLimiting::spawn_prune(
-        Arc::clone(&rate_limiting),
-        database.path.clone(),
-        log.clone(),
-        shutdown.clone(),
-    );
+    let rate_limiting_prune =
+        bencher_schema::context::RateLimitingPruneTask::new(RateLimiting::spawn_prune(
+            Arc::clone(&rate_limiting),
+            database.path.clone(),
+            log.clone(),
+            shutdown.clone(),
+        ));
 
     debug!(log, "Creating API context");
     Ok(ApiContext {
@@ -355,6 +356,8 @@ async fn into_context(
         database,
         #[cfg(feature = "plus")]
         rate_limiting,
+        #[cfg(feature = "plus")]
+        rate_limiting_prune,
         #[cfg(feature = "plus")]
         github_client,
         #[cfg(feature = "plus")]

--- a/lib/bencher_schema/src/context/mod.rs
+++ b/lib/bencher_schema/src/context/mod.rs
@@ -43,7 +43,7 @@ pub use indexer::{IndexError, Indexer};
 pub use messenger::ServerStatsBody;
 pub use messenger::{Body, ButtonBody, Email, Message, Messenger, NewUserBody};
 #[cfg(feature = "plus")]
-pub use rate_limiting::{HeaderMap, RateLimiting, RateLimitingError};
+pub use rate_limiting::{HeaderMap, RateLimiting, RateLimitingError, RateLimitingPruneTask};
 pub use rbac::{Rbac, RbacError};
 #[cfg(feature = "plus")]
 pub use runner_update::RunnerUpdate;
@@ -61,6 +61,10 @@ pub struct ApiContext {
     pub database: Database,
     #[cfg(feature = "plus")]
     pub rate_limiting: Arc<RateLimiting>,
+    /// Join handle for the periodic rate limiting prune, so shutdown can wait for an in-flight save
+    /// to finish before writing the final snapshot.
+    #[cfg(feature = "plus")]
+    pub rate_limiting_prune: RateLimitingPruneTask,
     #[cfg(feature = "plus")]
     pub github_client: Option<GitHubClient>,
     #[cfg(feature = "plus")]

--- a/lib/bencher_schema/src/context/mod.rs
+++ b/lib/bencher_schema/src/context/mod.rs
@@ -92,7 +92,8 @@ pub struct ApiContext {
     #[cfg(feature = "plus")]
     pub runner_update: RunnerUpdate,
     /// Cancellation signal tripped on graceful shutdown so long-lived handlers (the runner WebSocket
-    /// channel) can wind down and let `server.close()` complete.
+    /// channel) can wind down and let `server.close()` complete. It also stops the periodic rate
+    /// limiting prune.
     #[cfg(feature = "plus")]
     pub shutdown: CancellationToken,
 }

--- a/lib/bencher_schema/src/context/rate_limiting/bandwidth.rs
+++ b/lib/bencher_schema/src/context/rate_limiting/bandwidth.rs
@@ -67,8 +67,8 @@ impl BandwidthRateLimiter {
         self.limiter.restore(snapshot);
     }
 
-    pub fn prune(&self) {
-        self.limiter.prune();
+    pub fn prune(&self) -> usize {
+        self.limiter.prune()
     }
 
     fn limit_for_priority(&self, priority: Priority) -> u64 {

--- a/lib/bencher_schema/src/context/rate_limiting/mod.rs
+++ b/lib/bencher_schema/src/context/rate_limiting/mod.rs
@@ -1,4 +1,10 @@
-use std::{io::Write as _, net::IpAddr, path::Path, time::Duration};
+use std::{
+    io::Write as _,
+    net::IpAddr,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 
 use camino::{Utf8Path, Utf8PathBuf};
 
@@ -12,6 +18,7 @@ use bencher_otel::AuthorizationKind;
 use dropshot::HttpError;
 pub use http::HeaderMap;
 use slog::Logger;
+use tokio_util::sync::CancellationToken;
 
 use crate::{
     error::{BencherResource, too_many_requests},
@@ -37,6 +44,11 @@ use snapshot::RateLimitingSnapshot;
 use user::UserRateLimiter;
 
 use super::DbConnection;
+
+/// How often the periodic task compacts the in-memory limiter maps and persists the snapshot.
+///
+/// This is also the upper bound on how much limiter state an abrupt termination can lose.
+const PRUNE_PERIOD: Duration = Duration::from_hours(1);
 
 const DEFAULT_UNCLAIMED_LIMIT: u32 = u8::MAX as u32;
 const DEFAULT_CLAIMED_LIMIT: u32 = u16::MAX as u32;
@@ -232,12 +244,15 @@ impl RateLimiting {
         }
     }
 
-    pub fn prune(&self) {
-        self.public.prune();
-        self.user.prune();
-        self.project.prune();
-        self.runner.prune();
-        self.bandwidth.prune();
+    /// Compact every in-memory limiter map, dropping the keys whose events have all aged out.
+    ///
+    /// Returns the total number of evicted entries.
+    pub fn prune(&self) -> usize {
+        self.public.prune()
+            + self.user.prune()
+            + self.project.prune()
+            + self.runner.prune()
+            + self.bandwidth.prune()
     }
 
     pub fn window(&self) -> (DateTime, DateTime) {
@@ -449,6 +464,47 @@ impl RateLimiting {
         Ok(())
     }
 
+    /// Spawn the periodic task that compacts the in-memory limiter maps and persists the snapshot.
+    ///
+    /// Without it, a long-lived server only ever compacts at a clean shutdown, so its limiter maps
+    /// grow for as long as the process lives, and an abrupt termination loses all limiter state.
+    pub fn spawn_prune(
+        rate_limiting: Arc<Self>,
+        db_path: PathBuf,
+        log: Logger,
+        shutdown: CancellationToken,
+    ) {
+        tokio::spawn(async move {
+            // The first tick of an `interval` fires immediately. Start a full period out instead:
+            // the snapshot was just loaded, so there is nothing to compact or persist at startup.
+            let mut interval =
+                tokio::time::interval_at(tokio::time::Instant::now() + PRUNE_PERIOD, PRUNE_PERIOD);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            while shutdown
+                .run_until_cancelled(interval.tick())
+                .await
+                .is_some()
+            {
+                rate_limiting.prune_and_save(&db_path, &log);
+            }
+        });
+    }
+
+    /// Compact the in-memory limiter maps and persist the resulting snapshot.
+    ///
+    /// Returns the number of evicted entries. A failed save is logged and swallowed so that a
+    /// transient write error cannot kill the periodic task.
+    fn prune_and_save(&self, db_path: &Path, log: &Logger) -> usize {
+        let evicted = self.prune();
+        if evicted > 0 {
+            slog::info!(log, "Pruned {evicted} stale rate limiting entries");
+        }
+        if let Err(e) = self.save(db_path, log) {
+            slog::error!(log, "Failed to save rate limiting state: {e}");
+        }
+        evicted
+    }
+
     fn snapshot_path(db_path: &Path) -> Result<Utf8PathBuf, RateLimitingPersistError> {
         let db_path = Utf8Path::from_path(db_path).ok_or(RateLimitingPersistError::NonUtf8Path)?;
         let parent = db_path.parent().unwrap_or(Utf8Path::new("."));
@@ -478,5 +534,54 @@ fn interval_kind(interval: bencher_rate_limiter::Interval) -> bencher_otel::Inte
         bencher_rate_limiter::Interval::Minute => bencher_otel::IntervalKind::Minute,
         bencher_rate_limiter::Interval::Hour => bencher_otel::IntervalKind::Hour,
         bencher_rate_limiter::Interval::Day => bencher_otel::IntervalKind::Day,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::IpAddr;
+
+    use super::{Logger, RateLimiting, RateLimitingSnapshot};
+
+    fn test_log() -> Logger {
+        Logger::root(slog::Discard, slog::o!())
+    }
+
+    #[test]
+    fn prune_and_save_persists_live_entries() {
+        let rate_limiting = RateLimiting::default();
+        let ip: IpAddr = "10.0.0.1".parse().unwrap();
+        rate_limiting.public_request(ip).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("bencher.db");
+        let log = test_log();
+
+        // Every seeded entry is live, so nothing is evicted.
+        assert_eq!(rate_limiting.prune_and_save(&db_path, &log), 0);
+
+        let snapshot_path = dir.path().join("rate_limiting.json");
+        assert!(snapshot_path.exists());
+
+        let restored = RateLimiting::default();
+        restored.load(&db_path, &log).unwrap();
+        assert_eq!(restored.prune_and_save(&db_path, &log), 0);
+
+        let json = std::fs::read_to_string(&snapshot_path).unwrap();
+        let snapshot: RateLimitingSnapshot = serde_json::from_str(&json).unwrap();
+        assert!(snapshot.public.requests.minute.events.contains_key(&ip));
+    }
+
+    #[test]
+    fn prune_and_save_survives_a_failed_save() {
+        let rate_limiting = RateLimiting::default();
+        let ip: IpAddr = "10.0.0.1".parse().unwrap();
+        rate_limiting.public_request(ip).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("missing").join("bencher.db");
+
+        assert_eq!(rate_limiting.prune_and_save(&db_path, &test_log()), 0);
+        assert!(!dir.path().join("missing").exists());
     }
 }

--- a/lib/bencher_schema/src/context/rate_limiting/mod.rs
+++ b/lib/bencher_schema/src/context/rate_limiting/mod.rs
@@ -2,7 +2,7 @@ use std::{
     io::Write as _,
     net::IpAddr,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, Mutex},
     time::Duration,
 };
 
@@ -18,6 +18,7 @@ use bencher_otel::AuthorizationKind;
 use dropshot::HttpError;
 pub use http::HeaderMap;
 use slog::Logger;
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -468,12 +469,15 @@ impl RateLimiting {
     ///
     /// Without it, a long-lived server only ever compacts at a clean shutdown, so its limiter maps
     /// grow for as long as the process lives, and an abrupt termination loses all limiter state.
+    ///
+    /// The returned handle lets shutdown wait for an in-flight save to finish before it writes the
+    /// final snapshot, so the two never race over the same partial file.
     pub fn spawn_prune(
         rate_limiting: Arc<Self>,
         db_path: PathBuf,
         log: Logger,
         shutdown: CancellationToken,
-    ) {
+    ) -> JoinHandle<()> {
         tokio::spawn(async move {
             // The first tick of an `interval` fires immediately. Start a full period out instead:
             // the snapshot was just loaded, so there is nothing to compact or persist at startup.
@@ -487,14 +491,17 @@ impl RateLimiting {
             {
                 rate_limiting.prune_and_save(&db_path, &log);
             }
-        });
+        })
     }
 
     /// Compact the in-memory limiter maps and persist the resulting snapshot.
     ///
-    /// Returns the number of evicted entries. A failed save is logged and swallowed so that a
-    /// transient write error cannot kill the periodic task.
-    fn prune_and_save(&self, db_path: &Path, log: &Logger) -> usize {
+    /// Shared by the periodic task and the shutdown path, which are serialized against each other:
+    /// shutdown awaits the periodic task before it runs its own final pass.
+    ///
+    /// Returns the number of evicted entries. Both the count and a failed save are logged here, and
+    /// the failure is swallowed so that a transient write error cannot kill the periodic task.
+    pub fn prune_and_save(&self, db_path: &Path, log: &Logger) -> usize {
         let evicted = self.prune();
         if evicted > 0 {
             slog::info!(log, "Pruned {evicted} stale rate limiting entries");
@@ -528,6 +535,26 @@ pub enum RateLimitingPersistError {
     Deserialize(serde_json::Error),
 }
 
+/// Holds the periodic prune task's join handle so that shutdown can wait for it.
+///
+/// Shutdown only ever has a shared reference to the API context, hence the interior mutability.
+#[derive(Default)]
+pub struct RateLimitingPruneTask(Mutex<Option<JoinHandle<()>>>);
+
+impl RateLimitingPruneTask {
+    pub fn new(handle: JoinHandle<()>) -> Self {
+        Self(Mutex::new(Some(handle)))
+    }
+
+    /// Take the join handle, leaving the slot empty.
+    ///
+    /// Returns `None` if the handle was already taken or the lock was poisoned. Neither is worth
+    /// failing shutdown over: the task stops on its own once the shutdown signal is tripped.
+    pub fn take(&self) -> Option<JoinHandle<()>> {
+        self.0.lock().ok().and_then(|mut handle| handle.take())
+    }
+}
+
 #[cfg(feature = "otel")]
 fn interval_kind(interval: bencher_rate_limiter::Interval) -> bencher_otel::IntervalKind {
     match interval {
@@ -541,7 +568,9 @@ fn interval_kind(interval: bencher_rate_limiter::Interval) -> bencher_otel::Inte
 mod tests {
     use std::net::IpAddr;
 
-    use super::{Logger, RateLimiting, RateLimitingSnapshot};
+    use super::{
+        Arc, CancellationToken, Logger, RateLimiting, RateLimitingPruneTask, RateLimitingSnapshot,
+    };
 
     fn test_log() -> Logger {
         Logger::root(slog::Discard, slog::o!())
@@ -570,6 +599,33 @@ mod tests {
         let json = std::fs::read_to_string(&snapshot_path).unwrap();
         let snapshot: RateLimitingSnapshot = serde_json::from_str(&json).unwrap();
         assert!(snapshot.public.requests.minute.events.contains_key(&ip));
+    }
+
+    #[tokio::test]
+    async fn spawn_prune_stops_on_the_shutdown_signal() {
+        let dir = tempfile::tempdir().unwrap();
+        let shutdown = CancellationToken::new();
+        let handle = RateLimiting::spawn_prune(
+            Arc::new(RateLimiting::default()),
+            dir.path().join("bencher.db"),
+            test_log(),
+            shutdown.clone(),
+        );
+
+        // The first tick is a full period out, so the task is still waiting on it.
+        assert!(!handle.is_finished());
+
+        shutdown.cancel();
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn prune_task_slot_yields_the_handle_once() {
+        let handle = tokio::spawn(async {});
+        let slot = RateLimitingPruneTask::new(handle);
+
+        slot.take().unwrap().await.unwrap();
+        assert!(slot.take().is_none());
     }
 
     #[test]

--- a/lib/bencher_schema/src/context/rate_limiting/project.rs
+++ b/lib/bencher_schema/src/context/rate_limiting/project.rs
@@ -89,9 +89,8 @@ impl ProjectRateLimiter {
         Self::new(max, max)
     }
 
-    pub fn prune(&self) {
-        self.requests.prune();
-        self.runs.prune();
+    pub fn prune(&self) -> usize {
+        self.requests.prune() + self.runs.prune()
     }
 
     pub fn snapshot(&self) -> ProjectRateLimiterSnapshot {

--- a/lib/bencher_schema/src/context/rate_limiting/public.rs
+++ b/lib/bencher_schema/src/context/rate_limiting/public.rs
@@ -119,10 +119,8 @@ impl PublicRateLimiter {
         Self::new(max, max, max)
     }
 
-    pub fn prune(&self) {
-        self.requests.prune();
-        self.attempts.prune();
-        self.runs.prune();
+    pub fn prune(&self) -> usize {
+        self.requests.prune() + self.attempts.prune() + self.runs.prune()
     }
 
     pub fn snapshot(&self) -> PublicRateLimiterSnapshot {

--- a/lib/bencher_schema/src/context/rate_limiting/runner.rs
+++ b/lib/bencher_schema/src/context/rate_limiting/runner.rs
@@ -65,8 +65,8 @@ impl RunnerRateLimiter {
         Self::new(requests)
     }
 
-    pub fn prune(&self) {
-        self.requests.prune();
+    pub fn prune(&self) -> usize {
+        self.requests.prune()
     }
 
     pub fn snapshot(&self) -> RunnerRateLimiterSnapshot {

--- a/lib/bencher_schema/src/context/rate_limiting/user.rs
+++ b/lib/bencher_schema/src/context/rate_limiting/user.rs
@@ -213,13 +213,13 @@ impl UserRateLimiter {
         Self::new(max, max, max, max, max, max)
     }
 
-    pub fn prune(&self) {
-        self.requests.prune();
-        self.attempts.prune();
-        self.credentials.prune();
-        self.organizations.prune();
-        self.invites.prune();
-        self.runs.prune();
+    pub fn prune(&self) -> usize {
+        self.requests.prune()
+            + self.attempts.prune()
+            + self.credentials.prune()
+            + self.organizations.prune()
+            + self.invites.prune()
+            + self.runs.prune()
     }
 
     pub fn snapshot(&self) -> UserRateLimiterSnapshot {

--- a/plus/bencher_rate_limiter/src/bandwidth.rs
+++ b/plus/bencher_rate_limiter/src/bandwidth.rs
@@ -74,12 +74,18 @@ where
             .record(now_bucket, bytes);
     }
 
-    pub fn prune(&self) {
+    /// Drop every key whose bandwidth has all aged out of the window.
+    ///
+    /// Returns the number of evicted keys. The count is advisory: concurrent traffic can add or
+    /// remove keys while the pass runs, so it is only ever used for reporting.
+    pub fn prune(&self) -> usize {
         let cutoff = self.cutoff_bucket(SystemTime::now());
+        let before = self.event_map.len();
         self.event_map.retain(|_, bw| {
             bw.prune(cutoff);
             bw.total_bytes > 0
         });
+        before.saturating_sub(self.event_map.len())
     }
 
     pub fn snapshot(&self) -> BandwidthSnapshot<K> {
@@ -257,6 +263,45 @@ mod tests {
 
         limiter.prune();
         assert!(!limiter.event_map.contains_key(&1));
+    }
+
+    #[test]
+    fn prune_empty_returns_zero() {
+        let limiter: BandwidthLimiter<u32> = BandwidthLimiter::new(DAY);
+        assert_eq!(limiter.prune(), 0);
+    }
+
+    #[test]
+    fn prune_returns_evicted_count() {
+        let limiter = BandwidthLimiter::new(DAY);
+        let old = test_now() - Duration::from_hours(25);
+        limiter.record_at(1u32, 500, old);
+        limiter.record_at(2u32, 500, old);
+
+        assert_eq!(limiter.prune(), 2);
+        assert!(limiter.event_map.is_empty());
+    }
+
+    #[test]
+    fn prune_does_not_count_live_keys() {
+        let limiter = BandwidthLimiter::new(DAY);
+        let old = test_now() - Duration::from_hours(25);
+        limiter.record_at(1u32, 500, old);
+        limiter.record(2u32, 500);
+
+        assert_eq!(limiter.prune(), 1);
+        assert!(!limiter.event_map.contains_key(&1));
+        assert!(limiter.event_map.contains_key(&2));
+    }
+
+    #[test]
+    fn prune_returns_zero_when_all_keys_live() {
+        let limiter = BandwidthLimiter::new(DAY);
+        limiter.record(1u32, 500);
+        limiter.record(2u32, 500);
+
+        assert_eq!(limiter.prune(), 0);
+        assert_eq!(limiter.event_map.len(), 2);
     }
 
     #[test]

--- a/plus/bencher_rate_limiter/src/rate_limiter.rs
+++ b/plus/bencher_rate_limiter/src/rate_limiter.rs
@@ -73,10 +73,11 @@ where
         }
     }
 
-    pub fn prune(&self) {
-        self.minute.prune();
-        self.hour.prune();
-        self.day.prune();
+    /// Compact all 3 windows, dropping every key whose events have all aged out.
+    ///
+    /// Returns the total number of evicted keys.
+    pub fn prune(&self) -> usize {
+        self.minute.prune() + self.hour.prune() + self.day.prune()
     }
 
     pub fn snapshot(&self) -> RateLimiterSnapshot<K> {
@@ -168,12 +169,18 @@ where
         }
     }
 
-    fn prune(&self) {
+    /// Drop every key whose events have all aged out of the window.
+    ///
+    /// Returns the number of evicted keys. The count is advisory: concurrent traffic can add or
+    /// remove keys while the pass runs, so it is only ever used for reporting.
+    fn prune(&self) -> usize {
         let (_, cutoff) = self.now_and_cutoff();
+        let before = self.event_map.len();
         self.event_map.retain(|_, events| {
             events.prune(cutoff);
             events.total > 0
         });
+        before.saturating_sub(self.event_map.len())
     }
 
     fn check(&self, key: K) -> bool {
@@ -409,6 +416,76 @@ mod tests {
 
         window.prune();
         assert!(!window.event_map.contains_key(&1));
+    }
+
+    fn stale_bucket(bucket_secs: u64) -> u64 {
+        epoch_bucket(
+            test_now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+                - 120,
+            bucket_secs,
+        )
+    }
+
+    fn stale_events(bucket_secs: u64) -> BucketedEvents {
+        BucketedEvents {
+            buckets: VecDeque::from([(stale_bucket(bucket_secs), 3)]),
+            total: 3,
+        }
+    }
+
+    #[test]
+    fn prune_empty_returns_zero() {
+        let window: Window<u32> = Window::new(Duration::from_mins(1), 100);
+        assert_eq!(window.prune(), 0);
+    }
+
+    #[test]
+    fn prune_returns_evicted_count() {
+        let window: Window<u32> = Window::new(Duration::from_mins(1), 100);
+        window.event_map.insert(1, stale_events(60));
+        window.event_map.insert(2, stale_events(60));
+
+        assert_eq!(window.prune(), 2);
+        assert!(window.event_map.is_empty());
+    }
+
+    #[test]
+    fn prune_does_not_count_live_keys() {
+        let window: Window<u32> = Window::new(Duration::from_mins(1), 100);
+        window.event_map.insert(1, stale_events(60));
+        assert!(window.check(2));
+
+        assert_eq!(window.prune(), 1);
+        assert!(!window.event_map.contains_key(&1));
+        assert!(window.event_map.contains_key(&2));
+    }
+
+    #[test]
+    fn prune_returns_zero_when_all_keys_live() {
+        let window: Window<u32> = Window::new(Duration::from_mins(1), 100);
+        assert!(window.check(1));
+        assert!(window.check(2));
+
+        assert_eq!(window.prune(), 0);
+        assert_eq!(window.event_map.len(), 2);
+    }
+
+    #[test]
+    fn rate_limiter_prune_sums_windows() {
+        let limiter: RateLimiter<u32> = RateLimiter::new(RateLimits {
+            minute: 100,
+            hour: 1000,
+            day: 10000,
+        });
+        limiter.minute.event_map.insert(1, stale_events(60));
+        limiter.hour.event_map.insert(1, stale_events(3600));
+        limiter.hour.event_map.insert(2, stale_events(3600));
+        limiter.day.event_map.insert(1, stale_events(86400));
+
+        assert_eq!(limiter.prune(), 4);
     }
 
     #[test]

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -152,7 +152,10 @@ async fn shutdown(log: &Logger, server: HttpServer<ApiContext>) {
         ctx.shutdown.cancel();
         let rate_limiting = ctx.rate_limiting.clone();
         let database_path = ctx.database.path.clone();
-        rate_limiting.prune();
+        let evicted = rate_limiting.prune();
+        if evicted > 0 {
+            info!(log, "Pruned {evicted} stale rate limiting entries");
+        }
         move || rate_limiting.save(&database_path, log)
     };
     if let Err(e) = server.close().await {

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -143,27 +143,36 @@ async fn run(
 }
 
 async fn shutdown(log: &Logger, server: HttpServer<ApiContext>) {
+    // Everything shutdown needs out of the context, taken before `server.close()` consumes the
+    // server.
     #[cfg(feature = "plus")]
-    let save_rate_limiting = {
+    let (rate_limiting, database_path, prune_task) = {
         let ctx = server.app_private();
-        // Signal long-lived handlers (the runner WebSocket channel) to wind down so the in-flight
-        // connection drain in `server.close()` can complete instead of hanging until the platform
-        // escalates to SIGKILL (which would skip the rate limiting save below entirely).
+        // Signal long-lived handlers (the runner WebSocket channel) and the periodic rate limiting
+        // prune to wind down, so the in-flight connection drain in `server.close()` can complete
+        // instead of hanging until the platform escalates to SIGKILL (which would skip the rate
+        // limiting save below entirely).
         ctx.shutdown.cancel();
-        let rate_limiting = ctx.rate_limiting.clone();
-        let database_path = ctx.database.path.clone();
-        let evicted = rate_limiting.prune();
-        if evicted > 0 {
-            info!(log, "Pruned {evicted} stale rate limiting entries");
-        }
-        move || rate_limiting.save(&database_path, log)
+        (
+            ctx.rate_limiting.clone(),
+            ctx.database.path.clone(),
+            ctx.rate_limiting_prune.take(),
+        )
     };
     if let Err(e) = server.close().await {
         error!(log, "Server close error: {e}");
     }
     #[cfg(feature = "plus")]
-    if let Err(e) = save_rate_limiting() {
-        error!(log, "Failed to save rate limiting state: {e}");
+    {
+        // Let the periodic task finish any save already in flight, so it cannot race the final one
+        // over the shared partial file. It stops promptly: the shutdown signal above ends its wait
+        // for the next tick, and a save in progress is a few milliseconds of synchronous work.
+        if let Some(prune_task) = prune_task
+            && let Err(e) = prune_task.await
+        {
+            error!(log, "Rate limiting prune task failed to join: {e}");
+        }
+        rate_limiting.prune_and_save(&database_path, log);
     }
 }
 


### PR DESCRIPTION
## What

The in-memory rate limiter maps only compact and persist at shutdown. `check()` inserts a map entry for every new key and never removes one, so a long-lived server accumulates an entry for every key it ever saw. An abrupt termination (SIGKILL, OOM) also loses all limiter state, because `save()` only runs on the clean shutdown path.

This adds a periodic task that runs once per hour:

1. `prune()` every limiter: drop expired buckets and remove each key with no live events. `prune()` now returns the evicted-entry count, and the task logs the count at info level when it is nonzero.
2. `save()` the snapshot, so a crash loses at most 1 hour of limiter state. A failed save logs at error level and never ends the task.

The task spawns where the API context is built, so both startup paths get it. It skips the immediate first tick, uses `MissedTickBehavior::Delay`, and stops on the existing shutdown token. The shutdown path is unchanged except that the final prune now logs its evicted count.

The on-disk `rate_limiting.json` format is untouched: a server upgraded across this commit still loads its old snapshot.

## Tests

- Eviction counts: empty map, stale keys, live keys survive uncounted, and the 3-window sum.
- The tick body: live entries round-trip through `save()` and `load()` on a fresh limiter, and a failed save does not kill the task.
