### PR TITLE
Add the parameter resource endpoints

### DIFF
--- a/lib/api_projects/src/lib.rs
+++ b/lib/api_projects/src/lib.rs
@@ -18,6 +18,7 @@ pub mod jobs;
 mod keys;
 pub mod measures;
 pub mod metrics;
+pub mod parameters;
 pub mod perf;
 pub mod plots;
 pub mod projects;
@@ -142,6 +143,17 @@ impl bencher_endpoint::Registrar for Api {
         api_description.register(benchmarks::proj_benchmark_get)?;
         api_description.register(benchmarks::proj_benchmark_patch)?;
         api_description.register(benchmarks::proj_benchmark_delete)?;
+
+        // Parameters
+        if http_options {
+            api_description.register(parameters::proj_parameters_options)?;
+            api_description.register(parameters::proj_parameter_options)?;
+        }
+        api_description.register(parameters::proj_parameters_get)?;
+        api_description.register(parameters::proj_parameter_post)?;
+        api_description.register(parameters::proj_parameter_get)?;
+        api_description.register(parameters::proj_parameter_patch)?;
+        api_description.register(parameters::proj_parameter_delete)?;
 
         // Measures
         if http_options {

--- a/lib/api_projects/src/parameters.rs
+++ b/lib/api_projects/src/parameters.rs
@@ -1,0 +1,473 @@
+use bencher_endpoint::{
+    CorsResponse, Delete, Endpoint, Get, Patch, Post, ResponseCreated, ResponseDeleted, ResponseOk,
+    TotalCount,
+};
+use bencher_json::{
+    BenchmarkResourceId, JsonDirection, JsonPagination, JsonParameter, JsonParameters,
+    ParameterUuid, ProjectResourceId,
+    project::parameter::{JsonNewParameter, JsonUpdateParameter},
+};
+use bencher_rbac::project::Permission;
+use bencher_schema::{
+    actor_conn, auth_conn,
+    context::ApiContext,
+    error::{
+        conflict_error, resource_conflict_err, resource_not_found_err, with_auth_hint,
+        with_token_hint,
+    },
+    model::{
+        project::{
+            QueryProject,
+            benchmark::QueryBenchmark,
+            parameter::{QueryParameter, UpdateParameter},
+        },
+        user::{
+            actor::{ApiActor, PubProjectBearerToken},
+            auth::{AuthUser, BearerToken},
+        },
+    },
+    schema, write_conn,
+};
+use diesel::{BelongingToDsl as _, ExpressionMethods as _, QueryDsl as _, RunQueryDsl as _};
+use dropshot::{HttpError, Path, Query, RequestContext, TypedBody, endpoint};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[derive(Deserialize, JsonSchema)]
+pub struct ProjParametersParams {
+    /// The slug or UUID for a project.
+    pub project: ProjectResourceId,
+    /// The slug or UUID for a benchmark.
+    pub benchmark: BenchmarkResourceId,
+}
+
+pub type ProjParametersPagination = JsonPagination<ProjParametersSort>;
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjParametersSort {
+    /// Sort by parameter set creation date time.
+    #[default]
+    Created,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ProjParametersQuery {
+    /// If set to `true`, only returns archived parameter sets.
+    /// If not set or set to `false`, only returns non-archived parameter sets.
+    pub archived: Option<bool>,
+}
+
+#[endpoint {
+    method = OPTIONS,
+    path =  "/v0/projects/{project}/benchmarks/{benchmark}/parameters",
+    tags = ["projects", "parameters"]
+}]
+pub async fn proj_parameters_options(
+    _rqctx: RequestContext<ApiContext>,
+    _path_params: Path<ProjParametersParams>,
+    _pagination_params: Query<ProjParametersPagination>,
+    _query_params: Query<ProjParametersQuery>,
+) -> Result<CorsResponse, HttpError> {
+    Ok(Endpoint::cors(&[Get.into(), Post.into()]))
+}
+
+/// List parameter sets for a benchmark
+///
+/// List all parameter sets for a benchmark.
+/// If the project is public, then the user does not need to be authenticated.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
+/// By default, the parameter sets are sorted by creation date time.
+/// The HTTP response header `X-Total-Count` contains the total number of parameter sets.
+#[endpoint {
+    method = GET,
+    path =  "/v0/projects/{project}/benchmarks/{benchmark}/parameters",
+    tags = ["projects", "parameters"]
+}]
+pub async fn proj_parameters_get(
+    rqctx: RequestContext<ApiContext>,
+    path_params: Path<ProjParametersParams>,
+    pagination_params: Query<ProjParametersPagination>,
+    query_params: Query<ProjParametersQuery>,
+) -> Result<ResponseOk<JsonParameters>, HttpError> {
+    let api_actor = ApiActor::new(&rqctx).await?;
+    let (json, total_count) = get_ls_inner(
+        rqctx.context(),
+        &api_actor,
+        path_params.into_inner(),
+        pagination_params.into_inner(),
+        query_params.into_inner(),
+    )
+    .await
+    .map_err(with_auth_hint)?;
+    Ok(Get::response_ok_with_total_count(
+        json,
+        api_actor.is_auth(),
+        total_count,
+    ))
+}
+
+pub async fn get_ls_inner(
+    context: &ApiContext,
+    api_actor: &ApiActor,
+    path_params: ProjParametersParams,
+    pagination_params: ProjParametersPagination,
+    query_params: ProjParametersQuery,
+) -> Result<(JsonParameters, TotalCount), HttpError> {
+    let query_project = QueryProject::is_allowed_actor_pub(
+        actor_conn!(context, api_actor),
+        &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
+        &path_params.project,
+        api_actor,
+    )?;
+    let query_benchmark = QueryBenchmark::from_resource_id(
+        actor_conn!(context, api_actor),
+        query_project.id,
+        &path_params.benchmark,
+    )?;
+
+    let parameters = get_ls_query(&query_benchmark, &pagination_params, &query_params)
+        .offset(pagination_params.offset())
+        .limit(pagination_params.limit())
+        .load::<QueryParameter>(actor_conn!(context, api_actor))
+        .map_err(resource_not_found_err!(
+            Parameter,
+            (&query_benchmark, &pagination_params, &query_params)
+        ))?;
+
+    // Drop connection lock before iterating
+    let json_parameters = parameters
+        .into_iter()
+        .map(|parameter| parameter.into_json_for_benchmark(&query_benchmark))
+        .collect();
+
+    let total_count = get_ls_query(&query_benchmark, &pagination_params, &query_params)
+        .count()
+        .get_result::<i64>(actor_conn!(context, api_actor))
+        .map_err(resource_not_found_err!(
+            Parameter,
+            (&query_benchmark, &pagination_params, &query_params)
+        ))?
+        .try_into()?;
+
+    Ok((json_parameters, total_count))
+}
+
+fn get_ls_query<'q>(
+    query_benchmark: &'q QueryBenchmark,
+    pagination_params: &ProjParametersPagination,
+    query_params: &'q ProjParametersQuery,
+) -> schema::parameter::BoxedQuery<'q, diesel::sqlite::Sqlite> {
+    let mut query = QueryParameter::belonging_to(query_benchmark).into_boxed();
+
+    if let Some(true) = query_params.archived {
+        query = query.filter(schema::parameter::archived.is_not_null());
+    } else {
+        query = query.filter(schema::parameter::archived.is_null());
+    }
+
+    // A parameter set has no name to break ties with, and `created` is only second
+    // granular, so the row `id` orders sets minted within the same second. Without
+    // it a page boundary could repeat or skip a set.
+    match pagination_params.order() {
+        ProjParametersSort::Created => match pagination_params.direction {
+            Some(JsonDirection::Asc) | None => query.order((
+                schema::parameter::created.asc(),
+                schema::parameter::id.asc(),
+            )),
+            Some(JsonDirection::Desc) => query.order((
+                schema::parameter::created.desc(),
+                schema::parameter::id.desc(),
+            )),
+        },
+    }
+}
+
+/// Create a parameter set
+///
+/// Create a parameter set for a benchmark.
+/// The user must have `create` permissions for the project,
+/// or provide a valid project key for the project.
+/// A parameter set that already exists for the benchmark is a conflict,
+/// so this endpoint never returns an existing parameter set.
+#[endpoint {
+    method = POST,
+    path =  "/v0/projects/{project}/benchmarks/{benchmark}/parameters",
+    tags = ["projects", "parameters"]
+}]
+pub async fn proj_parameter_post(
+    rqctx: RequestContext<ApiContext>,
+    bearer_token: PubProjectBearerToken,
+    path_params: Path<ProjParametersParams>,
+    body: TypedBody<JsonNewParameter>,
+) -> Result<ResponseCreated<JsonParameter>, HttpError> {
+    let api_actor = ApiActor::from_token(
+        &rqctx.log,
+        rqctx.context(),
+        #[cfg(feature = "plus")]
+        rqctx.request.headers(),
+        bearer_token,
+    )
+    .await?;
+    let json = post_inner(
+        rqctx.context(),
+        path_params.into_inner(),
+        body.into_inner(),
+        &api_actor,
+    )
+    .await
+    .map_err(with_auth_hint)?;
+    Ok(Post::auth_response_created(json))
+}
+
+pub async fn post_inner(
+    context: &ApiContext,
+    path_params: ProjParametersParams,
+    json_parameter: JsonNewParameter,
+    api_actor: &ApiActor,
+) -> Result<JsonParameter, HttpError> {
+    // Verify that the user is allowed
+    let query_project = QueryProject::is_allowed_actor_auth(
+        auth_conn!(context),
+        &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
+        &path_params.project,
+        api_actor,
+        Permission::Create,
+    )?;
+    let query_benchmark = QueryBenchmark::from_resource_id(
+        auth_conn!(context),
+        query_project.id,
+        &path_params.benchmark,
+    )?;
+
+    let JsonNewParameter { set } = json_parameter;
+    QueryParameter::create(context, query_project.id, query_benchmark.id, &set)
+        .await
+        .map(|parameter| parameter.into_json_for_benchmark(&query_benchmark))
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct ProjParameterParams {
+    /// The slug or UUID for a project.
+    pub project: ProjectResourceId,
+    /// The slug or UUID for a benchmark.
+    pub benchmark: BenchmarkResourceId,
+    /// The UUID for a parameter set.
+    pub parameter: ParameterUuid,
+}
+
+#[endpoint {
+    method = OPTIONS,
+    path =  "/v0/projects/{project}/benchmarks/{benchmark}/parameters/{parameter}",
+    tags = ["projects", "parameters"]
+}]
+pub async fn proj_parameter_options(
+    _rqctx: RequestContext<ApiContext>,
+    _path_params: Path<ProjParameterParams>,
+) -> Result<CorsResponse, HttpError> {
+    Ok(Endpoint::cors(&[Get.into(), Patch.into(), Delete.into()]))
+}
+
+/// View a parameter set
+///
+/// View a parameter set for a benchmark.
+/// If the project is public, then the user does not need to be authenticated.
+/// If the project is private, then the user must be authenticated and have `view` permissions for the project,
+/// or provide a valid project key for the project.
+#[endpoint {
+    method = GET,
+    path =  "/v0/projects/{project}/benchmarks/{benchmark}/parameters/{parameter}",
+    tags = ["projects", "parameters"]
+}]
+pub async fn proj_parameter_get(
+    rqctx: RequestContext<ApiContext>,
+    bearer_token: PubProjectBearerToken,
+    path_params: Path<ProjParameterParams>,
+) -> Result<ResponseOk<JsonParameter>, HttpError> {
+    let api_actor = ApiActor::from_token(
+        &rqctx.log,
+        rqctx.context(),
+        #[cfg(feature = "plus")]
+        rqctx.request.headers(),
+        bearer_token,
+    )
+    .await?;
+    let json = get_one_inner(rqctx.context(), path_params.into_inner(), &api_actor)
+        .await
+        .map_err(with_auth_hint)?;
+    Ok(Get::response_ok(json, api_actor.is_auth()))
+}
+
+pub async fn get_one_inner(
+    context: &ApiContext,
+    path_params: ProjParameterParams,
+    api_actor: &ApiActor,
+) -> Result<JsonParameter, HttpError> {
+    actor_conn!(context, api_actor, |conn| {
+        let query_project = QueryProject::is_allowed_actor_pub(
+            conn,
+            &context.rbac,
+            #[cfg(feature = "plus")]
+            &context.rate_limiting,
+            &path_params.project,
+            api_actor,
+        )?;
+        let query_benchmark =
+            QueryBenchmark::from_resource_id(conn, query_project.id, &path_params.benchmark)?;
+
+        QueryParameter::from_uuid(conn, query_benchmark.id, path_params.parameter)
+            .map(|parameter| parameter.into_json_for_benchmark(&query_benchmark))
+    })
+}
+
+/// Update a parameter set
+///
+/// Update a parameter set for a benchmark.
+/// The user must have `edit` permissions for the project,
+/// or provide a valid project key for the project.
+/// Archiving a parameter set hides it without losing its history,
+/// and a report that names the set again unarchives it.
+#[endpoint {
+    method = PATCH,
+    path =  "/v0/projects/{project}/benchmarks/{benchmark}/parameters/{parameter}",
+    tags = ["projects", "parameters"]
+}]
+pub async fn proj_parameter_patch(
+    rqctx: RequestContext<ApiContext>,
+    bearer_token: PubProjectBearerToken,
+    path_params: Path<ProjParameterParams>,
+    body: TypedBody<JsonUpdateParameter>,
+) -> Result<ResponseOk<JsonParameter>, HttpError> {
+    let api_actor = ApiActor::from_token(
+        &rqctx.log,
+        rqctx.context(),
+        #[cfg(feature = "plus")]
+        rqctx.request.headers(),
+        bearer_token,
+    )
+    .await?;
+    let json = patch_inner(
+        rqctx.context(),
+        &api_actor,
+        path_params.into_inner(),
+        body.into_inner(),
+    )
+    .await
+    .map_err(with_auth_hint)?;
+    Ok(Patch::auth_response_ok(json))
+}
+
+pub async fn patch_inner(
+    context: &ApiContext,
+    api_actor: &ApiActor,
+    path_params: ProjParameterParams,
+    json_parameter: JsonUpdateParameter,
+) -> Result<JsonParameter, HttpError> {
+    let query_project = QueryProject::is_allowed_actor_auth(
+        auth_conn!(context),
+        &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
+        &path_params.project,
+        api_actor,
+        Permission::Edit,
+    )?;
+    let query_benchmark = QueryBenchmark::from_resource_id(
+        auth_conn!(context),
+        query_project.id,
+        &path_params.benchmark,
+    )?;
+    let query_parameter = QueryParameter::from_uuid(
+        auth_conn!(context),
+        query_benchmark.id,
+        path_params.parameter,
+    )?;
+
+    let update_parameter = UpdateParameter::from(json_parameter.clone());
+    diesel::update(schema::parameter::table.filter(schema::parameter::id.eq(query_parameter.id)))
+        .set(&update_parameter)
+        .execute(write_conn!(context))
+        .map_err(resource_conflict_err!(
+            Parameter,
+            (&query_parameter, &json_parameter)
+        ))?;
+
+    QueryParameter::get(auth_conn!(context), query_parameter.id)
+        .map(|parameter| parameter.into_json_for_benchmark(&query_benchmark))
+        .map_err(resource_not_found_err!(Parameter, query_parameter))
+}
+
+/// Delete a parameter set
+///
+/// Delete a parameter set for a benchmark.
+/// The user must have `delete` permissions for the project.
+/// All reports that use this parameter must be deleted first!
+///
+/// A benchmark's empty parameter set cannot be deleted.
+/// The empty set is structural: every benchmark is born with exactly one, and
+/// report ingest treats a missing empty set as data corruption rather than a set
+/// to mint. Deleting it would manufacture exactly that corruption, so the request
+/// is refused. Archiving the empty set stays allowed, because a later report
+/// revives it the same way it revives any other archived set.
+#[endpoint {
+    method = DELETE,
+    path =  "/v0/projects/{project}/benchmarks/{benchmark}/parameters/{parameter}",
+    tags = ["projects", "parameters"]
+}]
+pub async fn proj_parameter_delete(
+    rqctx: RequestContext<ApiContext>,
+    bearer_token: BearerToken,
+    path_params: Path<ProjParameterParams>,
+) -> Result<ResponseDeleted, HttpError> {
+    let auth_user = AuthUser::from_token(rqctx.context(), bearer_token).await?;
+    delete_inner(rqctx.context(), path_params.into_inner(), &auth_user)
+        .await
+        .map_err(with_token_hint)?;
+    Ok(Delete::auth_response_deleted())
+}
+
+async fn delete_inner(
+    context: &ApiContext,
+    path_params: ProjParameterParams,
+    auth_user: &AuthUser,
+) -> Result<(), HttpError> {
+    // Verify that the user is allowed
+    let query_project = QueryProject::is_allowed(
+        auth_conn!(context),
+        &context.rbac,
+        #[cfg(feature = "plus")]
+        &context.rate_limiting,
+        &path_params.project,
+        auth_user,
+        Permission::Delete,
+    )?;
+    let query_benchmark = QueryBenchmark::from_resource_id(
+        auth_conn!(context),
+        query_project.id,
+        &path_params.benchmark,
+    )?;
+    let query_parameter = QueryParameter::from_uuid(
+        auth_conn!(context),
+        query_benchmark.id,
+        path_params.parameter,
+    )?;
+
+    if query_parameter.set.is_empty() {
+        return Err(conflict_error(format!(
+            "The empty parameter set ({parameter}) for benchmark ({benchmark}) cannot be deleted. Every benchmark must have exactly one empty parameter set. Archive it or delete the benchmark instead.",
+            parameter = query_parameter.uuid,
+            benchmark = query_benchmark.uuid,
+        )));
+    }
+
+    diesel::delete(schema::parameter::table.filter(schema::parameter::id.eq(query_parameter.id)))
+        .execute(write_conn!(context))
+        .map_err(resource_conflict_err!(Parameter, &query_parameter))?;
+
+    Ok(())
+}

--- a/lib/api_projects/tests/parameters.rs
+++ b/lib/api_projects/tests/parameters.rs
@@ -17,7 +17,10 @@ use bencher_api_tests::{
     TestServer,
     helpers::{base_timestamp, get_project_id},
 };
-use bencher_json::{DateTime, MetricName, ParameterSet, Slug};
+use bencher_json::{
+    DateTime, JsonBenchmark, JsonBenchmarks, JsonParameter, JsonParameters, MetricName,
+    ParameterSet, ParameterUuid, Slug,
+};
 use bencher_schema::{
     context::DbConnection,
     model::{organization::OrganizationId, project::metric::QueryMetric},
@@ -1487,4 +1490,878 @@ async fn alert_json_carries_the_boundary_the_metric_exceeded() {
         &from_endpoint, from_report,
         "the two endpoints that render an alert render the same alert"
     );
+}
+
+// The parameter set resource endpoints, nested under their benchmark.
+//
+// A parameter set has neither a name nor a slug, so every one of these routes
+// addresses it by UUID, the way a report or an alert is addressed.
+
+/// Create a benchmark through the API and return the slug the parameter routes
+/// nest under.
+async fn create_benchmark(server: &TestServer, fixture: &Fixture, name: &str) -> String {
+    let resp = server
+        .client
+        .post(server.api_url(&format!("/v0/projects/{}/benchmarks", fixture.project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&fixture.token),
+        )
+        .json(&serde_json::json!({ "name": name }))
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(resp.status(), StatusCode::CREATED, "POST benchmark");
+    let benchmark: JsonBenchmark = resp.json().await.expect("Failed to parse the benchmark");
+    benchmark.slug.to_string()
+}
+
+/// The benchmark a report created, taken from the benchmarks endpoint so that the
+/// slug under test is the one the server minted.
+async fn only_benchmark(server: &TestServer, fixture: &Fixture) -> String {
+    let resp = server
+        .client
+        .get(server.api_url(&format!("/v0/projects/{}/benchmarks", fixture.project_slug)))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&fixture.token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(resp.status(), StatusCode::OK, "GET benchmarks");
+    let benchmarks: JsonBenchmarks = resp.json().await.expect("Failed to parse the benchmarks");
+    assert_eq!(benchmarks.0.len(), 1, "expected exactly one benchmark");
+    benchmarks
+        .0
+        .first()
+        .expect("the only benchmark")
+        .slug
+        .to_string()
+}
+
+async fn post_parameter(
+    server: &TestServer,
+    fixture: &Fixture,
+    benchmark: &str,
+    token: &str,
+    set: &serde_json::Value,
+) -> (StatusCode, String) {
+    let resp = server
+        .client
+        .post(server.api_url(&format!(
+            "/v0/projects/{}/benchmarks/{benchmark}/parameters",
+            fixture.project_slug
+        )))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(token),
+        )
+        .json(&serde_json::json!({ "set": set }))
+        .send()
+        .await
+        .expect("Request failed");
+    let status = resp.status();
+    let body = resp.text().await.expect("Failed to read the response");
+    (status, body)
+}
+
+async fn create_parameter(
+    server: &TestServer,
+    fixture: &Fixture,
+    benchmark: &str,
+    set: &serde_json::Value,
+) -> JsonParameter {
+    let (status, body) = post_parameter(server, fixture, benchmark, &fixture.token, set).await;
+    assert_eq!(status, StatusCode::CREATED, "POST parameter: {body}");
+    serde_json::from_str(&body).expect("Failed to parse the parameter")
+}
+
+/// A parameter list request, with the `X-Total-Count` header it answered with.
+async fn list_parameters(
+    server: &TestServer,
+    fixture: &Fixture,
+    benchmark: &str,
+    token: &str,
+    query: &str,
+) -> (StatusCode, Option<String>, String) {
+    let resp = server
+        .client
+        .get(server.api_url(&format!(
+            "/v0/projects/{}/benchmarks/{benchmark}/parameters{query}",
+            fixture.project_slug
+        )))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    let status = resp.status();
+    let total_count = resp
+        .headers()
+        .get("x-total-count")
+        .and_then(|total_count| total_count.to_str().ok())
+        .map(ToOwned::to_owned);
+    let body = resp.text().await.expect("Failed to read the response");
+    (status, total_count, body)
+}
+
+async fn parameter_list(
+    server: &TestServer,
+    fixture: &Fixture,
+    benchmark: &str,
+    query: &str,
+) -> Vec<JsonParameter> {
+    let (status, _, body) =
+        list_parameters(server, fixture, benchmark, &fixture.token, query).await;
+    assert_eq!(status, StatusCode::OK, "GET parameters: {body}");
+    let parameters: JsonParameters =
+        serde_json::from_str(&body).expect("Failed to parse the parameters");
+    parameters.0
+}
+
+async fn get_parameter(
+    server: &TestServer,
+    fixture: &Fixture,
+    benchmark: &str,
+    token: &str,
+    parameter: &ParameterUuid,
+) -> (StatusCode, String) {
+    let resp = server
+        .client
+        .get(server.api_url(&format!(
+            "/v0/projects/{}/benchmarks/{benchmark}/parameters/{parameter}",
+            fixture.project_slug
+        )))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    let status = resp.status();
+    let body = resp.text().await.expect("Failed to read the response");
+    (status, body)
+}
+
+async fn patch_parameter(
+    server: &TestServer,
+    fixture: &Fixture,
+    benchmark: &str,
+    token: &str,
+    parameter: &ParameterUuid,
+    update: &serde_json::Value,
+) -> (StatusCode, String) {
+    let resp = server
+        .client
+        .patch(server.api_url(&format!(
+            "/v0/projects/{}/benchmarks/{benchmark}/parameters/{parameter}",
+            fixture.project_slug
+        )))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(token),
+        )
+        .json(update)
+        .send()
+        .await
+        .expect("Request failed");
+    let status = resp.status();
+    let body = resp.text().await.expect("Failed to read the response");
+    (status, body)
+}
+
+async fn delete_parameter(
+    server: &TestServer,
+    fixture: &Fixture,
+    benchmark: &str,
+    token: &str,
+    parameter: &ParameterUuid,
+) -> (StatusCode, String) {
+    let resp = server
+        .client
+        .delete(server.api_url(&format!(
+            "/v0/projects/{}/benchmarks/{benchmark}/parameters/{parameter}",
+            fixture.project_slug
+        )))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    let status = resp.status();
+    let body = resp.text().await.expect("Failed to read the response");
+    (status, body)
+}
+
+async fn delete_report(
+    server: &TestServer,
+    fixture: &Fixture,
+    report: &str,
+) -> (StatusCode, String) {
+    let resp = server
+        .client
+        .delete(server.api_url(&format!(
+            "/v0/projects/{}/reports/{report}",
+            fixture.project_slug
+        )))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(&fixture.token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    let status = resp.status();
+    let body = resp.text().await.expect("Failed to read the response");
+    (status, body)
+}
+
+/// The row id of a parameter set, or `None` once it is deleted.
+fn parameter_row_id(conn: &mut DbConnection, parameter: &ParameterUuid) -> Option<i32> {
+    use diesel::OptionalExtension as _;
+
+    schema::parameter::table
+        .filter(schema::parameter::uuid.eq(parameter))
+        .select(schema::parameter::id)
+        .first(conn)
+        .optional()
+        .expect("Failed to query the parameter set")
+}
+
+fn report_benchmarks_for_parameter(conn: &mut DbConnection, parameter_id: i32) -> i64 {
+    schema::report_benchmark::table
+        .filter(schema::report_benchmark::parameter_id.eq(parameter_id))
+        .count()
+        .get_result(conn)
+        .expect("Failed to count the report benchmarks")
+}
+
+fn series_for_parameter(conn: &mut DbConnection, parameter_id: i32) -> i64 {
+    schema::series_last_seen::table
+        .filter(schema::series_last_seen::parameter_id.eq(parameter_id))
+        .count()
+        .get_result(conn)
+        .expect("Failed to count the billable series")
+}
+
+fn project_metric_count(conn: &mut DbConnection, project_id: i32) -> i64 {
+    schema::metric::table
+        .inner_join(schema::report_benchmark::table.inner_join(schema::benchmark::table))
+        .filter(schema::benchmark::project_id.eq(project_id))
+        .count()
+        .get_result(conn)
+        .expect("Failed to count the metrics")
+}
+
+// A benchmark is born with exactly one parameter set, the empty one, and it is
+// listed with its total count like every other dimension list.
+#[tokio::test]
+async fn parameter_list_starts_with_the_empty_set() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "list-empty").await;
+    let benchmark = create_benchmark(&server, &fixture, "bench one").await;
+
+    let (status, total_count, body) =
+        list_parameters(&server, &fixture, &benchmark, &fixture.token, "").await;
+    assert_eq!(status, StatusCode::OK, "GET parameters: {body}");
+    assert_eq!(total_count.as_deref(), Some("1"));
+
+    let parameters: JsonParameters =
+        serde_json::from_str(&body).expect("Failed to parse the parameters");
+    assert_eq!(
+        parameters.0.len(),
+        1,
+        "a benchmark is born with exactly one parameter set: {body}"
+    );
+    let parameter = parameters.0.first().expect("the only parameter set");
+    assert_eq!(parameter.set, ParameterSet::default());
+    assert!(
+        parameter.archived.is_none(),
+        "the birth parameter set is not archived"
+    );
+}
+
+// The list is sorted by creation, oldest first, and pages the way every other
+// dimension list pages.
+#[tokio::test]
+async fn parameter_list_paginates_in_creation_order() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "list-page").await;
+    let benchmark = create_benchmark(&server, &fixture, "bench one").await;
+
+    let mut created = Vec::new();
+    for size_mb in [16, 32, 64] {
+        let parameter = create_parameter(
+            &server,
+            &fixture,
+            &benchmark,
+            &serde_json::json!({ "size_mb": size_mb }),
+        )
+        .await;
+        created.push(parameter.uuid);
+    }
+
+    let (status, total_count, body) =
+        list_parameters(&server, &fixture, &benchmark, &fixture.token, "").await;
+    assert_eq!(status, StatusCode::OK, "GET parameters: {body}");
+    assert_eq!(total_count.as_deref(), Some("4"));
+
+    // The empty set the benchmark was born with, then the three grid points in the
+    // order they were created.
+    let all = parameter_list(&server, &fixture, &benchmark, "").await;
+    assert_eq!(all.len(), 4);
+    assert_eq!(
+        all.first().expect("the first parameter set").set,
+        ParameterSet::default(),
+        "the empty set the benchmark was born with sorts first"
+    );
+    assert_eq!(
+        all.iter().skip(1).map(|p| p.uuid).collect::<Vec<_>>(),
+        created,
+        "the grid points list in creation order"
+    );
+
+    let first_page = parameter_list(&server, &fixture, &benchmark, "?per_page=2&page=1").await;
+    let second_page = parameter_list(&server, &fixture, &benchmark, "?per_page=2&page=2").await;
+    assert_eq!(
+        first_page
+            .iter()
+            .chain(second_page.iter())
+            .map(|p| p.uuid)
+            .collect::<Vec<_>>(),
+        all.iter().map(|p| p.uuid).collect::<Vec<_>>(),
+        "the two pages are the whole list, in order"
+    );
+
+    let descending = parameter_list(&server, &fixture, &benchmark, "?direction=desc").await;
+    assert_eq!(
+        descending.iter().map(|p| p.uuid).collect::<Vec<_>>(),
+        all.iter().rev().map(|p| p.uuid).collect::<Vec<_>>(),
+        "descending is the same list, reversed"
+    );
+}
+
+// The archived filter has the same two states a benchmark's does: archived sets are
+// out of the default list and are the only thing `archived=true` returns.
+#[tokio::test]
+async fn parameter_list_filters_by_archived() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "list-archived").await;
+    let benchmark = create_benchmark(&server, &fixture, "bench one").await;
+    let parameter = create_parameter(
+        &server,
+        &fixture,
+        &benchmark,
+        &serde_json::json!({ "size_mb": 16 }),
+    )
+    .await;
+
+    let (status, body) = patch_parameter(
+        &server,
+        &fixture,
+        &benchmark,
+        &fixture.token,
+        &parameter.uuid,
+        &serde_json::json!({ "archived": true }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "PATCH parameter: {body}");
+
+    let default = parameter_list(&server, &fixture, &benchmark, "").await;
+    assert_eq!(default.len(), 1, "only the empty set is left unarchived");
+    assert_eq!(
+        default.first().expect("the empty set").set,
+        ParameterSet::default(),
+        "the archived set is out of the default list"
+    );
+
+    let archived = parameter_list(&server, &fixture, &benchmark, "?archived=true").await;
+    assert_eq!(archived.len(), 1);
+    let archived = archived.first().expect("the archived set");
+    assert_eq!(archived.uuid, parameter.uuid);
+    assert!(
+        archived.archived.is_some(),
+        "the archived set carries its timestamp"
+    );
+}
+
+// A created parameter set reads back the same through the one get endpoint.
+#[tokio::test]
+async fn parameter_get_reads_back_the_created_set() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "get-one").await;
+    let benchmark = create_benchmark(&server, &fixture, "bench one").await;
+    let created = create_parameter(
+        &server,
+        &fixture,
+        &benchmark,
+        &serde_json::json!({ "op": "read", "size_mb": 16 }),
+    )
+    .await;
+
+    let (status, body) =
+        get_parameter(&server, &fixture, &benchmark, &fixture.token, &created.uuid).await;
+    assert_eq!(status, StatusCode::OK, "GET parameter: {body}");
+    let parameter: JsonParameter = serde_json::from_str(&body).expect("Failed to parse");
+    assert_eq!(parameter.uuid, created.uuid);
+    assert_eq!(parameter.set, parameters(r#"{"op":"read","size_mb":16}"#));
+    assert_eq!(parameter.benchmark, created.benchmark);
+}
+
+// A parameter set that already exists under the benchmark is a conflict. This
+// endpoint is create, not get-or-create: the empty set the benchmark was born with
+// conflicts the same way any other repeated set does.
+#[tokio::test]
+async fn parameter_post_duplicate_is_a_conflict() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "post-duplicate").await;
+    let benchmark = create_benchmark(&server, &fixture, "bench one").await;
+
+    let set = serde_json::json!({ "size_mb": 16 });
+    let created = create_parameter(&server, &fixture, &benchmark, &set).await;
+
+    let (status, body) = post_parameter(&server, &fixture, &benchmark, &fixture.token, &set).await;
+    assert_eq!(status, StatusCode::CONFLICT, "POST duplicate: {body}");
+
+    // A set that is logically the same set, spelled differently, is the same set.
+    let (status, body) = post_parameter(
+        &server,
+        &fixture,
+        &benchmark,
+        &fixture.token,
+        &serde_json::json!({ "size_mb": 16.0 }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "POST respelled: {body}");
+
+    let (status, body) = post_parameter(
+        &server,
+        &fixture,
+        &benchmark,
+        &fixture.token,
+        &serde_json::json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "POST the empty set: {body}");
+
+    let all = parameter_list(&server, &fixture, &benchmark, "").await;
+    assert_eq!(
+        all.len(),
+        2,
+        "the birth empty set and the one created grid point"
+    );
+    assert!(all.iter().any(|parameter| parameter.uuid == created.uuid));
+}
+
+// The endpoint mints parameter sets, so it carries the same per project ceiling the
+// report path does, with the same error.
+#[tokio::test]
+async fn parameter_post_is_rate_limited() {
+    // Four creations per project per window. A benchmark is born with its empty
+    // parameter set, which is one of the four, so the fourth posted grid point is
+    // the one that is refused.
+    let server = TestServer::new_with_creation_limits(4, 4).await;
+    let fixture = fixture(&server, "post-limit").await;
+    let benchmark = create_benchmark(&server, &fixture, "bench one").await;
+
+    for size_mb in [16, 32, 64] {
+        create_parameter(
+            &server,
+            &fixture,
+            &benchmark,
+            &serde_json::json!({ "size_mb": size_mb }),
+        )
+        .await;
+    }
+
+    let (status, body) = post_parameter(
+        &server,
+        &fixture,
+        &benchmark,
+        &fixture.token,
+        &serde_json::json!({ "size_mb": 128 }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::TOO_MANY_REQUESTS,
+        "over the ceiling: {body}"
+    );
+    assert!(
+        body.contains("Parameter"),
+        "the limit that fired is the parameter one: {body}"
+    );
+
+    let all = parameter_list(&server, &fixture, &benchmark, "").await;
+    assert_eq!(all.len(), 4, "no parameter set is minted past the ceiling");
+}
+
+// Archiving sets the timestamp and unarchiving clears it, exactly as it does for a
+// benchmark.
+#[tokio::test]
+async fn parameter_patch_archives_and_unarchives() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "patch-archive").await;
+    let benchmark = create_benchmark(&server, &fixture, "bench one").await;
+    let created = create_parameter(
+        &server,
+        &fixture,
+        &benchmark,
+        &serde_json::json!({ "size_mb": 16 }),
+    )
+    .await;
+    assert!(created.archived.is_none());
+
+    let (status, body) = patch_parameter(
+        &server,
+        &fixture,
+        &benchmark,
+        &fixture.token,
+        &created.uuid,
+        &serde_json::json!({ "archived": true }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "PATCH archive: {body}");
+    let archived: JsonParameter = serde_json::from_str(&body).expect("Failed to parse");
+    assert!(archived.archived.is_some(), "archiving sets the timestamp");
+    assert_eq!(archived.set, created.set, "archiving does not move the set");
+
+    let (status, body) = patch_parameter(
+        &server,
+        &fixture,
+        &benchmark,
+        &fixture.token,
+        &created.uuid,
+        &serde_json::json!({ "archived": false }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "PATCH unarchive: {body}");
+    let unarchived: JsonParameter = serde_json::from_str(&body).expect("Failed to parse");
+    assert!(
+        unarchived.archived.is_none(),
+        "unarchiving clears the timestamp"
+    );
+}
+
+// Archiving the empty parameter set is allowed, because a later report revives it.
+#[tokio::test]
+async fn parameter_patch_archives_the_empty_set() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "patch-empty").await;
+    let benchmark = create_benchmark(&server, &fixture, "bench one").await;
+    let all = parameter_list(&server, &fixture, &benchmark, "").await;
+    let empty_set = all.first().expect("the empty parameter set").uuid;
+
+    let (status, body) = patch_parameter(
+        &server,
+        &fixture,
+        &benchmark,
+        &fixture.token,
+        &empty_set,
+        &serde_json::json!({ "archived": true }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "PATCH the empty set: {body}");
+
+    let archived = parameter_list(&server, &fixture, &benchmark, "?archived=true").await;
+    assert_eq!(archived.len(), 1);
+    assert_eq!(
+        archived.first().expect("the archived empty set").uuid,
+        empty_set
+    );
+}
+
+// A parameter set that a report still references cannot be deleted. Its results
+// have to be deleted first, exactly as a benchmark's do one level up, so the
+// deletable state is a parameter set nothing points at any more.
+#[tokio::test]
+async fn parameter_delete_refuses_while_reports_reference_it() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "delete-referenced").await;
+
+    let measures = serde_json::json!({ "latency": { "value": 1.0 } });
+    report(
+        &server,
+        &fixture,
+        1,
+        vec![v1(
+            "bench",
+            &[
+                entry(&serde_json::json!({}), &measures),
+                entry(&serde_json::json!({ "size_mb": 16 }), &measures),
+            ],
+        )],
+        None,
+        None,
+    )
+    .await;
+
+    let benchmark = only_benchmark(&server, &fixture).await;
+    let all = parameter_list(&server, &fixture, &benchmark, "").await;
+    assert_eq!(all.len(), 2);
+    let grid_point = all
+        .iter()
+        .find(|parameter| parameter.set == parameters(r#"{"size_mb":16}"#))
+        .expect("the reported grid point");
+
+    let project_id = get_project_id(&server, &fixture.project_slug);
+    let mut conn = server.db_conn();
+    let grid_point_id = parameter_row_id(&mut conn, &grid_point.uuid).expect("the grid point row");
+    assert_eq!(report_benchmarks_for_parameter(&mut conn, grid_point_id), 1);
+    drop(conn);
+
+    let (status, body) = delete_parameter(
+        &server,
+        &fixture,
+        &benchmark,
+        &fixture.token,
+        &grid_point.uuid,
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "a referenced parameter set is not deletable: {body}"
+    );
+
+    // Nothing moved: the parameter set, its results, its metrics, and its billable
+    // series are all still there.
+    let mut conn = server.db_conn();
+    assert!(
+        parameter_row_id(&mut conn, &grid_point.uuid).is_some(),
+        "the parameter set is still there"
+    );
+    assert_eq!(report_benchmarks_for_parameter(&mut conn, grid_point_id), 1);
+    assert_eq!(series_for_parameter(&mut conn, grid_point_id), 1);
+    assert_eq!(project_metric_count(&mut conn, project_id), 2);
+    drop(conn);
+
+    let all = parameter_list(&server, &fixture, &benchmark, "").await;
+    assert_eq!(all.len(), 2, "both parameter sets are still listed");
+}
+
+// A parameter set nothing references any more is deletable, and the billable series
+// it left behind go with it. Deleting the report is what unreferences it: the report
+// takes its own results, and the parameter set and its series outlive them.
+#[tokio::test]
+async fn parameter_delete_removes_an_unreferenced_set() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "delete-unreferenced").await;
+
+    let measures = serde_json::json!({ "latency": { "value": 1.0 } });
+    let json_report = report(
+        &server,
+        &fixture,
+        1,
+        vec![v1(
+            "bench",
+            &[
+                entry(&serde_json::json!({}), &measures),
+                entry(&serde_json::json!({ "size_mb": 16 }), &measures),
+            ],
+        )],
+        None,
+        None,
+    )
+    .await;
+    let report_uuid = json_report
+        .get("uuid")
+        .and_then(serde_json::Value::as_str)
+        .expect("the report carries its uuid")
+        .to_owned();
+
+    let benchmark = only_benchmark(&server, &fixture).await;
+    let all = parameter_list(&server, &fixture, &benchmark, "").await;
+    let grid_point = all
+        .iter()
+        .find(|parameter| parameter.set == parameters(r#"{"size_mb":16}"#))
+        .expect("the reported grid point");
+    let empty_set = all
+        .iter()
+        .find(|parameter| parameter.set == ParameterSet::default())
+        .expect("the empty parameter set");
+
+    let mut conn = server.db_conn();
+    let grid_point_id = parameter_row_id(&mut conn, &grid_point.uuid).expect("the grid point row");
+    let empty_set_id = parameter_row_id(&mut conn, &empty_set.uuid).expect("the empty set row");
+    drop(conn);
+
+    let (status, body) = delete_report(&server, &fixture, &report_uuid).await;
+    assert_eq!(status, StatusCode::NO_CONTENT, "DELETE report: {body}");
+
+    // The report took its results, and left the parameter sets and the series they
+    // billed behind.
+    let mut conn = server.db_conn();
+    assert_eq!(
+        report_benchmarks_for_parameter(&mut conn, grid_point_id),
+        0,
+        "the report took its results"
+    );
+    assert_eq!(
+        series_for_parameter(&mut conn, grid_point_id),
+        1,
+        "the billable series outlives the report"
+    );
+    drop(conn);
+
+    let (status, body) = delete_parameter(
+        &server,
+        &fixture,
+        &benchmark,
+        &fixture.token,
+        &grid_point.uuid,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT, "DELETE parameter: {body}");
+
+    let mut conn = server.db_conn();
+    assert!(
+        parameter_row_id(&mut conn, &grid_point.uuid).is_none(),
+        "the parameter set is gone"
+    );
+    assert_eq!(
+        series_for_parameter(&mut conn, grid_point_id),
+        0,
+        "its billable series go with it"
+    );
+    // The benchmark's empty parameter set is untouched.
+    assert!(
+        parameter_row_id(&mut conn, &empty_set.uuid).is_some(),
+        "the empty set is still there"
+    );
+    assert_eq!(series_for_parameter(&mut conn, empty_set_id), 1);
+    drop(conn);
+
+    let remaining = parameter_list(&server, &fixture, &benchmark, "").await;
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(
+        remaining.first().expect("the empty set").uuid,
+        empty_set.uuid
+    );
+}
+
+// The empty parameter set is structural, so this endpoint may not delete it. Every
+// benchmark is born with exactly one, and ingest treats a missing empty set as data
+// corruption rather than a set to mint.
+#[tokio::test]
+async fn parameter_delete_refuses_the_empty_set() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "delete-empty").await;
+    let benchmark = create_benchmark(&server, &fixture, "bench one").await;
+    let all = parameter_list(&server, &fixture, &benchmark, "").await;
+    let empty_set = all.first().expect("the empty parameter set").uuid;
+
+    let (status, body) =
+        delete_parameter(&server, &fixture, &benchmark, &fixture.token, &empty_set).await;
+    assert_eq!(status, StatusCode::CONFLICT, "DELETE the empty set: {body}");
+
+    let all = parameter_list(&server, &fixture, &benchmark, "").await;
+    assert_eq!(all.len(), 1, "the empty set is still there");
+    assert_eq!(all.first().expect("the empty set").uuid, empty_set);
+}
+
+// A parameter set under one benchmark is not addressable through another, and a
+// UUID that does not exist is not found.
+#[tokio::test]
+async fn parameter_get_is_scoped_to_its_benchmark() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "get-scope").await;
+    let first = create_benchmark(&server, &fixture, "bench one").await;
+    let second = create_benchmark(&server, &fixture, "bench two").await;
+    let parameter = create_parameter(
+        &server,
+        &fixture,
+        &first,
+        &serde_json::json!({ "size_mb": 16 }),
+    )
+    .await;
+
+    let (status, _) =
+        get_parameter(&server, &fixture, &second, &fixture.token, &parameter.uuid).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    let (status, _) = get_parameter(
+        &server,
+        &fixture,
+        &first,
+        &fixture.token,
+        &ParameterUuid::new(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+// Permissions are the benchmark endpoints' permissions: a public project's sets are
+// readable by anyone, and writing one takes a role on the project.
+#[tokio::test]
+async fn parameter_writes_require_permission() {
+    let server = TestServer::new().await;
+    let fixture = fixture(&server, "permissions").await;
+    let outsider = server
+        .signup("Outsider", "paramsoutsider@example.com")
+        .await;
+    let benchmark = create_benchmark(&server, &fixture, "bench one").await;
+    let parameter = create_parameter(
+        &server,
+        &fixture,
+        &benchmark,
+        &serde_json::json!({ "size_mb": 16 }),
+    )
+    .await;
+
+    // The project is public, so the outsider may read.
+    let (status, _, body) =
+        list_parameters(&server, &fixture, &benchmark, &outsider.token, "").await;
+    assert_eq!(status, StatusCode::OK, "GET parameters: {body}");
+    let (status, body) = get_parameter(
+        &server,
+        &fixture,
+        &benchmark,
+        &outsider.token,
+        &parameter.uuid,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "GET parameter: {body}");
+
+    // Every write is refused.
+    let (status, body) = post_parameter(
+        &server,
+        &fixture,
+        &benchmark,
+        &outsider.token,
+        &serde_json::json!({ "size_mb": 32 }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "POST parameter: {body}");
+
+    let (status, body) = patch_parameter(
+        &server,
+        &fixture,
+        &benchmark,
+        &outsider.token,
+        &parameter.uuid,
+        &serde_json::json!({ "archived": true }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "PATCH parameter: {body}");
+
+    let (status, body) = delete_parameter(
+        &server,
+        &fixture,
+        &benchmark,
+        &outsider.token,
+        &parameter.uuid,
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "DELETE parameter: {body}");
+
+    let all = parameter_list(&server, &fixture, &benchmark, "").await;
+    assert_eq!(all.len(), 2, "nothing the outsider sent landed");
+    assert!(all.iter().all(|parameter| parameter.archived.is_none()));
 }

--- a/lib/bencher_json/src/lib.rs
+++ b/lib/bencher_json/src/lib.rs
@@ -86,7 +86,7 @@ pub use project::{
         JsonMetricTriple, JsonMetricsMap, JsonNewMetric, JsonOneMetric, JsonResultsMap, MetricUuid,
     },
     model::{JsonModel, ModelUuid},
-    parameter::{MAX_PARAMETER_KEYS, ParameterSet, ParameterUuid},
+    parameter::{JsonParameter, JsonParameters, MAX_PARAMETER_KEYS, ParameterSet, ParameterUuid},
     perf::{JsonPerf, JsonPerfQuery, ReportBenchmarkUuid},
     plot::{JsonNewPlot, JsonPlot, JsonPlots, PlotUuid},
     report::{

--- a/lib/bencher_json/src/project/parameter/mod.rs
+++ b/lib/bencher_json/src/project/parameter/mod.rs
@@ -1,15 +1,56 @@
 use std::{cmp::Ordering, collections::BTreeMap, fmt, str::FromStr};
 
-use bencher_valid::{ParameterKey as ValidParameterKey, ParameterValue};
+use bencher_valid::{DateTime, ParameterKey as ValidParameterKey, ParameterValue};
 use ordered_float::OrderedFloat;
 #[cfg(feature = "schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de, ser::SerializeMap as _};
 
+use crate::BenchmarkUuid;
+
 #[cfg(feature = "db")]
 pub mod jsonb;
 
 crate::typed_uuid::typed_uuid!(ParameterUuid);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub struct JsonNewParameter {
+    /// The parameter set.
+    /// Each key maps to a JSON scalar: a string, a number, or a boolean.
+    pub set: ParameterSet,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub struct JsonParameters(pub Vec<JsonParameter>);
+
+crate::from_vec!(JsonParameters[JsonParameter]);
+
+#[typeshare::typeshare]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub struct JsonParameter {
+    pub uuid: ParameterUuid,
+    pub benchmark: BenchmarkUuid,
+    pub set: ParameterSet,
+    pub created: DateTime,
+    pub modified: DateTime,
+    pub archived: Option<DateTime>,
+}
+
+impl fmt::Display for JsonParameter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.set)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub struct JsonUpdateParameter {
+    /// Set whether the parameter set is archived.
+    pub archived: Option<bool>,
+}
 
 /// The most keys one parameter set may carry, anchored to the number of named
 /// values one measure may carry.

--- a/lib/bencher_schema/src/model/project/parameter.rs
+++ b/lib/bencher_schema/src/model/project/parameter.rs
@@ -1,4 +1,7 @@
-use bencher_json::{DateTime, ParameterSet, ParameterUuid, project::report::JsonReportParameter};
+use bencher_json::{
+    DateTime, JsonParameter, ParameterSet, ParameterUuid,
+    project::{parameter::JsonUpdateParameter, report::JsonReportParameter},
+};
 use diesel::{
     ExpressionMethods as _, OptionalExtension as _, QueryDsl as _, RunQueryDsl as _,
     SelectableHelper as _,
@@ -8,7 +11,7 @@ use dropshot::HttpError;
 use crate::{
     auth_conn,
     context::{ApiContext, DbConnection},
-    error::{issue_error, resource_conflict_err},
+    error::{BencherResource, assert_parentage, issue_error, resource_conflict_err},
     macros::{
         fn_get::{fn_from_uuid, fn_get, fn_get_id, fn_get_uuid},
         sql::last_insert_rowid,
@@ -143,7 +146,13 @@ impl QueryParameter {
         }
     }
 
-    async fn create(
+    /// Create a parameter set under its benchmark.
+    ///
+    /// A set that already exists under the benchmark collides on
+    /// `UNIQUE (benchmark_id, "set")`, so this is create and not get-or-create.
+    /// The per project ceiling is checked first, exactly as it is for a set a
+    /// report mints.
+    pub async fn create(
         context: &ApiContext,
         project_id: ProjectId,
         benchmark_id: BenchmarkId,
@@ -184,6 +193,33 @@ impl QueryParameter {
                 );
                 issue_error(&message, &message, e)
             })
+    }
+
+    /// The parameter set as its own resource, under its benchmark.
+    pub fn into_json_for_benchmark(self, benchmark: &QueryBenchmark) -> JsonParameter {
+        let Self {
+            id: _,
+            uuid,
+            benchmark_id,
+            set,
+            created,
+            modified,
+            archived,
+        } = self;
+        assert_parentage(
+            BencherResource::Benchmark,
+            benchmark.id,
+            BencherResource::Parameter,
+            benchmark_id,
+        );
+        JsonParameter {
+            uuid,
+            benchmark: benchmark.uuid,
+            set,
+            created,
+            modified,
+            archived,
+        }
     }
 
     /// The parameter set as a report result names it.
@@ -316,16 +352,23 @@ impl InsertParameter {
 #[derive(Debug, Clone, diesel::AsChangeset)]
 #[diesel(table_name = parameter_table)]
 pub struct UpdateParameter {
-    pub set: Option<ParameterSet>,
     pub modified: DateTime,
     pub archived: Option<Option<DateTime>>,
+}
+
+impl From<JsonUpdateParameter> for UpdateParameter {
+    fn from(update: JsonUpdateParameter) -> Self {
+        let JsonUpdateParameter { archived } = update;
+        let modified = DateTime::now();
+        let archived = archived.map(|archived| archived.then_some(modified));
+        Self { modified, archived }
+    }
 }
 
 impl UpdateParameter {
     /// A grid point that reports again is a live grid point.
     fn unarchive() -> Self {
         Self {
-            set: None,
             modified: DateTime::now(),
             archived: Some(None),
         }

--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -4181,6 +4181,517 @@
         }
       }
     },
+    "/v0/projects/{project}/benchmarks/{benchmark}/parameters": {
+      "get": {
+        "tags": [
+          "projects",
+          "parameters"
+        ],
+        "summary": "List parameter sets for a benchmark",
+        "description": "List all parameter sets for a benchmark. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project. By default, the parameter sets are sorted by creation date time. The HTTP response header `X-Total-Count` contains the total number of parameter sets.",
+        "operationId": "proj_parameters_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "benchmark",
+            "description": "The slug or UUID for a benchmark.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ResourceId"
+            }
+          },
+          {
+            "in": "path",
+            "name": "project",
+            "description": "The slug or UUID for a project.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ResourceId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "direction",
+            "description": "The direction to sort by. If not specified, the default sort direction is used.",
+            "schema": {
+              "$ref": "#/components/schemas/JsonDirection"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "description": "The page number to return. If not specified, the first page is returned.",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            }
+          },
+          {
+            "in": "query",
+            "name": "per_page",
+            "description": "The number of items to return per page. If not specified, the default number of items per page (8) is used.",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "description": "The field to sort by. If not specified, the default sort field is used.",
+            "schema": {
+              "$ref": "#/components/schemas/ProjParametersSort"
+            }
+          },
+          {
+            "in": "query",
+            "name": "archived",
+            "description": "If set to `true`, only returns archived parameter sets. If not set or set to `false`, only returns non-archived parameter sets.",
+            "schema": {
+              "nullable": true,
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "headers": {
+              "access-control-allow-headers": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-allow-methods": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-allow-origin": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-expose-headers": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "x-total-count": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonParameters"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "projects",
+          "parameters"
+        ],
+        "summary": "Create a parameter set",
+        "description": "Create a parameter set for a benchmark. The user must have `create` permissions for the project, or provide a valid project key for the project. A parameter set that already exists for the benchmark is a conflict, so this endpoint never returns an existing parameter set.",
+        "operationId": "proj_parameter_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "benchmark",
+            "description": "The slug or UUID for a benchmark.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ResourceId"
+            }
+          },
+          {
+            "in": "path",
+            "name": "project",
+            "description": "The slug or UUID for a project.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ResourceId"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonNewParameter"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "successful creation",
+            "headers": {
+              "access-control-allow-headers": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-allow-methods": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-allow-origin": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-expose-headers": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "x-total-count": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonParameter"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/v0/projects/{project}/benchmarks/{benchmark}/parameters/{parameter}": {
+      "get": {
+        "tags": [
+          "projects",
+          "parameters"
+        ],
+        "summary": "View a parameter set",
+        "description": "View a parameter set for a benchmark. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project.",
+        "operationId": "proj_parameter_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "benchmark",
+            "description": "The slug or UUID for a benchmark.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ResourceId"
+            }
+          },
+          {
+            "in": "path",
+            "name": "parameter",
+            "description": "The UUID for a parameter set.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ParameterUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "project",
+            "description": "The slug or UUID for a project.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ResourceId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "headers": {
+              "access-control-allow-headers": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-allow-methods": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-allow-origin": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-expose-headers": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "x-total-count": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonParameter"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "projects",
+          "parameters"
+        ],
+        "summary": "Delete a parameter set",
+        "description": "Delete a parameter set for a benchmark. The user must have `delete` permissions for the project. All reports that use this parameter must be deleted first!\n\nA benchmark's empty parameter set cannot be deleted. The empty set is structural: every benchmark is born with exactly one, and report ingest treats a missing empty set as data corruption rather than a set to mint. Deleting it would manufacture exactly that corruption, so the request is refused. Archiving the empty set stays allowed, because a later report revives it the same way it revives any other archived set.",
+        "operationId": "proj_parameter_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "benchmark",
+            "description": "The slug or UUID for a benchmark.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ResourceId"
+            }
+          },
+          {
+            "in": "path",
+            "name": "parameter",
+            "description": "The UUID for a parameter set.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ParameterUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "project",
+            "description": "The slug or UUID for a project.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ResourceId"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion",
+            "headers": {
+              "access-control-allow-headers": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-allow-methods": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-allow-origin": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-expose-headers": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "x-total-count": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "projects",
+          "parameters"
+        ],
+        "summary": "Update a parameter set",
+        "description": "Update a parameter set for a benchmark. The user must have `edit` permissions for the project, or provide a valid project key for the project. Archiving a parameter set hides it without losing its history, and a report that names the set again unarchives it.",
+        "operationId": "proj_parameter_patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "benchmark",
+            "description": "The slug or UUID for a benchmark.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ResourceId"
+            }
+          },
+          {
+            "in": "path",
+            "name": "parameter",
+            "description": "The UUID for a parameter set.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ParameterUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "project",
+            "description": "The slug or UUID for a project.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ResourceId"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonUpdateParameter"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "headers": {
+              "access-control-allow-headers": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-allow-methods": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-allow-origin": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-expose-headers": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "x-total-count": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonParameter"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/v0/projects/{project}/branches": {
       "get": {
         "tags": [
@@ -13622,6 +14133,22 @@
           "name"
         ]
       },
+      "JsonNewParameter": {
+        "type": "object",
+        "properties": {
+          "set": {
+            "description": "The parameter set. Each key maps to a JSON scalar: a string, a number, or a boolean.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ParameterSet"
+              }
+            ]
+          }
+        },
+        "required": [
+          "set"
+        ]
+      },
       "JsonNewPlan": {
         "type": "object",
         "properties": {
@@ -14790,6 +15317,47 @@
           "endpoint",
           "protocol"
         ]
+      },
+      "JsonParameter": {
+        "type": "object",
+        "properties": {
+          "archived": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTime"
+              }
+            ]
+          },
+          "benchmark": {
+            "$ref": "#/components/schemas/BenchmarkUuid"
+          },
+          "created": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "modified": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "set": {
+            "$ref": "#/components/schemas/ParameterSet"
+          },
+          "uuid": {
+            "$ref": "#/components/schemas/ParameterUuid"
+          }
+        },
+        "required": [
+          "benchmark",
+          "created",
+          "modified",
+          "set",
+          "uuid"
+        ]
+      },
+      "JsonParameters": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/JsonParameter"
+        }
       },
       "JsonPerf": {
         "type": "object",
@@ -17857,6 +18425,16 @@
           }
         ]
       },
+      "JsonUpdateParameter": {
+        "type": "object",
+        "properties": {
+          "archived": {
+            "nullable": true,
+            "description": "Set whether the parameter set is archived.",
+            "type": "boolean"
+          }
+        }
+      },
       "JsonUpdatePlan": {
         "type": "object",
         "properties": {
@@ -19073,6 +19651,17 @@
           }
         ]
       },
+      "ProjParametersSort": {
+        "oneOf": [
+          {
+            "description": "Sort by parameter set creation date time.",
+            "type": "string",
+            "enum": [
+              "created"
+            ]
+          }
+        ]
+      },
       "ProjBranchesSort": {
         "oneOf": [
           {
@@ -19321,6 +19910,10 @@
     {
       "name": "organizations",
       "description": "Organizations"
+    },
+    {
+      "name": "parameters",
+      "description": "Benchmark Parameters"
     },
     {
       "name": "perf",

--- a/services/console/src/types/bencher.ts
+++ b/services/console/src/types/bencher.ts
@@ -921,6 +921,15 @@ export interface JsonOrganization {
 	claimed?: string;
 }
 
+export interface JsonParameter {
+	uuid: Uuid;
+	benchmark: Uuid;
+	set: Record<string, string | number | boolean>;
+	created: string;
+	modified: string;
+	archived?: string;
+}
+
 export interface JsonProject {
 	uuid: Uuid;
 	organization: Uuid;

--- a/tasks/gen_types/src/task/spec.rs
+++ b/tasks/gen_types/src/task/spec.rs
@@ -58,6 +58,7 @@ impl Spec {
                 "branches" => TagDetails { description: Some("Branches".into()), external_docs: None},
                 "testbeds" => TagDetails { description: Some("Testbeds".into()), external_docs: None},
                 "benchmarks" => TagDetails { description: Some("Benchmarks".into()), external_docs: None},
+                "parameters" => TagDetails { description: Some("Benchmark Parameters".into()), external_docs: None},
                 "measures" => TagDetails { description: Some("Measures".into()), external_docs: None},
                 "metrics" => TagDetails { description: Some("Metrics".into()), external_docs: None},
                 "thresholds" => TagDetails { description: Some("Thresholds".into()), external_docs: None},


### PR DESCRIPTION
A parameter set becomes a first class resource, with full parity to the other dimension entities. It nests under its benchmark and is addressed by UUID only, because it has neither a name nor a slug, the same way a report or an alert is addressed.

## Routes

Under `/v0/projects/{project}/benchmarks/{benchmark}/parameters`:

- `OPTIONS`, `GET` (list): pages and sorts like the benchmark list, defaulting to creation order, with `X-Total-Count` on the response. The `archived` filter carries the same two states a benchmark list's does. There is no search parameter, because there is nothing to search by.
- `POST` (create): body `{ "set": { ... } }`.

Under `/v0/projects/{project}/benchmarks/{benchmark}/parameters/{parameter}`:

- `OPTIONS`, `GET` (view).
- `PATCH`: body `{ "archived": true | false }`, mirroring benchmark archive semantics exactly.
- `DELETE`.

Permissions mirror the benchmark endpoints. A public project's sets are readable without authentication, and create, edit, and delete each take the same permission the corresponding benchmark endpoint takes.

## Create

Create is create, never get or create. A parameter set that already exists under the benchmark collides on `UNIQUE (benchmark_id, "set")` and comes back as a conflict, which is the same error class a duplicate benchmark name returns. Two spellings of one set are one set, so `{"size_mb": 16.0}` conflicts with `{"size_mb": 16}`, and posting `{}` conflicts with the empty set the benchmark was born with.

This path mints parameter sets, so it carries the per project creation ceiling that report ingest already enforces, with the same error. Without it, this endpoint would be an unbounded way to mint rows, grid points, and billable series.

## Delete

Delete follows the benchmark precedent. If any report still references a parameter set, then the request comes back as a conflict, the same way a referenced benchmark refuses with "All reports that use this benchmark must be deleted first!". A set is deletable only once nothing references it, and deleting it takes its billable series rows with it. Archive is the expected path for retiring a grid point. Delete exists for the set that never should have been minted.

## The one refusal

A benchmark's empty parameter set cannot be deleted. The empty set is structural. Every benchmark is born with exactly one, and report ingest treats a missing empty set as data corruption rather than a set to mint, so this endpoint must not be able to manufacture that corruption. The request is refused with a conflict. Archiving the empty set stays allowed, because a later report revives it the same way it revives any other archived set.

## Tests

Integration tests cover the list with its archived filter and its pagination, the one get and its scoping to its own benchmark, create, create on a duplicate, create at the ceiling, the archive and unarchive round trip, the delete refusal while a report references the set, the delete of an unreferenced set down to its series rows, the refusal on the empty set, and the permission failures on every write.
