### PR TITLE
Rename the metric triple and the parameter set field

### DIFF
--- a/lib/api_projects/tests/benchmarks.rs
+++ b/lib/api_projects/tests/benchmarks.rs
@@ -7,7 +7,7 @@
 //! Integration tests for project benchmark endpoints.
 
 use bencher_api_tests::{TestServer, helpers::create_empty_parameter};
-use bencher_json::{JsonBenchmark, JsonBenchmarks, JsonParameters};
+use bencher_json::{JsonBenchmark, JsonBenchmarks, ParameterSet};
 use bencher_schema::schema;
 use diesel::{
     ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _, connection::SimpleConnection as _,
@@ -149,14 +149,14 @@ fn assert_benchmark_birth_invariant(server: &TestServer) {
     );
 
     for benchmark_id in benchmark_ids {
-        let parameters: Vec<JsonParameters> = schema::parameter::table
+        let parameters: Vec<ParameterSet> = schema::parameter::table
             .filter(schema::parameter::benchmark_id.eq(benchmark_id))
-            .select(schema::parameter::parameters)
+            .select(schema::parameter::set)
             .load(&mut conn)
             .expect("Failed to load parameters");
         assert_eq!(
             parameters,
-            vec![JsonParameters::default()],
+            vec![ParameterSet::default()],
             "benchmark {benchmark_id} must have exactly one empty parameter set"
         );
     }
@@ -196,12 +196,12 @@ async fn benchmarks_create_empty_parameter_set() {
         .select(schema::benchmark::id)
         .first(&mut conn)
         .expect("Failed to get benchmark ID");
-    let parameters: Vec<JsonParameters> = schema::parameter::table
+    let parameters: Vec<ParameterSet> = schema::parameter::table
         .filter(schema::parameter::benchmark_id.eq(benchmark_id))
-        .select(schema::parameter::parameters)
+        .select(schema::parameter::set)
         .load(&mut conn)
         .expect("Failed to load parameters");
-    assert_eq!(parameters, vec![JsonParameters::default()]);
+    assert_eq!(parameters, vec![ParameterSet::default()]);
 
     assert_benchmark_birth_invariant(&server);
 }
@@ -221,7 +221,7 @@ async fn benchmarks_create_rolls_back_with_parameter_set() {
 
     // Poison the empty parameter set that the next benchmark will be born with.
     // SQLite hands an `INTEGER PRIMARY KEY` the next rowid after the largest in
-    // use, so the row below collides on `UNIQUE(benchmark_id, parameters)` with
+    // use, so the row below collides on `UNIQUE(benchmark_id, "set")` with
     // the set created inside the benchmark's own transaction. Foreign keys are
     // off on this connection, so it may point at a benchmark that does not exist yet.
     let mut conn = server.db_conn();

--- a/lib/api_projects/tests/metric_migration.rs
+++ b/lib/api_projects/tests/metric_migration.rs
@@ -19,12 +19,12 @@
 
 use bencher_api_tests::{
     TestServer,
-    helpers::{base_timestamp, create_empty_parameter, get_project_id},
+    helpers::{base_timestamp, get_project_id},
 };
 use bencher_json::{
     AlertUuid, BenchmarkUuid, BoundaryUuid, BranchUuid, HeadUuid, MeasureUuid, MetricName,
-    MetricUuid, ModelUuid, ReportBenchmarkUuid, ReportUuid, TestbedUuid, ThresholdUuid,
-    VersionUuid, project::alert::AlertStatus, project::boundary::BoundaryLimit,
+    MetricUuid, ModelUuid, ParameterUuid, ReportBenchmarkUuid, ReportUuid, TestbedUuid,
+    ThresholdUuid, VersionUuid, project::alert::AlertStatus, project::boundary::BoundaryLimit,
 };
 use bencher_schema::{MIGRATIONS, context::DbConnection, schema};
 use diesel::{
@@ -710,6 +710,36 @@ fn revert_migration(conn: &mut DbConnection) {
         .expect("Failed to enable foreign keys");
 }
 
+/// Seed a benchmark's empty parameter set at the reverted schema point.
+///
+/// Benchmarks inserted directly into the database bypass `QueryBenchmark::create`,
+/// so they need the birth invariant applied by hand. The migrations are reverted
+/// when this runs, so the column is still spelled `parameters`: the rename to `set`
+/// is a layer above, and the chain puts it back on the way up. That is why this is
+/// raw SQL rather than `create_empty_parameter`, for the same reason the metric rows
+/// below are.
+fn seed_empty_parameter(conn: &mut DbConnection, benchmark_id: i32) -> i32 {
+    let now = base_timestamp();
+
+    let parameter_uuid = ParameterUuid::new();
+    diesel::sql_query(
+        "INSERT INTO parameter (uuid, benchmark_id, parameters, created, modified)
+         VALUES (?, ?, jsonb('{}'), ?, ?)",
+    )
+    .bind::<Text, _>(parameter_uuid.to_string())
+    .bind::<Integer, _>(benchmark_id)
+    .bind::<BigInt, _>(now)
+    .bind::<BigInt, _>(now)
+    .execute(&mut *conn)
+    .expect("Failed to seed the empty parameter set");
+
+    schema::parameter::table
+        .filter(schema::parameter::uuid.eq(&parameter_uuid))
+        .select(schema::parameter::id)
+        .first(&mut *conn)
+        .expect("Failed to get the parameter id")
+}
+
 /// The `metric_boundary` column list, in the order `view.rs` declares it.
 const VIEW_COLUMNS: [&str; 14] = [
     "metric_id",
@@ -904,7 +934,7 @@ async fn seed_legacy_project(server: &TestServer, label: &str) -> Fixture {
         .select(schema::benchmark::id)
         .first(&mut conn)
         .expect("Failed to get the benchmark id");
-    let parameter_id = create_empty_parameter(&mut conn, benchmark_id);
+    let parameter_id = seed_empty_parameter(&mut conn, benchmark_id);
 
     // Two measures, so a pivot that joins on the report benchmark alone pulls a
     // bound across measures and fails.

--- a/lib/api_projects/tests/parameters.rs
+++ b/lib/api_projects/tests/parameters.rs
@@ -17,7 +17,7 @@ use bencher_api_tests::{
     TestServer,
     helpers::{base_timestamp, get_project_id},
 };
-use bencher_json::{DateTime, JsonParameters, MetricName, Slug};
+use bencher_json::{DateTime, MetricName, ParameterSet, Slug};
 use bencher_schema::{
     context::DbConnection,
     model::{organization::OrganizationId, project::metric::QueryMetric},
@@ -140,12 +140,12 @@ fn organization_id(conn: &mut DbConnection, project_id: i32) -> OrganizationId {
 
 /// Every parameter set stored under a project, with the number of `report_benchmark`
 /// rows pointing at it.
-fn parameter_sets(conn: &mut DbConnection, project_id: i32) -> Vec<(JsonParameters, i64)> {
-    let parameters: Vec<(i32, JsonParameters)> = schema::parameter::table
+fn parameter_sets(conn: &mut DbConnection, project_id: i32) -> Vec<(ParameterSet, i64)> {
+    let parameters: Vec<(i32, ParameterSet)> = schema::parameter::table
         .inner_join(schema::benchmark::table)
         .filter(schema::benchmark::project_id.eq(project_id))
         .order(schema::parameter::id.asc())
-        .select((schema::parameter::id, schema::parameter::parameters))
+        .select((schema::parameter::id, schema::parameter::set))
         .load(&mut *conn)
         .expect("Failed to load the parameter sets");
 
@@ -163,7 +163,7 @@ fn parameter_sets(conn: &mut DbConnection, project_id: i32) -> Vec<(JsonParamete
 }
 
 /// Every metric name stored for a project, with its value, keyed by parameter set.
-fn named_values(conn: &mut DbConnection, project_id: i32) -> Vec<(JsonParameters, String, f64)> {
+fn named_values(conn: &mut DbConnection, project_id: i32) -> Vec<(ParameterSet, String, f64)> {
     schema::metric::table
         .inner_join(
             schema::report_benchmark::table
@@ -173,11 +173,11 @@ fn named_values(conn: &mut DbConnection, project_id: i32) -> Vec<(JsonParameters
         .filter(schema::benchmark::project_id.eq(project_id))
         .order((schema::parameter::id.asc(), schema::metric::name.asc()))
         .select((
-            schema::parameter::parameters,
+            schema::parameter::set,
             schema::metric::name,
             schema::metric::value,
         ))
-        .load::<(JsonParameters, MetricName, f64)>(&mut *conn)
+        .load::<(ParameterSet, MetricName, f64)>(&mut *conn)
         .expect("Failed to load the metric rows")
         .into_iter()
         .map(|(parameters, name, value)| (parameters, name.to_string(), value))
@@ -185,7 +185,7 @@ fn named_values(conn: &mut DbConnection, project_id: i32) -> Vec<(JsonParameters
 }
 
 /// The parameter set and metric name of every alert in a project.
-fn alerts(conn: &mut DbConnection, project_id: i32) -> Vec<(JsonParameters, String)> {
+fn alerts(conn: &mut DbConnection, project_id: i32) -> Vec<(ParameterSet, String)> {
     schema::alert::table
         .inner_join(
             schema::boundary::table.inner_join(
@@ -198,8 +198,8 @@ fn alerts(conn: &mut DbConnection, project_id: i32) -> Vec<(JsonParameters, Stri
         )
         .filter(schema::benchmark::project_id.eq(project_id))
         .order(schema::alert::id.asc())
-        .select((schema::parameter::parameters, schema::metric::name))
-        .load::<(JsonParameters, MetricName)>(&mut *conn)
+        .select((schema::parameter::set, schema::metric::name))
+        .load::<(ParameterSet, MetricName)>(&mut *conn)
         .expect("Failed to load the alerts")
         .into_iter()
         .map(|(parameters, name)| (parameters, name.to_string()))
@@ -239,7 +239,7 @@ fn series_measures(conn: &mut DbConnection, project_id: i32) -> Vec<String> {
         .collect()
 }
 
-fn parameters(canonical: &str) -> JsonParameters {
+fn parameters(canonical: &str) -> ParameterSet {
     canonical.parse().expect("Failed to parse the parameters")
 }
 
@@ -279,7 +279,7 @@ async fn v1_report_lands_grid_points_and_named_values() {
     assert_eq!(
         parameter_sets(&mut conn, project_id),
         vec![
-            (JsonParameters::default(), 0),
+            (ParameterSet::default(), 0),
             (parameters(r#"{"size_mb": 16}"#), 1),
             (parameters(r#"{"size_mb": 32}"#), 1),
         ],
@@ -499,7 +499,7 @@ async fn bare_threshold_gates_only_the_value_name() {
     let alerts = alerts(&mut conn, project_id);
     assert_eq!(
         alerts,
-        vec![(JsonParameters::default(), "value".to_owned())],
+        vec![(ParameterSet::default(), "value".to_owned())],
         "the alert is on the point estimate"
     );
 }
@@ -534,7 +534,7 @@ async fn absent_parameters_land_on_the_empty_set() {
 
     assert_eq!(
         parameter_sets(&mut conn, project_id),
-        vec![(JsonParameters::default(), 1)],
+        vec![(ParameterSet::default(), 1)],
         "an absent parameter set and an explicit empty one are one grid point"
     );
 }
@@ -595,7 +595,7 @@ async fn v1_entry_without_measures_mints_nothing() {
     assert_eq!(benchmark_count(&mut conn, project_id), 1);
     assert_eq!(
         parameter_sets(&mut conn, project_id),
-        vec![(JsonParameters::default(), 0)],
+        vec![(ParameterSet::default(), 0)],
         "only the empty set the benchmark was born with, pointed at by nothing"
     );
     assert_eq!(named_values(&mut conn, project_id), vec![]);
@@ -623,7 +623,7 @@ async fn v1_benchmark_without_entries_mints_nothing() {
     assert_eq!(benchmark_count(&mut conn, project_id), 1);
     assert_eq!(
         parameter_sets(&mut conn, project_id),
-        vec![(JsonParameters::default(), 0)],
+        vec![(ParameterSet::default(), 0)],
     );
     assert_eq!(named_values(&mut conn, project_id), vec![]);
     assert_eq!(series_measures(&mut conn, project_id), Vec::<String>::new());
@@ -655,7 +655,7 @@ async fn v0_benchmark_without_measures_is_unchanged() {
     assert_eq!(benchmark_count(&mut conn, project_id), 1);
     assert_eq!(
         parameter_sets(&mut conn, project_id),
-        vec![(JsonParameters::default(), 1)],
+        vec![(ParameterSet::default(), 1)],
         "the v0 row still lands on the empty parameter set"
     );
     assert_eq!(named_values(&mut conn, project_id), vec![]);
@@ -684,7 +684,7 @@ async fn archived_parameter_set_is_unarchived_on_report() {
         let mut conn = server.db_conn();
         let updated = diesel::update(
             schema::parameter::table
-                .filter(schema::parameter::parameters.eq(parameters(r#"{"size_mb": 16}"#))),
+                .filter(schema::parameter::set.eq(parameters(r#"{"size_mb": 16}"#))),
         )
         .set(schema::parameter::archived.eq(Some(1_000_000_000i64)))
         .execute(&mut conn)
@@ -698,7 +698,7 @@ async fn archived_parameter_set_is_unarchived_on_report() {
     let archived: Vec<Option<i64>> = schema::parameter::table
         .inner_join(schema::benchmark::table)
         .filter(schema::benchmark::project_id.eq(project_id))
-        .filter(schema::parameter::parameters.eq(parameters(r#"{"size_mb": 16}"#)))
+        .filter(schema::parameter::set.eq(parameters(r#"{"size_mb": 16}"#)))
         .select(schema::parameter::archived)
         .load(&mut conn)
         .expect("Failed to load the parameter set");
@@ -978,12 +978,12 @@ async fn report_response_echoes_named_values_and_separates_grid_points() {
         Some(&serde_json::json!({ "benchmarks": 2, "measures": 2 })),
     );
 
-    let grid_points: Vec<JsonParameters> = results
+    let grid_points: Vec<ParameterSet> = results
         .iter()
         .map(|result| {
             serde_json::from_value(
                 result
-                    .pointer("/parameter/parameters")
+                    .pointer("/parameter/set")
                     .expect("each result names its parameter set")
                     .clone(),
             )

--- a/lib/api_projects/tests/reports.rs
+++ b/lib/api_projects/tests/reports.rs
@@ -16,8 +16,8 @@ use bencher_api_tests::{
     },
 };
 use bencher_json::{
-    BenchmarkUuid, BoundaryUuid, JsonParameters, JsonReport, JsonReports, MeasureUuid, MetricName,
-    MetricUuid, ModelUuid, ReportBenchmarkUuid, ThresholdUuid,
+    BenchmarkUuid, BoundaryUuid, JsonReport, JsonReports, MeasureUuid, MetricName, MetricUuid,
+    ModelUuid, ParameterSet, ReportBenchmarkUuid, ThresholdUuid,
 };
 use bencher_schema::{
     context::DbConnection,
@@ -626,14 +626,14 @@ async fn reports_ingest_empty_parameter_sets() {
     assert_eq!(benchmark_ids.len(), 2, "two benchmarks were ingested");
 
     for benchmark_id in benchmark_ids {
-        let parameters: Vec<JsonParameters> = schema::parameter::table
+        let parameters: Vec<ParameterSet> = schema::parameter::table
             .filter(schema::parameter::benchmark_id.eq(benchmark_id))
-            .select(schema::parameter::parameters)
+            .select(schema::parameter::set)
             .load(&mut conn)
             .expect("Failed to load parameters");
         assert_eq!(
             parameters,
-            vec![JsonParameters::default()],
+            vec![ParameterSet::default()],
             "benchmark {benchmark_id} must have exactly one empty parameter set"
         );
     }

--- a/lib/bencher_adapter/src/adapters/json/v0.rs
+++ b/lib/bencher_adapter/src/adapters/json/v0.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use bencher_json::{BenchmarkNameId, JsonNewMetric, JsonParameters, MeasureNameId};
+use bencher_json::{BenchmarkNameId, JsonNewMetric, MeasureNameId, ParameterSet};
 
 use crate::{
     Adaptable, Settings,
@@ -39,7 +39,7 @@ fn from_wire(results: JsonV0Results) -> AdapterResults {
                 .collect::<HashMap<_, _>>();
             (
                 benchmark,
-                std::iter::once((JsonParameters::default(), metrics.into())).collect(),
+                std::iter::once((ParameterSet::default(), metrics.into())).collect(),
             )
         })
         .collect::<ResultsMap>()

--- a/lib/bencher_adapter/src/adapters/json/v1.rs
+++ b/lib/bencher_adapter/src/adapters/json/v1.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use bencher_json::{BenchmarkNameId, JsonParameters, MeasureNameId};
+use bencher_json::{BenchmarkNameId, MeasureNameId, ParameterSet};
 use serde::Deserialize;
 
 use crate::{
@@ -21,7 +21,7 @@ pub struct JsonV1Entry {
     /// Optional. An entry without it resolves to the benchmark's empty parameter set,
     /// which is exactly what an explicit `{}` resolves to.
     #[serde(default)]
-    pub parameters: JsonParameters,
+    pub parameters: ParameterSet,
     pub measures: HashMap<MeasureNameId, JsonV1Measure>,
 }
 
@@ -86,7 +86,7 @@ fn from_wire(results: JsonV1Results) -> AdapterResults {
 
 #[cfg(test)]
 pub(crate) mod test_json_v1 {
-    use bencher_json::{BenchmarkNameId, JsonParameters, MAX_PARAMETER_KEYS, MetricName};
+    use bencher_json::{BenchmarkNameId, MAX_PARAMETER_KEYS, MetricName, ParameterSet};
     use ordered_float::OrderedFloat;
     use pretty_assertions::assert_eq;
 
@@ -125,7 +125,7 @@ pub(crate) mod test_json_v1 {
             .parse::<BenchmarkNameId>()
             .expect("Failed to parse benchmark name");
         let parameters = parameters
-            .parse::<JsonParameters>()
+            .parse::<ParameterSet>()
             .expect("Failed to parse parameters");
         results
             .inner
@@ -217,7 +217,7 @@ pub(crate) mod test_json_v1 {
         let merged = "tests::merged".parse::<BenchmarkNameId>().unwrap();
         let entries = &results.inner[&merged];
         assert_eq!(entries.len(), 1);
-        let metrics = &entries[&JsonParameters::default()];
+        let metrics = &entries[&ParameterSet::default()];
         assert_eq!(named(metrics, "latency", "value"), Some(1.0.into()));
         assert_eq!(named(metrics, "throughput", "value"), Some(2.0.into()));
     }

--- a/lib/bencher_adapter/src/results/adapter_results.rs
+++ b/lib/bencher_adapter/src/results/adapter_results.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 
 use bencher_json::{
-    BenchmarkName, BenchmarkNameId, JsonNewMetric, JsonParameters,
+    BenchmarkName, BenchmarkNameId, JsonNewMetric, ParameterSet,
     project::measure::built_in::{self, BuiltInMeasure as _},
 };
 
@@ -31,7 +31,7 @@ pub type ResultsMap = HashMap<BenchmarkNameId, BenchmarkEntries>;
 ///
 /// The empty parameter set is the key every BMF v0 adapter uses, since a v0
 /// payload only ever reports one grid point per benchmark.
-pub type BenchmarkEntries = BTreeMap<JsonParameters, AdapterMetrics>;
+pub type BenchmarkEntries = BTreeMap<ParameterSet, AdapterMetrics>;
 
 /// The Bencher Metric Format version a results payload was parsed from.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -71,7 +71,7 @@ impl From<FoldableResults> for AdapterResults {
                     .into();
                 (
                     benchmark,
-                    std::iter::once((JsonParameters::default(), metrics)).collect(),
+                    std::iter::once((ParameterSet::default(), metrics)).collect(),
                 )
             })
             .collect::<ResultsMap>()
@@ -87,7 +87,7 @@ fn empty_set(results_map: &mut ResultsMap, benchmark_name: BenchmarkName) -> &mu
     results_map
         .entry(BenchmarkNameId::new_name(benchmark_name))
         .or_default()
-        .entry(JsonParameters::default())
+        .entry(ParameterSet::default())
         .or_default()
 }
 
@@ -590,7 +590,7 @@ impl AdapterResults {
     /// The metrics a benchmark reported on the empty parameter set.
     #[cfg(test)]
     pub fn entry(&self, benchmark: &BenchmarkNameId) -> Option<&AdapterMetrics> {
-        self.inner.get(benchmark)?.get(&JsonParameters::default())
+        self.inner.get(benchmark)?.get(&ParameterSet::default())
     }
 
     pub fn is_empty(&self) -> bool {
@@ -606,7 +606,7 @@ impl AdapterResults {
     pub(crate) fn into_foldable(self) -> FoldableResults {
         let mut fold_map = FoldableMap::with_capacity(self.inner.len());
         for (benchmark, mut entries) in self.inner {
-            let Some(metrics) = entries.remove(&JsonParameters::default()) else {
+            let Some(metrics) = entries.remove(&ParameterSet::default()) else {
                 continue;
             };
             let metrics = metrics

--- a/lib/bencher_api_tests/src/helpers.rs
+++ b/lib/bencher_api_tests/src/helpers.rs
@@ -3,8 +3,8 @@
 //! These helpers are used by both `api_projects` and `api_runners` integration tests.
 
 use bencher_json::{
-    BranchUuid, DateTime, HeadUuid, JobStatus, JobUuid, JsonParameters, Jwt, MetricName,
-    MetricUuid, ParameterUuid, ReportUuid, ResourceName, TestbedUuid, TokenUuid, VersionUuid,
+    BranchUuid, DateTime, HeadUuid, JobStatus, JobUuid, Jwt, MetricName, MetricUuid, ParameterSet,
+    ParameterUuid, ReportUuid, ResourceName, TestbedUuid, TokenUuid, VersionUuid,
 };
 use bencher_schema::{context::DbConnection, model::user::UserId, schema};
 use diesel::{ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
@@ -42,7 +42,7 @@ pub fn create_empty_parameter(conn: &mut DbConnection, benchmark_id: i32) -> i32
         .values((
             schema::parameter::uuid.eq(&parameter_uuid),
             schema::parameter::benchmark_id.eq(benchmark_id),
-            schema::parameter::parameters.eq(JsonParameters::default()),
+            schema::parameter::set.eq(ParameterSet::default()),
             schema::parameter::created.eq(&now),
             schema::parameter::modified.eq(&now),
         ))
@@ -61,7 +61,7 @@ pub fn create_empty_parameter(conn: &mut DbConnection, benchmark_id: i32) -> i32
 pub fn get_empty_parameter(conn: &mut DbConnection, benchmark_id: i32) -> i32 {
     schema::parameter::table
         .filter(schema::parameter::benchmark_id.eq(benchmark_id))
-        .filter(schema::parameter::parameters.eq(JsonParameters::default()))
+        .filter(schema::parameter::set.eq(ParameterSet::default()))
         .select(schema::parameter::id)
         .first(&mut *conn)
         .expect("Failed to get empty parameter set")

--- a/lib/bencher_comment/src/lib.rs
+++ b/lib/bencher_comment/src/lib.rs
@@ -1281,7 +1281,7 @@ mod tests {
             },
             "parameter": {
                 "uuid": "77777777-7777-7777-7777-777777777777",
-                "parameters": {},
+                "set": {},
             },
             "measures": [
                 {

--- a/lib/bencher_json/src/lib.rs
+++ b/lib/bencher_json/src/lib.rs
@@ -83,10 +83,10 @@ pub use project::{
         MeasureUuid,
     },
     metric::{
-        JsonMetric, JsonMetricsMap, JsonNewMetric, JsonOneMetric, JsonResultsMap, MetricUuid,
+        JsonMetricTriple, JsonMetricsMap, JsonNewMetric, JsonOneMetric, JsonResultsMap, MetricUuid,
     },
     model::{JsonModel, ModelUuid},
-    parameter::{JsonParameters, MAX_PARAMETER_KEYS, ParameterUuid},
+    parameter::{MAX_PARAMETER_KEYS, ParameterSet, ParameterUuid},
     perf::{JsonPerf, JsonPerfQuery, ReportBenchmarkUuid},
     plot::{JsonNewPlot, JsonPlot, JsonPlots, PlotUuid},
     report::{

--- a/lib/bencher_json/src/project/alert.rs
+++ b/lib/bencher_json/src/project/alert.rs
@@ -2,7 +2,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{DateTime, JsonBenchmark, JsonBoundary, JsonMetric, JsonThreshold};
+use crate::{DateTime, JsonBenchmark, JsonBoundary, JsonMetricTriple, JsonThreshold};
 
 use super::{boundary::BoundaryLimit, report::Iteration, report::ReportUuid};
 
@@ -22,7 +22,7 @@ pub struct JsonAlert {
     pub report: ReportUuid,
     pub iteration: Iteration,
     pub benchmark: JsonBenchmark,
-    pub metric: JsonMetric,
+    pub metric: JsonMetricTriple,
     pub threshold: JsonThreshold,
     pub boundary: JsonBoundary,
     pub limit: BoundaryLimit,

--- a/lib/bencher_json/src/project/metric/mod.rs
+++ b/lib/bencher_json/src/project/metric/mod.rs
@@ -160,14 +160,14 @@ impl Median for JsonNewMetric {}
 #[typeshare::typeshare]
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
-pub struct JsonMetric {
+pub struct JsonMetricTriple {
     pub uuid: MetricUuid,
     pub value: OrderedFloat<f64>,
     pub lower_value: Option<OrderedFloat<f64>>,
     pub upper_value: Option<OrderedFloat<f64>>,
 }
 
-impl fmt::Display for JsonMetric {
+impl fmt::Display for JsonMetricTriple {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.value)
     }
@@ -186,7 +186,7 @@ pub struct JsonOneMetric {
     pub testbed: JsonTestbed,
     pub benchmark: JsonBenchmark,
     pub measure: JsonMeasure,
-    pub metric: JsonMetric,
+    pub metric: JsonMetricTriple,
     pub threshold: Option<JsonThresholdModel>,
     pub boundary: Option<JsonBoundary>,
     pub alert: Option<JsonPerfAlert>,

--- a/lib/bencher_json/src/project/parameter/jsonb.rs
+++ b/lib/bencher_json/src/project/parameter/jsonb.rs
@@ -1,8 +1,8 @@
 //! `SQLite`'s [JSONB][jsonb] binary encoding.
 //!
-//! Two writers reach the `parameter.parameters` column: this encoder, and
+//! Two writers reach the `parameter.set` column: this encoder, and
 //! `SQLite`'s own `jsonb()` in the migration that mints the empty parameter set.
-//! `UNIQUE(benchmark_id, parameters)` compares bytes, so the two have to agree
+//! `UNIQUE(benchmark_id, "set")` compares bytes, so the two have to agree
 //! byte for byte, and `SQLite` is the definition of correct. Where the format
 //! admits more than one encoding of the same value, this matches what `jsonb()`
 //! produces over the RFC 8785 (JCS) canonical text of the same parameter set.

--- a/lib/bencher_json/src/project/parameter/mod.rs
+++ b/lib/bencher_json/src/project/parameter/mod.rs
@@ -24,16 +24,16 @@ pub const MAX_PARAMETER_KEYS: usize = 8;
 /// object keys sorted by UTF-16 code unit, ECMAScript number formatting,
 /// and no insignificant whitespace.
 /// Canonicalization happens here, before the write,
-/// so the database's `UNIQUE(benchmark_id, parameters)` constraint
+/// so the database's `UNIQUE(benchmark_id, "set")` constraint
 /// is the enforcement point for canonical equality.
 ///
 /// [jcs]: https://www.rfc-editor.org/rfc/rfc8785
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "db", derive(diesel::FromSqlRow, diesel::AsExpression))]
 #[cfg_attr(feature = "db", diesel(sql_type = diesel::sql_types::Jsonb))]
-pub struct JsonParameters(BTreeMap<ParameterKey, ParameterScalar>);
+pub struct ParameterSet(BTreeMap<ParameterKey, ParameterScalar>);
 
-impl JsonParameters {
+impl ParameterSet {
     /// The RFC 8785 (JCS) canonical serialization of this parameter set.
     pub fn canonical(&self) -> String {
         let mut canonical = String::from("{");
@@ -68,7 +68,7 @@ impl JsonParameters {
     ///
     /// Byte identical to what `SQLite`'s own `jsonb()` produces over
     /// [`Self::canonical`], which is what lets a set written here collide with a
-    /// set minted in SQL on `UNIQUE(benchmark_id, parameters)`.
+    /// set minted in SQL on `UNIQUE(benchmark_id, "set")`.
     #[cfg(feature = "db")]
     pub fn to_jsonb(&self) -> Result<Vec<u8>, jsonb::JsonbError> {
         let mut object = jsonb::Object::default();
@@ -88,13 +88,13 @@ impl JsonParameters {
     }
 }
 
-impl fmt::Display for JsonParameters {
+impl fmt::Display for ParameterSet {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.canonical())
     }
 }
 
-impl FromStr for JsonParameters {
+impl FromStr for ParameterSet {
     type Err = ParametersError;
 
     fn from_str(parameters: &str) -> Result<Self, Self::Err> {
@@ -102,7 +102,7 @@ impl FromStr for JsonParameters {
     }
 }
 
-impl Serialize for JsonParameters {
+impl Serialize for ParameterSet {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -115,7 +115,7 @@ impl Serialize for JsonParameters {
     }
 }
 
-impl<'de> Deserialize<'de> for JsonParameters {
+impl<'de> Deserialize<'de> for ParameterSet {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -138,9 +138,9 @@ impl<'de> Deserialize<'de> for JsonParameters {
 /// Written out by hand because the serialized form is a map with a custom key
 /// order and a hand written value enum, neither of which derives.
 #[cfg(feature = "schema")]
-impl JsonSchema for JsonParameters {
+impl JsonSchema for ParameterSet {
     fn schema_name() -> String {
-        "JsonParameters".to_owned()
+        "ParameterSet".to_owned()
     }
 
     fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
@@ -380,19 +380,19 @@ fn hex_digit(nibble: u32) -> char {
 mod tests {
     use ordered_float::OrderedFloat;
 
-    use super::{JsonParameters, ParameterKey, ParameterScalar};
+    use super::{ParameterKey, ParameterScalar, ParameterSet};
 
     fn canonical(parameters: &str) -> String {
         parameters
-            .parse::<JsonParameters>()
+            .parse::<ParameterSet>()
             .expect("Failed to parse parameters")
             .canonical()
     }
 
     /// A one key parameter set holding an exact `f64`, built without a parsing
     /// step so a bit pattern reaches the canonicalizer unchanged.
-    fn number(value: f64) -> JsonParameters {
-        JsonParameters(
+    fn number(value: f64) -> ParameterSet {
+        ParameterSet(
             [(
                 ParameterKey("n".parse().expect("Failed to parse parameter key")),
                 ParameterScalar::Number(OrderedFloat(value)),
@@ -405,7 +405,7 @@ mod tests {
     #[test]
     fn canonical_empty_set() {
         assert_eq!(canonical("{}"), "{}");
-        assert_eq!(JsonParameters::default().canonical(), "{}");
+        assert_eq!(ParameterSet::default().canonical(), "{}");
     }
 
     #[test]
@@ -554,7 +554,7 @@ mod tests {
 
     // The canonical form has to survive a write and a read: a parameter set read
     // back out of the database is parsed, and re-canonicalizing it must land on
-    // the same bytes or `UNIQUE(benchmark_id, parameters)` stops holding.
+    // the same bytes or `UNIQUE(benchmark_id, "set")` stops holding.
     #[test]
     fn canonical_survives_a_round_trip() {
         // Deterministic xorshift64, so the sample never varies between runs.
@@ -570,7 +570,7 @@ mod tests {
 
             let once = number(value).canonical();
             let twice = once
-                .parse::<JsonParameters>()
+                .parse::<ParameterSet>()
                 .expect("Failed to parse canonical parameters")
                 .canonical();
             assert_eq!(once, twice, "for {bits:016x}");
@@ -623,7 +623,7 @@ mod tests {
             r#"{"a": {"b": 1}}"#,
         ] {
             assert!(
-                parameters.parse::<JsonParameters>().is_err(),
+                parameters.parse::<ParameterSet>().is_err(),
                 "expected {parameters} to be rejected"
             );
         }
@@ -633,7 +633,7 @@ mod tests {
     fn rejects_non_object_payloads() {
         for parameters in ["null", "[]", "1", r#""a""#, "true"] {
             assert!(
-                parameters.parse::<JsonParameters>().is_err(),
+                parameters.parse::<ParameterSet>().is_err(),
                 "expected {parameters} to be rejected"
             );
         }
@@ -658,10 +658,10 @@ mod tests {
     #[test]
     fn rejects_more_than_the_key_cap() {
         keys(8)
-            .parse::<JsonParameters>()
+            .parse::<ParameterSet>()
             .expect("Failed to parse a parameter set at the cap");
         assert!(
-            keys(9).parse::<JsonParameters>().is_err(),
+            keys(9).parse::<ParameterSet>().is_err(),
             "expected a ninth key to be rejected"
         );
     }
@@ -688,7 +688,7 @@ mod tests {
                 .join(",")
         );
         doubled
-            .parse::<JsonParameters>()
+            .parse::<ParameterSet>()
             .expect("Failed to parse duplicated keys at the cap");
     }
 
@@ -701,11 +701,11 @@ mod tests {
     #[test]
     fn rejects_long_keys() {
         format!(r#"{{"{LEN_64_STR}": 1}}"#)
-            .parse::<JsonParameters>()
+            .parse::<ParameterSet>()
             .expect("Failed to parse a 64 byte key");
         assert!(
             format!(r#"{{"{LEN_65_STR}": 1}}"#)
-                .parse::<JsonParameters>()
+                .parse::<ParameterSet>()
                 .is_err(),
             "expected a 65 byte key to be rejected"
         );
@@ -714,11 +714,11 @@ mod tests {
     #[test]
     fn rejects_long_string_values() {
         format!(r#"{{"a": "{LEN_64_STR}"}}"#)
-            .parse::<JsonParameters>()
+            .parse::<ParameterSet>()
             .expect("Failed to parse a 64 byte string value");
         assert!(
             format!(r#"{{"a": "{LEN_65_STR}"}}"#)
-                .parse::<JsonParameters>()
+                .parse::<ParameterSet>()
                 .is_err(),
             "expected a 65 byte string value to be rejected"
         );
@@ -729,7 +729,7 @@ mod tests {
         for key in ["", " ", "\\r", "\\n", "\\t", " a", "a "] {
             let parameters = format!(r#"{{"{key}": 1}}"#);
             assert!(
-                parameters.parse::<JsonParameters>().is_err(),
+                parameters.parse::<ParameterSet>().is_err(),
                 "expected {parameters} to be rejected"
             );
         }
@@ -740,7 +740,7 @@ mod tests {
         for value in ["", " ", "\\r", "\\n", "\\t", " a", "a "] {
             let parameters = format!(r#"{{"a": "{value}"}}"#);
             assert!(
-                parameters.parse::<JsonParameters>().is_err(),
+                parameters.parse::<ParameterSet>().is_err(),
                 "expected {parameters} to be rejected"
             );
         }
@@ -763,7 +763,7 @@ mod tests {
     #[test]
     fn accepts_scalar_values() {
         let parameters = r#"{"s": "a", "n": 1, "b": true}"#
-            .parse::<JsonParameters>()
+            .parse::<ParameterSet>()
             .expect("Failed to parse parameters");
         assert!(!parameters.is_empty());
     }
@@ -775,9 +775,9 @@ mod tests {
 /// claiming an encoding it does not have.
 #[cfg(feature = "db")]
 mod db {
-    use super::{JsonParameters, jsonb};
+    use super::{ParameterSet, jsonb};
 
-    impl diesel::serialize::ToSql<diesel::sql_types::Jsonb, diesel::sqlite::Sqlite> for JsonParameters {
+    impl diesel::serialize::ToSql<diesel::sql_types::Jsonb, diesel::sqlite::Sqlite> for ParameterSet {
         fn to_sql<'b>(
             &'b self,
             out: &mut diesel::serialize::Output<'b, '_, diesel::sqlite::Sqlite>,
@@ -788,7 +788,7 @@ mod db {
     }
 
     impl diesel::deserialize::FromSql<diesel::sql_types::Jsonb, diesel::sqlite::Sqlite>
-        for JsonParameters
+        for ParameterSet
     {
         fn from_sql(
             mut bytes: diesel::sqlite::SqliteValue<'_, '_, '_>,

--- a/lib/bencher_json/src/project/perf.rs
+++ b/lib/bencher_json/src/project/perf.rs
@@ -18,7 +18,7 @@ use crate::{
 use super::alert::JsonPerfAlert;
 use super::boundary::JsonBoundary;
 use super::head::JsonVersion;
-use super::metric::JsonMetric;
+use super::metric::JsonMetricTriple;
 use super::report::Iteration;
 use super::threshold::JsonThresholdModel;
 
@@ -376,7 +376,7 @@ pub struct JsonPerfMetric {
     pub start_time: DateTime,
     pub end_time: DateTime,
     pub version: JsonVersion,
-    pub metric: JsonMetric,
+    pub metric: JsonMetricTriple,
     // The threshold model is necessary for each metric as it may change over time
     pub threshold: Option<JsonThresholdModel>,
     pub boundary: Option<JsonBoundary>,
@@ -392,7 +392,7 @@ pub mod table {
     use tabled::{Table, Tabled};
 
     use crate::{
-        DateTime, JsonBenchmark, JsonBranch, JsonMeasure, JsonMetric, JsonPerf, JsonProject,
+        DateTime, JsonBenchmark, JsonBranch, JsonMeasure, JsonMetricTriple, JsonPerf, JsonProject,
         JsonTestbed,
         project::{head::VersionNumber, report::Iteration},
     };
@@ -461,7 +461,7 @@ pub mod table {
         #[tabled(rename = "Version Hash")]
         pub version_hash: DisplayOption<GitHash>,
         #[tabled(rename = "Metric Value")]
-        pub metric: JsonMetric,
+        pub metric: JsonMetricTriple,
         #[tabled(rename = "Boundary Baseline")]
         pub baseline: DisplayOption<OrderedFloat<f64>>,
         #[tabled(rename = "Lower Boundary Limit")]

--- a/lib/bencher_json/src/project/report.rs
+++ b/lib/bencher_json/src/project/report.rs
@@ -9,9 +9,9 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "plus")]
 use crate::runner::job::JobUuid;
 use crate::{
-    BranchNameId, JsonAlert, JsonBenchmark, JsonBoundary, JsonBranch, JsonMeasure, JsonMetric,
-    JsonParameters, JsonProject, JsonPubUser, JsonTestbed, MeasureNameId, MetricUuid,
-    ParameterUuid, TestbedNameId,
+    BranchNameId, JsonAlert, JsonBenchmark, JsonBoundary, JsonBranch, JsonMeasure,
+    JsonMetricTriple, JsonProject, JsonPubUser, JsonTestbed, MeasureNameId, MetricUuid,
+    ParameterSet, ParameterUuid, TestbedNameId,
     urlencoded::{UrlEncodedError, from_urlencoded, to_urlencoded},
 };
 
@@ -441,7 +441,7 @@ pub struct JsonReportResult {
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct JsonReportParameter {
     pub uuid: ParameterUuid,
-    pub parameters: JsonParameters,
+    pub set: ParameterSet,
 }
 
 #[typeshare::typeshare]
@@ -459,7 +459,7 @@ pub struct JsonReportMeasure {
     /// Absent when the measure carries no `value` name, which BMF v1 permits. Never
     /// absent for anything an older client could produce.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub metric: Option<JsonMetric>,
+    pub metric: Option<JsonMetricTriple>,
     /// Deprecated. The threshold that gated the `value` row, if any.
     pub threshold: Option<JsonThresholdModel>,
     /// Deprecated. The boundary computed for the `value` row, if any.

--- a/lib/bencher_schema/migrations/2026-08-23-120000_parameter_set/down.sql
+++ b/lib/bencher_schema/migrations/2026-08-23-120000_parameter_set/down.sql
@@ -1,0 +1,4 @@
+-- parameter
+-- The reverse of the rename, and just as much a metadata only operation.
+ALTER TABLE parameter
+    RENAME COLUMN "set" TO parameters;

--- a/lib/bencher_schema/migrations/2026-08-23-120000_parameter_set/up.sql
+++ b/lib/bencher_schema/migrations/2026-08-23-120000_parameter_set/up.sql
@@ -1,0 +1,11 @@
+-- parameter
+-- The column holds the parameter set itself, so it is named for what it is:
+-- `parameter.set`, not `parameter.parameters`.
+--
+-- `set` is an SQL keyword, so every reference to it is quoted.
+--
+-- This is a metadata only rename. SQLite rewrites the stored DDL in place,
+-- including `UNIQUE(benchmark_id, "set")` and the index that backs it,
+-- so no row is read and no table is recreated.
+ALTER TABLE parameter
+    RENAME COLUMN parameters TO "set";

--- a/lib/bencher_schema/src/model/project/metric_boundary.rs
+++ b/lib/bencher_schema/src/model/project/metric_boundary.rs
@@ -1,4 +1,4 @@
-use bencher_json::{BoundaryUuid, JsonMetric, MetricUuid};
+use bencher_json::{BoundaryUuid, JsonMetricTriple, MetricUuid};
 
 use crate::{model::project::metric::MetricId, view::metric_boundary as metric_boundary_table};
 
@@ -42,7 +42,7 @@ impl QueryMetricBoundary {
     /// The view pivots the named rows back into the metric triple, so the JSON it
     /// yields is the same JSON the row-per-measure table yielded, and the boundary
     /// beside it is the one the view already carries.
-    pub fn split(self) -> (JsonMetric, Option<QueryBoundary>) {
+    pub fn split(self) -> (JsonMetricTriple, Option<QueryBoundary>) {
         let Self {
             metric_id,
             metric_uuid,
@@ -59,7 +59,7 @@ impl QueryMetricBoundary {
             lower_limit,
             upper_limit,
         } = self;
-        let json_metric = JsonMetric {
+        let json_metric = JsonMetricTriple {
             uuid: metric_uuid,
             value: value.into(),
             lower_value: lower_value.map(Into::into),

--- a/lib/bencher_schema/src/model/project/parameter.rs
+++ b/lib/bencher_schema/src/model/project/parameter.rs
@@ -1,4 +1,4 @@
-use bencher_json::{DateTime, JsonParameters, ParameterUuid, project::report::JsonReportParameter};
+use bencher_json::{DateTime, ParameterSet, ParameterUuid, project::report::JsonReportParameter};
 use diesel::{
     ExpressionMethods as _, OptionalExtension as _, QueryDsl as _, RunQueryDsl as _,
     SelectableHelper as _,
@@ -37,7 +37,7 @@ pub struct QueryParameter {
     pub id: ParameterId,
     pub uuid: ParameterUuid,
     pub benchmark_id: BenchmarkId,
-    pub parameters: JsonParameters,
+    pub set: ParameterSet,
     pub created: DateTime,
     pub modified: DateTime,
     pub archived: Option<DateTime>,
@@ -65,7 +65,7 @@ impl QueryParameter {
     ) -> Result<ParameterId, HttpError> {
         schema::parameter::table
             .filter(schema::parameter::benchmark_id.eq(benchmark_id))
-            .filter(schema::parameter::parameters.eq(JsonParameters::default()))
+            .filter(schema::parameter::set.eq(ParameterSet::default()))
             .select(schema::parameter::id)
             .first(conn)
             .map_err(|e| {
@@ -81,7 +81,7 @@ impl QueryParameter {
     /// The empty parameter set is never created here: every benchmark is born with
     /// one, so its absence is data corruption rather than a row to mint. Every
     /// other set is created on first sight by its canonical form, and
-    /// `UNIQUE (benchmark_id, parameters)` is what makes that idempotent under
+    /// `UNIQUE (benchmark_id, "set")` is what makes that idempotent under
     /// concurrent reports.
     ///
     /// Mirrors [`QueryBenchmark::get_or_create`]: a resolved set that is archived is
@@ -93,7 +93,7 @@ impl QueryParameter {
         context: &ApiContext,
         project_id: ProjectId,
         benchmark_id: BenchmarkId,
-        parameters: &JsonParameters,
+        parameters: &ParameterSet,
     ) -> Result<ParameterId, HttpError> {
         let query_parameter =
             Self::get_or_create_inner(context, project_id, benchmark_id, parameters).await?;
@@ -115,7 +115,7 @@ impl QueryParameter {
         context: &ApiContext,
         project_id: ProjectId,
         benchmark_id: BenchmarkId,
-        parameters: &JsonParameters,
+        parameters: &ParameterSet,
     ) -> Result<Self, HttpError> {
         if let Some(query_parameter) =
             Self::from_parameters(auth_conn!(context), benchmark_id, parameters)?
@@ -147,7 +147,7 @@ impl QueryParameter {
         context: &ApiContext,
         project_id: ProjectId,
         benchmark_id: BenchmarkId,
-        parameters: &JsonParameters,
+        parameters: &ParameterSet,
     ) -> Result<Self, HttpError> {
         #[cfg(feature = "plus")]
         InsertParameter::rate_limit(context, project_id).await?;
@@ -170,11 +170,11 @@ impl QueryParameter {
     fn from_parameters(
         conn: &mut DbConnection,
         benchmark_id: BenchmarkId,
-        parameters: &JsonParameters,
+        parameters: &ParameterSet,
     ) -> Result<Option<Self>, HttpError> {
         schema::parameter::table
             .filter(schema::parameter::benchmark_id.eq(benchmark_id))
-            .filter(schema::parameter::parameters.eq(parameters))
+            .filter(schema::parameter::set.eq(parameters))
             .select(Self::as_select())
             .first(conn)
             .optional()
@@ -192,12 +192,12 @@ impl QueryParameter {
             id: _,
             uuid,
             benchmark_id: _,
-            parameters,
+            set,
             created: _,
             modified: _,
             archived: _,
         } = self;
-        JsonReportParameter { uuid, parameters }
+        JsonReportParameter { uuid, set }
     }
 }
 
@@ -206,7 +206,7 @@ impl QueryParameter {
 pub struct InsertParameter {
     pub uuid: ParameterUuid,
     pub benchmark_id: BenchmarkId,
-    pub parameters: JsonParameters,
+    pub set: ParameterSet,
     pub created: DateTime,
     pub modified: DateTime,
     pub archived: Option<DateTime>,
@@ -277,15 +277,15 @@ impl InsertParameter {
     /// The timestamp is the benchmark's own creation timestamp:
     /// the parameter set is created in the same transaction as its benchmark.
     pub fn empty_set(benchmark_id: BenchmarkId, timestamp: DateTime) -> Self {
-        Self::new(benchmark_id, JsonParameters::default(), timestamp)
+        Self::new(benchmark_id, ParameterSet::default(), timestamp)
     }
 
     /// A parameter set as a report first named it, already canonical.
-    pub fn new(benchmark_id: BenchmarkId, parameters: JsonParameters, timestamp: DateTime) -> Self {
+    pub fn new(benchmark_id: BenchmarkId, set: ParameterSet, timestamp: DateTime) -> Self {
         Self {
             uuid: ParameterUuid::new(),
             benchmark_id,
-            parameters,
+            set,
             created: timestamp,
             modified: timestamp,
             archived: None,
@@ -296,7 +296,7 @@ impl InsertParameter {
         let Self {
             uuid,
             benchmark_id,
-            parameters,
+            set,
             created,
             modified,
             archived,
@@ -305,7 +305,7 @@ impl InsertParameter {
             id,
             uuid,
             benchmark_id,
-            parameters,
+            set,
             created,
             modified,
             archived,
@@ -316,7 +316,7 @@ impl InsertParameter {
 #[derive(Debug, Clone, diesel::AsChangeset)]
 #[diesel(table_name = parameter_table)]
 pub struct UpdateParameter {
-    pub parameters: Option<JsonParameters>,
+    pub set: Option<ParameterSet>,
     pub modified: DateTime,
     pub archived: Option<Option<DateTime>>,
 }
@@ -325,7 +325,7 @@ impl UpdateParameter {
     /// A grid point that reports again is a live grid point.
     fn unarchive() -> Self {
         Self {
-            parameters: None,
+            set: None,
             modified: DateTime::now(),
             archived: Some(None),
         }
@@ -334,7 +334,7 @@ impl UpdateParameter {
 
 #[cfg(test)]
 mod tests {
-    use bencher_json::{DateTime, JsonParameters, ParameterUuid};
+    use bencher_json::{DateTime, ParameterSet, ParameterUuid};
     use diesel::{
         ExpressionMethods as _, QueryDsl as _, QueryResult, RunQueryDsl as _, SqliteConnection,
         connection::SimpleConnection as _,
@@ -356,7 +356,7 @@ mod tests {
     /// Where the blob under test comes from.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum Encode {
-        /// Written through the `parameter.parameters` column: the production path.
+        /// Written through the `parameter.set` column: the production path.
         Column,
         /// Encoded directly. Parameter values are scalar only, so a null value
         /// never reaches the column, but the encoder still has to agree with `SQLite`.
@@ -420,7 +420,7 @@ mod tests {
         value: i32,
     }
 
-    fn parameters(parameters: &str) -> JsonParameters {
+    fn parameters(parameters: &str) -> ParameterSet {
         parameters.parse().expect("Failed to parse parameters")
     }
 
@@ -492,8 +492,8 @@ mod tests {
         canonical: &str,
     ) -> QueryResult<usize> {
         diesel::sql_query(
-            "INSERT INTO parameter(uuid, benchmark_id, parameters, created, modified)
-             VALUES (?, ?, jsonb(?), 0, 0)",
+            r#"INSERT INTO parameter(uuid, benchmark_id, "set", created, modified)
+               VALUES (?, ?, jsonb(?), 0, 0)"#,
         )
         .bind::<diesel::sql_types::Text, _>(ParameterUuid::new().to_string())
         .bind::<diesel::sql_types::Integer, _>(benchmark_id)
@@ -524,7 +524,7 @@ mod tests {
     fn write_parameter(
         conn: &mut SqliteConnection,
         benchmark_id: BenchmarkId,
-        parameters: &JsonParameters,
+        parameters: &ParameterSet,
     ) -> super::ParameterId {
         if parameters.is_empty() {
             get_empty_parameter(conn, benchmark_id)
@@ -534,7 +534,7 @@ mod tests {
     }
 
     // The encoder has to be byte identical to SQLite's `jsonb()` over the same
-    // canonical text, because `UNIQUE(benchmark_id, parameters)` compares bytes and
+    // canonical text, because `UNIQUE(benchmark_id, "set")` compares bytes and
     // both writers reach that column: the migration mints the empty set with
     // `jsonb('{}')` and everything after that is written through Diesel.
     #[test]
@@ -562,17 +562,17 @@ mod tests {
 
                     let parameter_id = write_parameter(&mut conn, benchmark_id, &parameters);
                     assert_eq!(
-                        parameter_text(&mut conn, parameter_id, "hex(parameters)"),
+                        parameter_text(&mut conn, parameter_id, "hex(\"set\")"),
                         minted,
                         "{name}: the written bytes must be the bytes jsonb() mints"
                     );
                     assert_eq!(
-                        parameter_integer(&mut conn, parameter_id, "json_valid(parameters, 8)"),
+                        parameter_integer(&mut conn, parameter_id, "json_valid(\"set\", 8)"),
                         1,
                         "{name}: SQLite's JSON functions must accept the written bytes"
                     );
                     assert_eq!(
-                        parameter_text(&mut conn, parameter_id, "json(parameters)"),
+                        parameter_text(&mut conn, parameter_id, "json(\"set\")"),
                         *canonical,
                         "{name}: the canonical text must survive the column unchanged"
                     );
@@ -643,9 +643,9 @@ mod tests {
             let parameters = parameters(canonical);
 
             let parameter_id = write_parameter(&mut conn, written, &parameters);
-            let read: JsonParameters = schema::parameter::table
+            let read: ParameterSet = schema::parameter::table
                 .filter(schema::parameter::id.eq(parameter_id))
-                .select(schema::parameter::parameters)
+                .select(schema::parameter::set)
                 .first(&mut conn)
                 .expect("Failed to read back a written parameter set");
             assert_eq!(read, parameters, "{name}: written and read back");
@@ -656,10 +656,10 @@ mod tests {
             );
 
             mint_parameter(&mut conn, minted, canonical).expect("Failed to mint a parameter set");
-            let read: JsonParameters = schema::parameter::table
+            let read: ParameterSet = schema::parameter::table
                 .filter(schema::parameter::benchmark_id.eq(minted))
                 .order(schema::parameter::id.desc())
-                .select(schema::parameter::parameters)
+                .select(schema::parameter::set)
                 .first(&mut conn)
                 .expect("Failed to read back a minted parameter set");
             assert_eq!(read, parameters, "{name}: minted and read back");
@@ -697,7 +697,7 @@ mod tests {
 
             assert!(
                 is_unique_violation(&minted) || is_unique_violation(&written),
-                "{name}: the two writers must collide on UNIQUE(benchmark_id, parameters)"
+                r#"{name}: the two writers must collide on UNIQUE(benchmark_id, "set")"#
             );
             assert!(
                 landed_or_collided(&minted),
@@ -720,13 +720,13 @@ mod tests {
     fn insert_parameter(
         conn: &mut SqliteConnection,
         benchmark_id: BenchmarkId,
-        parameters: &JsonParameters,
+        parameters: &ParameterSet,
     ) -> QueryResult<usize> {
         diesel::insert_into(schema::parameter::table)
             .values((
                 schema::parameter::uuid.eq(ParameterUuid::new()),
                 schema::parameter::benchmark_id.eq(benchmark_id),
-                schema::parameter::parameters.eq(parameters),
+                schema::parameter::set.eq(parameters),
                 schema::parameter::created.eq(DateTime::TEST),
                 schema::parameter::modified.eq(DateTime::TEST),
             ))
@@ -760,7 +760,7 @@ mod tests {
 
         assert!(
             collision.is_err(),
-            "logically equal parameter sets must collide on UNIQUE(benchmark_id, parameters)"
+            r#"logically equal parameter sets must collide on UNIQUE(benchmark_id, "set")"#
         );
         // The empty set the benchmark was born with, plus the one that landed.
         assert_eq!(count_parameters(&mut conn, benchmark_id), 2);
@@ -895,21 +895,21 @@ mod tests {
         assert_eq!(benchmark_ids.len(), 2);
 
         for benchmark_id in benchmark_ids {
-            let backfilled: Vec<JsonParameters> = schema::parameter::table
+            let backfilled: Vec<ParameterSet> = schema::parameter::table
                 .filter(schema::parameter::benchmark_id.eq(benchmark_id))
-                .select(schema::parameter::parameters)
+                .select(schema::parameter::set)
                 .load(&mut conn)
                 .expect("Failed to load parameters");
             assert_eq!(
                 backfilled,
-                vec![JsonParameters::default()],
+                vec![ParameterSet::default()],
                 "every benchmark gets exactly one empty parameter set"
             );
 
             // The migration mints the canonical empty object in SQL, so a set minted
             // in Rust has to be byte identical to it.
             assert!(
-                insert_parameter(&mut conn, benchmark_id, &JsonParameters::default()).is_err(),
+                insert_parameter(&mut conn, benchmark_id, &ParameterSet::default()).is_err(),
                 "the backfilled empty set must collide with a Rust minted one"
             );
         }

--- a/lib/bencher_schema/src/model/project/report/mod.rs
+++ b/lib/bencher_schema/src/model/project/report/mod.rs
@@ -3,7 +3,7 @@ use bencher_json::runner::job::{JobUuid, JsonNewRunJob};
 use std::collections::HashSet;
 
 use bencher_json::{
-    DateTime, JsonBenchmark, JsonMeasure, JsonMetric, JsonNewReport, JsonReport,
+    DateTime, JsonBenchmark, JsonMeasure, JsonMetricTriple, JsonNewReport, JsonReport,
     JsonReportAlertsCounts, JsonReportCounts, JsonReportIterationCounts, MetricName, ReportUuid,
     project::{
         alert::AlertStatus,
@@ -909,7 +909,7 @@ impl PendingMeasure {
                 .find(|report_metric| report_metric.name == *name)
         };
         let value = named(&MetricName::value());
-        let metric = value.map(|value| JsonMetric {
+        let metric = value.map(|value| JsonMetricTriple {
             uuid: value.uuid,
             value: value.value,
             lower_value: named(&MetricName::lower_value()).map(|metric| metric.value),

--- a/lib/bencher_schema/src/model/project/report/report_benchmark.rs
+++ b/lib/bencher_schema/src/model/project/report/report_benchmark.rs
@@ -57,7 +57,7 @@ impl InsertReportBenchmark {
 
 #[cfg(test)]
 mod tests {
-    use bencher_json::{DateTime, JsonParameters, ParameterUuid, ReportBenchmarkUuid};
+    use bencher_json::{DateTime, ParameterSet, ParameterUuid, ReportBenchmarkUuid};
     use diesel::{
         ExpressionMethods as _, QueryDsl as _, QueryResult, RunQueryDsl as _, SqliteConnection,
     };
@@ -120,13 +120,13 @@ mod tests {
         );
         let empty_set_id = get_empty_parameter(conn, benchmark_id);
 
-        let grid_point: JsonParameters =
+        let grid_point: ParameterSet =
             r#"{"size_mb": 16}"#.parse().expect("Failed to parse parameters");
         diesel::insert_into(schema::parameter::table)
             .values((
                 schema::parameter::uuid.eq(ParameterUuid::new()),
                 schema::parameter::benchmark_id.eq(benchmark_id),
-                schema::parameter::parameters.eq(&grid_point),
+                schema::parameter::set.eq(&grid_point),
                 schema::parameter::created.eq(DateTime::TEST),
                 schema::parameter::modified.eq(DateTime::TEST),
             ))

--- a/lib/bencher_schema/src/model/project/report/results/mod.rs
+++ b/lib/bencher_schema/src/model/project/report/results/mod.rs
@@ -8,7 +8,7 @@ use bencher_adapter::{
     },
 };
 use bencher_json::{
-    BenchmarkName, BenchmarkNameId, JsonParameters, MeasureNameId, MetricName, Slug,
+    BenchmarkName, BenchmarkNameId, MeasureNameId, MetricName, ParameterSet, Slug,
     project::report::{Adapter, Iteration, JsonReportSettings},
 };
 use diesel::RunQueryDsl as _;
@@ -62,7 +62,7 @@ pub struct ReportResults {
     #[cfg(feature = "plus")]
     pub series_cache: SeriesCacheContext,
     pub benchmark_cache: HashMap<BenchmarkNameId, BenchmarkId>,
-    pub parameter_cache: HashMap<(BenchmarkId, JsonParameters), ParameterId>,
+    pub parameter_cache: HashMap<(BenchmarkId, ParameterSet), ParameterId>,
     pub measure_cache: HashMap<MeasureNameId, MeasureId>,
     pub detector_cache: HashMap<MeasureId, Option<Detector>>,
 }
@@ -332,7 +332,7 @@ impl ReportResults {
         iteration: Iteration,
         benchmark_id: BenchmarkId,
         ignore_benchmark: bool,
-        parameters: JsonParameters,
+        parameters: ParameterSet,
         metrics: AdapterMetrics,
     ) -> Result<PreparedGridPoint, HttpError> {
         // Resolved here in Phase 1, alongside the benchmark and the measures, so the
@@ -399,7 +399,7 @@ impl ReportResults {
         &mut self,
         context: &ApiContext,
         benchmark_id: BenchmarkId,
-        parameters: JsonParameters,
+        parameters: ParameterSet,
     ) -> Result<ParameterId, HttpError> {
         let key = (benchmark_id, parameters);
         Ok(if let Some(id) = self.parameter_cache.get(&key) {

--- a/lib/bencher_schema/src/model/project/series.rs
+++ b/lib/bencher_schema/src/model/project/series.rs
@@ -692,12 +692,12 @@ mod tests {
 
         // Every cache row names a parameter set, and it is the benchmark's empty one.
         let mismatched = sql_query(
-            "SELECT COUNT(*) AS count
-             FROM series_last_seen s
-             LEFT JOIN parameter p ON p.id = s.parameter_id
-             WHERE p.id IS NULL
-                OR p.benchmark_id != s.benchmark_id
-                OR p.parameters != jsonb('{}')",
+            r#"SELECT COUNT(*) AS count
+               FROM series_last_seen s
+               LEFT JOIN parameter p ON p.id = s.parameter_id
+               WHERE p.id IS NULL
+                  OR p.benchmark_id != s.benchmark_id
+                  OR p."set" != jsonb('{}')"#,
         )
         .get_result::<SqlCount>(&mut conn)
         .expect("Failed to check the backfilled parameter sets")

--- a/lib/bencher_schema/src/schema.rs
+++ b/lib/bencher_schema/src/schema.rs
@@ -177,7 +177,7 @@ diesel::table! {
         id -> Integer,
         uuid -> Text,
         benchmark_id -> Integer,
-        parameters -> Jsonb,
+        set -> Jsonb,
         created -> BigInt,
         modified -> BigInt,
         archived -> Nullable<BigInt>,

--- a/lib/bencher_schema/src/test_util.rs
+++ b/lib/bencher_schema/src/test_util.rs
@@ -10,7 +10,7 @@
 //! so no concurrent INSERT can interleave between the INSERT and the `last_insert_rowid()` call.
 
 use bencher_json::{
-    DateTime, JsonParameters, MetricName, ParameterUuid,
+    DateTime, MetricName, ParameterSet, ParameterUuid,
     project::{
         alert::AlertStatus,
         boundary::BoundaryLimit,
@@ -529,7 +529,7 @@ pub fn create_benchmark(
         .get_result(conn)
         .expect("Failed to get benchmark id");
 
-    create_parameter(conn, benchmark_id, &JsonParameters::default());
+    create_parameter(conn, benchmark_id, &ParameterSet::default());
 
     benchmark_id
 }
@@ -538,13 +538,13 @@ pub fn create_benchmark(
 pub fn create_parameter(
     conn: &mut SqliteConnection,
     benchmark_id: BenchmarkId,
-    parameters: &JsonParameters,
+    parameters: &ParameterSet,
 ) -> ParameterId {
     diesel::insert_into(schema::parameter::table)
         .values((
             schema::parameter::uuid.eq(ParameterUuid::new()),
             schema::parameter::benchmark_id.eq(benchmark_id),
-            schema::parameter::parameters.eq(parameters),
+            schema::parameter::set.eq(parameters),
             schema::parameter::created.eq(DateTime::TEST),
             schema::parameter::modified.eq(DateTime::TEST),
         ))
@@ -560,7 +560,7 @@ pub fn create_parameter(
 pub fn get_empty_parameter(conn: &mut SqliteConnection, benchmark_id: BenchmarkId) -> ParameterId {
     schema::parameter::table
         .filter(schema::parameter::benchmark_id.eq(benchmark_id))
-        .filter(schema::parameter::parameters.eq(JsonParameters::default()))
+        .filter(schema::parameter::set.eq(ParameterSet::default()))
         .select(schema::parameter::id)
         .first(conn)
         .expect("Failed to get empty parameter set")

--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -12126,7 +12126,7 @@
             "$ref": "#/components/schemas/BoundaryLimit"
           },
           "metric": {
-            "$ref": "#/components/schemas/JsonMetric"
+            "$ref": "#/components/schemas/JsonMetricTriple"
           },
           "modified": {
             "$ref": "#/components/schemas/DateTime"
@@ -13334,7 +13334,7 @@
           "$ref": "#/components/schemas/JsonMember"
         }
       },
-      "JsonMetric": {
+      "JsonMetricTriple": {
         "type": "object",
         "properties": {
           "lower_value": {
@@ -14604,7 +14604,7 @@
             "$ref": "#/components/schemas/JsonMeasure"
           },
           "metric": {
-            "$ref": "#/components/schemas/JsonMetric"
+            "$ref": "#/components/schemas/JsonMetricTriple"
           },
           "report": {
             "$ref": "#/components/schemas/ReportUuid"
@@ -14791,23 +14791,6 @@
           "protocol"
         ]
       },
-      "JsonParameters": {
-        "type": "object",
-        "additionalProperties": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "number",
-              "format": "double"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        }
-      },
       "JsonPerf": {
         "type": "object",
         "properties": {
@@ -14891,7 +14874,7 @@
             "$ref": "#/components/schemas/Iteration"
           },
           "metric": {
-            "$ref": "#/components/schemas/JsonMetric"
+            "$ref": "#/components/schemas/JsonMetricTriple"
           },
           "report": {
             "$ref": "#/components/schemas/ReportUuid"
@@ -16220,7 +16203,7 @@
             "description": "Deprecated. Reconstructed from the `value` row and its `lower_value`/`upper_value` siblings. Retained for compatibility with older clients and removed in a future release.\n\nAbsent when the measure carries no `value` name, which BMF v1 permits. Never absent for anything an older client could produce.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/JsonMetric"
+                "$ref": "#/components/schemas/JsonMetricTriple"
               }
             ]
           },
@@ -16279,15 +16262,15 @@
         "description": "The parameter set a report result ran with.",
         "type": "object",
         "properties": {
-          "parameters": {
-            "$ref": "#/components/schemas/JsonParameters"
+          "set": {
+            "$ref": "#/components/schemas/ParameterSet"
           },
           "uuid": {
             "$ref": "#/components/schemas/ParameterUuid"
           }
         },
         "required": [
-          "parameters",
+          "set",
           "uuid"
         ]
       },
@@ -18583,6 +18566,23 @@
             ]
           }
         ]
+      },
+      "ParameterSet": {
+        "type": "object",
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number",
+              "format": "double"
+            },
+            {
+              "type": "boolean"
+            }
+          ]
+        }
       },
       "ParameterUuid": {
         "type": "string",

--- a/services/console/src/types/bencher.ts
+++ b/services/console/src/types/bencher.ts
@@ -215,7 +215,7 @@ export interface JsonBenchmark {
 	archived?: string;
 }
 
-export interface JsonMetric {
+export interface JsonMetricTriple {
 	uuid: Uuid;
 	value: number;
 	lower_value?: number;
@@ -338,7 +338,7 @@ export interface JsonAlert {
 	report: Uuid;
 	iteration: Iteration;
 	benchmark: JsonBenchmark;
-	metric: JsonMetric;
+	metric: JsonMetricTriple;
 	threshold: JsonThreshold;
 	boundary: JsonBoundary;
 	limit: BoundaryLimit;
@@ -352,7 +352,7 @@ export type JsonReportAlerts = JsonAlert[];
 /** The parameter set a report result ran with. */
 export interface JsonReportParameter {
 	uuid: Uuid;
-	parameters: Record<string, string | number | boolean>;
+	set: Record<string, string | number | boolean>;
 }
 
 export interface JsonThresholdModel {
@@ -392,7 +392,7 @@ export interface JsonReportMeasure {
 	 * Absent when the measure carries no `value` name, which BMF v1 permits. Never
 	 * absent for anything an older client could produce.
 	 */
-	metric?: JsonMetric;
+	metric?: JsonMetricTriple;
 	/** Deprecated. The threshold that gated the `value` row, if any. */
 	threshold?: JsonThresholdModel;
 	/** Deprecated. The boundary computed for the `value` row, if any. */
@@ -898,7 +898,7 @@ export interface JsonOneMetric {
 	testbed: JsonTestbed;
 	benchmark: JsonBenchmark;
 	measure: JsonMeasure;
-	metric: JsonMetric;
+	metric: JsonMetricTriple;
 	threshold?: JsonThresholdModel;
 	boundary?: JsonBoundary;
 	alert?: JsonPerfAlert;
@@ -939,7 +939,7 @@ export interface JsonPerfMetric {
 	start_time: string;
 	end_time: string;
 	version: JsonVersion;
-	metric: JsonMetric;
+	metric: JsonMetricTriple;
 	threshold?: JsonThresholdModel;
 	boundary?: JsonBoundary;
 	alert?: JsonPerfAlert;

--- a/services/console/typeshare.toml
+++ b/services/console/typeshare.toml
@@ -42,7 +42,7 @@
 "Utf8PathBuf" = "string"
 "OrderedFloat" = "number"
 "MetricName" = "string"
-"JsonParameters" = "Record<string, string | number | boolean>"
+"ParameterSet" = "Record<string, string | number | boolean>"
 "BigInt" = "number"
 "TimestampMillis" = "number"
 "Cpu" = "number"


### PR DESCRIPTION
## The renames

Three renames and the migration one of them needs. No behavior change.

### `JsonMetric` -> `JsonMetricTriple`

A `JsonMetric` is a value with its two bounds, the triple a metric row used to be before named values existed. The plain name read like the whole of what a metric is, which it is not any more.

This is a type rename only. Every serde field that carries one keeps its own name (`JsonAlert.metric`, `JsonPerfMetric.metric`, and the rest), so not one response byte changes. The OpenAPI component and the TypeScript type follow.

### `JsonReportParameter.parameters` -> `set`

The object is already named `parameter` where a report result carries it, so the field spelled its parent again. It now spells what it holds:

```json
"parameter": { "uuid": "...", "set": { "size_mb": 16 } }
```

This one does change report response bytes. It is free right now, because no released CLI deserializes the report `parameter` object, so nothing in the wild reads the old spelling. Once the next release ships a client that does, the same rename becomes a break. The type name `JsonReportParameter` is unchanged.

The BMF v1 **input** format is untouched. A report still submits `"parameters"` on each entry, and every adapter fixture stays as it was.

### `JsonParameters` -> `ParameterSet`

The type has been called a parameter set in its own prose since it was written. It is an internal newtype with a hand written `JsonSchema` impl, so the component name is renamed there as well, and the typeshare mapping follows.

## The migration

`2026-08-23-120000_parameter_set` renames the `parameter.parameters` column to `parameter.set`, and the model fields follow it (`QueryParameter.set`, `InsertParameter.set`, `UpdateParameter.set`).

`set` is an SQL keyword, so the migration and the raw SQL that reads the column quote it. Diesel quotes identifiers of its own accord, so the DSL needs nothing.

The migration is metadata only:

```sql
ALTER TABLE parameter RENAME COLUMN parameters TO "set";
```

SQLite rewrites the stored DDL in place, `UNIQUE(benchmark_id, "set")` and the index that backs it included, without reading a row. `down.sql` is the reverse, and just as cheap.

Migrations already written keep the spelling that was true when they ran. The migrations that create and read `parameter.parameters` are history and are left alone. The one seed in the migration tests that hand writes a `parameter` row below this layer now does so in raw SQL under the old column name, which is what the schema at that point in the chain has. The chain renames it on the way back up.

## Gates

- `cargo fmt -- --check`
- `cargo clippy --no-deps --all-targets --all-features -- -Dwarnings`
- `cargo nextest run --all-features --profile ci`, `cargo test --doc --all-features`
- `cargo check --no-default-features`
- `cargo gen-types`, with the regenerated spec and TypeScript types committed
