### PR TITLE
Label the perf image per variant

### DIFF
--- a/lib/api_projects/src/perf/img.rs
+++ b/lib/api_projects/src/perf/img.rs
@@ -33,6 +33,8 @@ pub async fn proj_perf_img_options(
 /// The query results are every permutation of each branch, testbed, benchmark, and measure.
 /// There is a limit of 8 permutations for a single image.
 /// Therefore, only the first 8 permutations are plotted.
+/// Each permutation plots one line per variant of its benchmark,
+/// narrowed by the `parameters` filter when one is given.
 /// If the project is public, then the user does not need to be authenticated.
 /// If the project is private, then the user must be authenticated and have `view` permissions for the project,
 /// or provide a valid project key for the project.

--- a/lib/api_projects/tests/perf.rs
+++ b/lib/api_projects/tests/perf.rs
@@ -4869,3 +4869,101 @@ async fn perf_window_runs_back_from_the_end_time() {
     let perf = get_perf(&server, &user.token, &perf_query_url(&project_slug, &query)).await;
     assert!(perf.results.is_empty());
 }
+
+// =============================================================================
+// Section: The perf image
+// =============================================================================
+
+/// The perf image path for a fully built query, through the encoder a client uses.
+fn perf_img_url(project_slug: &str, query: &JsonPerfQuery) -> String {
+    format!(
+        "/v0/projects/{project_slug}/perf/img?{}",
+        query.to_query_string(&[]).expect("build query string")
+    )
+}
+
+/// GET a perf image path and return the JPEG.
+async fn get_perf_img(server: &TestServer, token: &str, url: &str) -> Vec<u8> {
+    let resp = server
+        .client
+        .get(server.api_url(url))
+        .header(
+            bencher_json::AUTHORIZATION,
+            bencher_json::bearer_header(token),
+        )
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(resp.status(), StatusCode::OK, "GET {url}");
+    assert_eq!(
+        resp.headers()
+            .get(http::header::CONTENT_TYPE)
+            .expect("content type"),
+        "image/jpeg",
+        "GET {url} is a JPEG"
+    );
+    resp.bytes().await.expect("read image").to_vec()
+}
+
+// The image takes the same `parameters` filter the query takes, and plots exactly
+// the lines the query answers with: the image of a filtered query is the plot of
+// that query's response, byte for byte.
+#[tokio::test]
+async fn perf_img_parameters_filter_plots_the_queried_variants() {
+    let server = perf_server().await;
+    let user = server
+        .signup("Test User", "perfimgfilter@example.com")
+        .await;
+    let org = server.create_org(&user, "Perf Img Filter Org").await;
+    let project = server
+        .create_project(&user, &org, "Perf Img Filter Project")
+        .await;
+
+    let project_id = get_project_id(&server, project.slug.as_ref());
+    let data = create_perf_data(&server, project_id);
+    create_variant(&server, &data, data.benchmark_id, r#"{"size_mb": 16}"#, 1.0);
+    create_variant(&server, &data, data.benchmark_id, r#"{"size_mb": 32}"#, 2.0);
+
+    let filtered = fixture_query(
+        &data,
+        vec![data.benchmark_uuid],
+        &[r#"{"size_mb": 16}"#, r#"{"size_mb": 32}"#],
+    );
+    let perf = get_perf(
+        &server,
+        &user.token,
+        &perf_query_url(project.slug.as_ref(), &filtered),
+    )
+    .await;
+    assert_eq!(
+        line_parameters(&perf),
+        vec![
+            r#"{"size_mb":16}"#.to_owned(),
+            r#"{"size_mb":32}"#.to_owned()
+        ],
+        "the filter leaves the empty variant out"
+    );
+
+    // The image endpoint takes no title here, so both sides fall back to the
+    // project name and the plot is handed the very same inputs.
+    let jpeg = get_perf_img(
+        &server,
+        &user.token,
+        &perf_img_url(project.slug.as_ref(), &filtered),
+    )
+    .await;
+    let plotted = bencher_plot::LinePlot::new()
+        .draw(None, &perf)
+        .expect("draw the queried lines");
+    assert_eq!(jpeg, plotted, "the image plots the query's own lines");
+
+    // Without the filter the empty variant is a third line, so the image differs.
+    let unfiltered = fixture_query(&data, vec![data.benchmark_uuid], &[]);
+    let all_jpeg = get_perf_img(
+        &server,
+        &user.token,
+        &perf_img_url(project.slug.as_ref(), &unfiltered),
+    )
+    .await;
+    assert_ne!(jpeg, all_jpeg, "the filter reaches the image query");
+}

--- a/lib/bencher_json/src/project/perf.rs
+++ b/lib/bencher_json/src/project/perf.rs
@@ -94,6 +94,12 @@ pub struct JsonPerfImgQueryParams {
     /// A comma separated list of benchmark UUIDs to query.
     /// Only the first 64 benchmarks are queried.
     pub benchmarks: String,
+    /// An optional comma separated list of URL encoded parameter sets to filter on.
+    /// A variant is queried when at least one of them is a subset of its
+    /// parameter set: every key the filter names, with the same value.
+    /// Leaving this off queries every variant.
+    /// Only the first 64 parameter sets are queried.
+    pub parameters: Option<String>,
     /// A comma separated list of measure UUIDs to query.
     /// Only the first 64 measures are queried.
     pub measures: String,
@@ -114,6 +120,7 @@ impl From<JsonPerfImgQueryParams> for JsonPerfQueryParams {
             testbeds,
             specs,
             benchmarks,
+            parameters,
             measures,
             start_time,
             end_time,
@@ -124,8 +131,7 @@ impl From<JsonPerfImgQueryParams> for JsonPerfQueryParams {
             testbeds,
             specs,
             benchmarks,
-            // No filter, so every variant is plotted.
-            parameters: None,
+            parameters,
             measures,
             start_time,
             end_time,

--- a/lib/bencher_plot/perf_missing_value.json
+++ b/lib/bencher_plot/perf_missing_value.json
@@ -1,0 +1,317 @@
+{
+    "project": {
+        "uuid": "c7fd3581-73d1-443c-b30f-6aa5c1c516cf",
+        "organization": "4142ce9a-f0a0-44d5-94cd-fc76c77d9098",
+        "name": "The Computer",
+        "slug": "the-computer",
+        "url": null,
+        "visibility": "public",
+        "created": "2023-07-02T12:53:33Z",
+        "modified": "2023-07-02T12:53:33Z"
+    },
+    "start_time": null,
+    "end_time": null,
+    "results": [
+        {
+            "branch": {
+                "uuid": "7d7e73de-78c2-43f7-bc2a-da31a5b9a819",
+                "project": "c7fd3581-73d1-443c-b30f-6aa5c1c516cf",
+                "name": "master",
+                "slug": "master",
+                "head": {
+                    "uuid": "7d7e73de-78c2-43f7-bc2a-da31a5b9a819",
+                    "branch": "7d7e73de-78c2-43f7-bc2a-da31a5b9a819",
+                    "start_point": null,
+                    "version": null,
+                    "created": "2023-07-02T12:53:33Z",
+                    "replaced": null
+                },
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z"
+            },
+            "testbed": {
+                "uuid": "e095df48-52a6-474b-aaa7-1a8546c235b6",
+                "project": "c7fd3581-73d1-443c-b30f-6aa5c1c516cf",
+                "name": "base",
+                "slug": "base",
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z"
+            },
+            "benchmark": {
+                "uuid": "dbb90f5c-e7e2-438c-9533-ce86792174ee",
+                "project": "c7fd3581-73d1-443c-b30f-6aa5c1c516cf",
+                "name": "bencher::mock_0",
+                "slug": "dbb90f5c-e7e2-438c-9533-ce86792174ee",
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z"
+            },
+            "parameter": {
+                "uuid": "dbb90f5c-e7e2-438c-9533-ce86792174ee",
+                "benchmark": "dbb90f5c-e7e2-438c-9533-ce86792174ee",
+                "set": {},
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z",
+                "archived": null
+            },
+            "measure": {
+                "uuid": "61a385d0-f19d-4f20-895a-e3c684ec6cbc",
+                "project": "c7fd3581-73d1-443c-b30f-6aa5c1c516cf",
+                "name": "Latency",
+                "slug": "latency",
+                "units": "nanoseconds (ns)",
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z"
+            },
+            "metrics": [
+                {
+                    "report": "ef582192-c7f4-47a0-8668-55cf7d99d8cc",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:33Z",
+                    "end_time": "2023-07-02T12:53:33Z",
+                    "version": {
+                        "number": 0,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 6.363568939941679
+                        },
+                        "upper_value": {
+                            "value": 7.77769537103983
+                        },
+                        "value": {
+                            "value": 7.070632155490754
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 7.070632155490754,
+                        "lower_value": 6.363568939941679,
+                        "upper_value": 7.77769537103983
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "ef582192-c7f4-47a0-8668-55cf7d99d8cc",
+                    "iteration": 1,
+                    "start_time": "2023-07-02T12:53:33Z",
+                    "end_time": "2023-07-02T12:53:33Z",
+                    "version": {
+                        "number": 0,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 0.35090864273162703
+                        },
+                        "upper_value": {
+                            "value": 0.42888834111643304
+                        },
+                        "value": {
+                            "value": 0.38989849192403
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 0.38989849192403,
+                        "lower_value": 0.35090864273162703,
+                        "upper_value": 0.42888834111643304
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "ef582192-c7f4-47a0-8668-55cf7d99d8cc",
+                    "iteration": 2,
+                    "start_time": "2023-07-02T12:53:33Z",
+                    "end_time": "2023-07-02T12:53:33Z",
+                    "version": {
+                        "number": 0,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "allocations": {
+                            "value": 1024.0
+                        }
+                    },
+                    "boundary": null
+                },
+                {
+                    "report": "48439503-0803-47ab-be0f-713ee13b5704",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:36Z",
+                    "end_time": "2023-07-02T12:53:36Z",
+                    "version": {
+                        "number": 1,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 1.824757736467896
+                        },
+                        "upper_value": {
+                            "value": 2.230259455682984
+                        },
+                        "value": {
+                            "value": 2.02750859607544
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 2.02750859607544,
+                        "lower_value": 1.824757736467896,
+                        "upper_value": 2.230259455682984
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "a0dc813c-1eec-4062-919e-822562aeb1d6",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:38Z",
+                    "end_time": "2023-07-02T12:53:38Z",
+                    "version": {
+                        "number": 2,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 1.4382864542637654
+                        },
+                        "upper_value": {
+                            "value": 1.75790566632238
+                        },
+                        "value": {
+                            "value": 1.5980960602930727
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 1.5980960602930727,
+                        "lower_value": 1.4382864542637654,
+                        "upper_value": 1.75790566632238
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "cdcf7763-2776-4536-acc1-fa317833ee39",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:39Z",
+                    "end_time": "2023-07-02T12:53:39Z",
+                    "version": {
+                        "number": 3,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 6.479398002777131
+                        },
+                        "upper_value": {
+                            "value": 7.919264225616493
+                        },
+                        "value": {
+                            "value": 7.199331114196812
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 7.199331114196812,
+                        "lower_value": 6.479398002777131,
+                        "upper_value": 7.919264225616493
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "2d57774e-594d-4b1e-8335-8950b9389547",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:40Z",
+                    "end_time": "2023-07-02T12:53:40Z",
+                    "version": {
+                        "number": 4,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 5.506783742659492
+                        },
+                        "upper_value": {
+                            "value": 6.730513463250489
+                        },
+                        "value": {
+                            "value": 6.11864860295499
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 6.11864860295499,
+                        "lower_value": 5.506783742659492,
+                        "upper_value": 6.730513463250489
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "c3677a74-a4cc-4fd7-bff2-1a57ba5d28bb",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:41Z",
+                    "end_time": "2023-07-02T12:53:41Z",
+                    "version": {
+                        "number": 5,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 1.395044920023633
+                        },
+                        "upper_value": {
+                            "value": 1.705054902251107
+                        },
+                        "value": {
+                            "value": 1.55004991113737
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 1.55004991113737,
+                        "lower_value": 1.395044920023633,
+                        "upper_value": 1.705054902251107
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/lib/bencher_plot/perf_variants.json
+++ b/lib/bencher_plot/perf_variants.json
@@ -1,0 +1,1288 @@
+{
+    "project": {
+        "uuid": "c7fd3581-73d1-443c-b30f-6aa5c1c516cf",
+        "organization": "4142ce9a-f0a0-44d5-94cd-fc76c77d9098",
+        "name": "The Computer",
+        "slug": "the-computer",
+        "url": null,
+        "visibility": "public",
+        "created": "2023-07-02T12:53:33Z",
+        "modified": "2023-07-02T12:53:33Z"
+    },
+    "start_time": null,
+    "end_time": null,
+    "results": [
+        {
+            "branch": {
+                "uuid": "7d7e73de-78c2-43f7-bc2a-da31a5b9a819",
+                "project": "c7fd3581-73d1-443c-b30f-6aa5c1c516cf",
+                "name": "master",
+                "slug": "master",
+                "head": {
+                    "uuid": "7d7e73de-78c2-43f7-bc2a-da31a5b9a819",
+                    "branch": "7d7e73de-78c2-43f7-bc2a-da31a5b9a819",
+                    "start_point": null,
+                    "version": null,
+                    "created": "2023-07-02T12:53:33Z",
+                    "replaced": null
+                },
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z"
+            },
+            "testbed": {
+                "uuid": "e095df48-52a6-474b-aaa7-1a8546c235b6",
+                "project": "c7fd3581-73d1-443c-b30f-6aa5c1c516cf",
+                "name": "base",
+                "slug": "base",
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z"
+            },
+            "benchmark": {
+                "uuid": "dbb90f5c-e7e2-438c-9533-ce86792174ee",
+                "project": "c7fd3581-73d1-443c-b30f-6aa5c1c516cf",
+                "name": "bencher::mock_0",
+                "slug": "dbb90f5c-e7e2-438c-9533-ce86792174ee",
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z"
+            },
+            "parameter": {
+                "uuid": "dbb90f5c-e7e2-438c-9533-ce86792174ee",
+                "benchmark": "dbb90f5c-e7e2-438c-9533-ce86792174ee",
+                "set": {},
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z",
+                "archived": null
+            },
+            "measure": {
+                "uuid": "61a385d0-f19d-4f20-895a-e3c684ec6cbc",
+                "project": "c7fd3581-73d1-443c-b30f-6aa5c1c516cf",
+                "name": "Latency",
+                "slug": "latency",
+                "units": "nanoseconds (ns)",
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z"
+            },
+            "metrics": [
+                {
+                    "report": "ef582192-c7f4-47a0-8668-55cf7d99d8cc",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:33Z",
+                    "end_time": "2023-07-02T12:53:33Z",
+                    "version": {
+                        "number": 0,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 6.363568939941679
+                        },
+                        "upper_value": {
+                            "value": 7.77769537103983
+                        },
+                        "value": {
+                            "value": 7.070632155490754
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 7.070632155490754,
+                        "lower_value": 6.363568939941679,
+                        "upper_value": 7.77769537103983
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "ef582192-c7f4-47a0-8668-55cf7d99d8cc",
+                    "iteration": 1,
+                    "start_time": "2023-07-02T12:53:33Z",
+                    "end_time": "2023-07-02T12:53:33Z",
+                    "version": {
+                        "number": 0,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 0.35090864273162703
+                        },
+                        "upper_value": {
+                            "value": 0.42888834111643304
+                        },
+                        "value": {
+                            "value": 0.38989849192403
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 0.38989849192403,
+                        "lower_value": 0.35090864273162703,
+                        "upper_value": 0.42888834111643304
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "ef582192-c7f4-47a0-8668-55cf7d99d8cc",
+                    "iteration": 2,
+                    "start_time": "2023-07-02T12:53:33Z",
+                    "end_time": "2023-07-02T12:53:33Z",
+                    "version": {
+                        "number": 0,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 7.756277114705289
+                        },
+                        "upper_value": {
+                            "value": 9.479894251306463
+                        },
+                        "value": {
+                            "value": 8.618085683005877
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 8.618085683005877,
+                        "lower_value": 7.756277114705289,
+                        "upper_value": 9.479894251306463
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "48439503-0803-47ab-be0f-713ee13b5704",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:36Z",
+                    "end_time": "2023-07-02T12:53:36Z",
+                    "version": {
+                        "number": 1,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 1.824757736467896
+                        },
+                        "upper_value": {
+                            "value": 2.230259455682984
+                        },
+                        "value": {
+                            "value": 2.02750859607544
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 2.02750859607544,
+                        "lower_value": 1.824757736467896,
+                        "upper_value": 2.230259455682984
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "a0dc813c-1eec-4062-919e-822562aeb1d6",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:38Z",
+                    "end_time": "2023-07-02T12:53:38Z",
+                    "version": {
+                        "number": 2,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 1.4382864542637654
+                        },
+                        "upper_value": {
+                            "value": 1.75790566632238
+                        },
+                        "value": {
+                            "value": 1.5980960602930727
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 1.5980960602930727,
+                        "lower_value": 1.4382864542637654,
+                        "upper_value": 1.75790566632238
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "cdcf7763-2776-4536-acc1-fa317833ee39",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:39Z",
+                    "end_time": "2023-07-02T12:53:39Z",
+                    "version": {
+                        "number": 3,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 6.479398002777131
+                        },
+                        "upper_value": {
+                            "value": 7.919264225616493
+                        },
+                        "value": {
+                            "value": 7.199331114196812
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 7.199331114196812,
+                        "lower_value": 6.479398002777131,
+                        "upper_value": 7.919264225616493
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "2d57774e-594d-4b1e-8335-8950b9389547",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:40Z",
+                    "end_time": "2023-07-02T12:53:40Z",
+                    "version": {
+                        "number": 4,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 5.506783742659492
+                        },
+                        "upper_value": {
+                            "value": 6.730513463250489
+                        },
+                        "value": {
+                            "value": 6.11864860295499
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 6.11864860295499,
+                        "lower_value": 5.506783742659492,
+                        "upper_value": 6.730513463250489
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "c3677a74-a4cc-4fd7-bff2-1a57ba5d28bb",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:41Z",
+                    "end_time": "2023-07-02T12:53:41Z",
+                    "version": {
+                        "number": 5,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 1.395044920023633
+                        },
+                        "upper_value": {
+                            "value": 1.705054902251107
+                        },
+                        "value": {
+                            "value": 1.55004991113737
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 1.55004991113737,
+                        "lower_value": 1.395044920023633,
+                        "upper_value": 1.705054902251107
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                }
+            ]
+        },
+        {
+            "branch": {
+                "uuid": "7d7e73de-78c2-43f7-bc2a-da31a5b9a819",
+                "project": "c7fd3581-73d1-443c-b30f-6aa5c1c516cf",
+                "name": "master",
+                "slug": "master",
+                "head": {
+                    "uuid": "7d7e73de-78c2-43f7-bc2a-da31a5b9a819",
+                    "branch": "7d7e73de-78c2-43f7-bc2a-da31a5b9a819",
+                    "start_point": null,
+                    "version": null,
+                    "created": "2023-07-02T12:53:33Z",
+                    "replaced": null
+                },
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z"
+            },
+            "testbed": {
+                "uuid": "e095df48-52a6-474b-aaa7-1a8546c235b6",
+                "project": "c7fd3581-73d1-443c-b30f-6aa5c1c516cf",
+                "name": "base",
+                "slug": "base",
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z"
+            },
+            "benchmark": {
+                "uuid": "dbb90f5c-e7e2-438c-9533-ce86792174ee",
+                "project": "c7fd3581-73d1-443c-b30f-6aa5c1c516cf",
+                "name": "bencher::mock_0",
+                "slug": "dbb90f5c-e7e2-438c-9533-ce86792174ee",
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z"
+            },
+            "parameter": {
+                "uuid": "1a4b0f14-1b0e-4a2e-8a0f-4b1d9c2f0a01",
+                "benchmark": "dbb90f5c-e7e2-438c-9533-ce86792174ee",
+                "set": {
+                    "size_mb": 16
+                },
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z",
+                "archived": null
+            },
+            "measure": {
+                "uuid": "61a385d0-f19d-4f20-895a-e3c684ec6cbc",
+                "project": "c7fd3581-73d1-443c-b30f-6aa5c1c516cf",
+                "name": "Latency",
+                "slug": "latency",
+                "units": "nanoseconds (ns)",
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z"
+            },
+            "metrics": [
+                {
+                    "report": "ef582192-c7f4-47a0-8668-55cf7d99d8cc",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:33Z",
+                    "end_time": "2023-07-02T12:53:33Z",
+                    "version": {
+                        "number": 0,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 12.727137879883
+                        },
+                        "upper_value": {
+                            "value": 15.55539074208
+                        },
+                        "value": {
+                            "value": 14.141264310982
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 14.141264310982,
+                        "lower_value": 12.727137879883,
+                        "upper_value": 15.55539074208
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "ef582192-c7f4-47a0-8668-55cf7d99d8cc",
+                    "iteration": 1,
+                    "start_time": "2023-07-02T12:53:33Z",
+                    "end_time": "2023-07-02T12:53:33Z",
+                    "version": {
+                        "number": 0,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 0.701817285463
+                        },
+                        "upper_value": {
+                            "value": 0.857776682233
+                        },
+                        "value": {
+                            "value": 0.779796983848
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 0.779796983848,
+                        "lower_value": 0.701817285463,
+                        "upper_value": 0.857776682233
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "ef582192-c7f4-47a0-8668-55cf7d99d8cc",
+                    "iteration": 2,
+                    "start_time": "2023-07-02T12:53:33Z",
+                    "end_time": "2023-07-02T12:53:33Z",
+                    "version": {
+                        "number": 0,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 15.512554229411
+                        },
+                        "upper_value": {
+                            "value": 18.959788502613
+                        },
+                        "value": {
+                            "value": 17.236171366012
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 17.236171366012,
+                        "lower_value": 15.512554229411,
+                        "upper_value": 18.959788502613
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "48439503-0803-47ab-be0f-713ee13b5704",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:36Z",
+                    "end_time": "2023-07-02T12:53:36Z",
+                    "version": {
+                        "number": 1,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 3.649515472936
+                        },
+                        "upper_value": {
+                            "value": 4.460518911366
+                        },
+                        "value": {
+                            "value": 4.055017192151
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 4.055017192151,
+                        "lower_value": 3.649515472936,
+                        "upper_value": 4.460518911366
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "a0dc813c-1eec-4062-919e-822562aeb1d6",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:38Z",
+                    "end_time": "2023-07-02T12:53:38Z",
+                    "version": {
+                        "number": 2,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 2.876572908528
+                        },
+                        "upper_value": {
+                            "value": 3.515811332645
+                        },
+                        "value": {
+                            "value": 3.196192120586
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 3.196192120586,
+                        "lower_value": 2.876572908528,
+                        "upper_value": 3.515811332645
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "cdcf7763-2776-4536-acc1-fa317833ee39",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:39Z",
+                    "end_time": "2023-07-02T12:53:39Z",
+                    "version": {
+                        "number": 3,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 12.958796005554
+                        },
+                        "upper_value": {
+                            "value": 15.838528451233
+                        },
+                        "value": {
+                            "value": 14.398662228394
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 14.398662228394,
+                        "lower_value": 12.958796005554,
+                        "upper_value": 15.838528451233
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "2d57774e-594d-4b1e-8335-8950b9389547",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:40Z",
+                    "end_time": "2023-07-02T12:53:40Z",
+                    "version": {
+                        "number": 4,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 11.013567485319
+                        },
+                        "upper_value": {
+                            "value": 13.461026926501
+                        },
+                        "value": {
+                            "value": 12.23729720591
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 12.23729720591,
+                        "lower_value": 11.013567485319,
+                        "upper_value": 13.461026926501
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "c3677a74-a4cc-4fd7-bff2-1a57ba5d28bb",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:41Z",
+                    "end_time": "2023-07-02T12:53:41Z",
+                    "version": {
+                        "number": 5,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 2.790089840047
+                        },
+                        "upper_value": {
+                            "value": 3.410109804502
+                        },
+                        "value": {
+                            "value": 3.100099822275
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 3.100099822275,
+                        "lower_value": 2.790089840047,
+                        "upper_value": 3.410109804502
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                }
+            ]
+        },
+        {
+            "branch": {
+                "uuid": "7d7e73de-78c2-43f7-bc2a-da31a5b9a819",
+                "project": "c7fd3581-73d1-443c-b30f-6aa5c1c516cf",
+                "name": "master",
+                "slug": "master",
+                "head": {
+                    "uuid": "7d7e73de-78c2-43f7-bc2a-da31a5b9a819",
+                    "branch": "7d7e73de-78c2-43f7-bc2a-da31a5b9a819",
+                    "start_point": null,
+                    "version": null,
+                    "created": "2023-07-02T12:53:33Z",
+                    "replaced": null
+                },
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z"
+            },
+            "testbed": {
+                "uuid": "e095df48-52a6-474b-aaa7-1a8546c235b6",
+                "project": "c7fd3581-73d1-443c-b30f-6aa5c1c516cf",
+                "name": "base",
+                "slug": "base",
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z"
+            },
+            "benchmark": {
+                "uuid": "dbb90f5c-e7e2-438c-9533-ce86792174ee",
+                "project": "c7fd3581-73d1-443c-b30f-6aa5c1c516cf",
+                "name": "bencher::mock_0",
+                "slug": "dbb90f5c-e7e2-438c-9533-ce86792174ee",
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z"
+            },
+            "parameter": {
+                "uuid": "1a4b0f14-1b0e-4a2e-8a0f-4b1d9c2f0a02",
+                "benchmark": "dbb90f5c-e7e2-438c-9533-ce86792174ee",
+                "set": {
+                    "size_mb": 32
+                },
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z",
+                "archived": null
+            },
+            "measure": {
+                "uuid": "61a385d0-f19d-4f20-895a-e3c684ec6cbc",
+                "project": "c7fd3581-73d1-443c-b30f-6aa5c1c516cf",
+                "name": "Latency",
+                "slug": "latency",
+                "units": "nanoseconds (ns)",
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z"
+            },
+            "metrics": [
+                {
+                    "report": "ef582192-c7f4-47a0-8668-55cf7d99d8cc",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:33Z",
+                    "end_time": "2023-07-02T12:53:33Z",
+                    "version": {
+                        "number": 0,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 19.090706819825
+                        },
+                        "upper_value": {
+                            "value": 23.333086113119
+                        },
+                        "value": {
+                            "value": 21.211896466472
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 21.211896466472,
+                        "lower_value": 19.090706819825,
+                        "upper_value": 23.333086113119
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "ef582192-c7f4-47a0-8668-55cf7d99d8cc",
+                    "iteration": 1,
+                    "start_time": "2023-07-02T12:53:33Z",
+                    "end_time": "2023-07-02T12:53:33Z",
+                    "version": {
+                        "number": 0,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 1.052725928195
+                        },
+                        "upper_value": {
+                            "value": 1.286665023349
+                        },
+                        "value": {
+                            "value": 1.169695475772
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 1.169695475772,
+                        "lower_value": 1.052725928195,
+                        "upper_value": 1.286665023349
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "ef582192-c7f4-47a0-8668-55cf7d99d8cc",
+                    "iteration": 2,
+                    "start_time": "2023-07-02T12:53:33Z",
+                    "end_time": "2023-07-02T12:53:33Z",
+                    "version": {
+                        "number": 0,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 23.268831344116
+                        },
+                        "upper_value": {
+                            "value": 28.439682753919
+                        },
+                        "value": {
+                            "value": 25.854257049018
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 25.854257049018,
+                        "lower_value": 23.268831344116,
+                        "upper_value": 28.439682753919
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "48439503-0803-47ab-be0f-713ee13b5704",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:36Z",
+                    "end_time": "2023-07-02T12:53:36Z",
+                    "version": {
+                        "number": 1,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 5.474273209404
+                        },
+                        "upper_value": {
+                            "value": 6.690778367049
+                        },
+                        "value": {
+                            "value": 6.082525788226
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 6.082525788226,
+                        "lower_value": 5.474273209404,
+                        "upper_value": 6.690778367049
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "a0dc813c-1eec-4062-919e-822562aeb1d6",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:38Z",
+                    "end_time": "2023-07-02T12:53:38Z",
+                    "version": {
+                        "number": 2,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 4.314859362791
+                        },
+                        "upper_value": {
+                            "value": 5.273716998967
+                        },
+                        "value": {
+                            "value": 4.794288180879
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 4.794288180879,
+                        "lower_value": 4.314859362791,
+                        "upper_value": 5.273716998967
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "cdcf7763-2776-4536-acc1-fa317833ee39",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:39Z",
+                    "end_time": "2023-07-02T12:53:39Z",
+                    "version": {
+                        "number": 3,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 19.438194008331
+                        },
+                        "upper_value": {
+                            "value": 23.757792676849
+                        },
+                        "value": {
+                            "value": 21.59799334259
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 21.59799334259,
+                        "lower_value": 19.438194008331,
+                        "upper_value": 23.757792676849
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "2d57774e-594d-4b1e-8335-8950b9389547",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:40Z",
+                    "end_time": "2023-07-02T12:53:40Z",
+                    "version": {
+                        "number": 4,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 16.520351227978
+                        },
+                        "upper_value": {
+                            "value": 20.191540389751
+                        },
+                        "value": {
+                            "value": 18.355945808865
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 18.355945808865,
+                        "lower_value": 16.520351227978,
+                        "upper_value": 20.191540389751
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "c3677a74-a4cc-4fd7-bff2-1a57ba5d28bb",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:41Z",
+                    "end_time": "2023-07-02T12:53:41Z",
+                    "version": {
+                        "number": 5,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 4.185134760071
+                        },
+                        "upper_value": {
+                            "value": 5.115164706753
+                        },
+                        "value": {
+                            "value": 4.650149733412
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 4.650149733412,
+                        "lower_value": 4.185134760071,
+                        "upper_value": 5.115164706753
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                }
+            ]
+        },
+        {
+            "branch": {
+                "uuid": "7d7e73de-78c2-43f7-bc2a-da31a5b9a819",
+                "project": "c7fd3581-73d1-443c-b30f-6aa5c1c516cf",
+                "name": "master",
+                "slug": "master",
+                "head": {
+                    "uuid": "7d7e73de-78c2-43f7-bc2a-da31a5b9a819",
+                    "branch": "7d7e73de-78c2-43f7-bc2a-da31a5b9a819",
+                    "start_point": null,
+                    "version": null,
+                    "created": "2023-07-02T12:53:33Z",
+                    "replaced": null
+                },
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z"
+            },
+            "testbed": {
+                "uuid": "e095df48-52a6-474b-aaa7-1a8546c235b6",
+                "project": "c7fd3581-73d1-443c-b30f-6aa5c1c516cf",
+                "name": "base",
+                "slug": "base",
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z"
+            },
+            "benchmark": {
+                "uuid": "0d680df6-432b-4335-bb37-afd2453c0db1",
+                "project": "c7fd3581-73d1-443c-b30f-6aa5c1c516cf",
+                "name": "bencher::mock_1",
+                "slug": "0d680df6-432b-4335-bb37-afd2453c0db1",
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z"
+            },
+            "parameter": {
+                "uuid": "0d680df6-432b-4335-bb37-afd2453c0db1",
+                "benchmark": "0d680df6-432b-4335-bb37-afd2453c0db1",
+                "set": {},
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z",
+                "archived": null
+            },
+            "measure": {
+                "uuid": "61a385d0-f19d-4f20-895a-e3c684ec6cbc",
+                "project": "c7fd3581-73d1-443c-b30f-6aa5c1c516cf",
+                "name": "Latency",
+                "slug": "latency",
+                "units": "nanoseconds (ns)",
+                "created": "2023-07-02T12:53:33Z",
+                "modified": "2023-07-02T12:53:33Z"
+            },
+            "metrics": [
+                {
+                    "report": "ef582192-c7f4-47a0-8668-55cf7d99d8cc",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:33Z",
+                    "end_time": "2023-07-02T12:53:33Z",
+                    "version": {
+                        "number": 0,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 9.646146370344914
+                        },
+                        "upper_value": {
+                            "value": 11.789734452643785
+                        },
+                        "value": {
+                            "value": 10.717940411494348
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 10.717940411494348,
+                        "lower_value": 9.646146370344914,
+                        "upper_value": 11.789734452643785
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "ef582192-c7f4-47a0-8668-55cf7d99d8cc",
+                    "iteration": 1,
+                    "start_time": "2023-07-02T12:53:33Z",
+                    "end_time": "2023-07-02T12:53:33Z",
+                    "version": {
+                        "number": 0,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 10.46675044099625
+                        },
+                        "upper_value": {
+                            "value": 12.792694983439862
+                        },
+                        "value": {
+                            "value": 11.629722712218056
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 11.629722712218056,
+                        "lower_value": 10.46675044099625,
+                        "upper_value": 12.792694983439862
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "ef582192-c7f4-47a0-8668-55cf7d99d8cc",
+                    "iteration": 2,
+                    "start_time": "2023-07-02T12:53:33Z",
+                    "end_time": "2023-07-02T12:53:33Z",
+                    "version": {
+                        "number": 0,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 17.31126368636183
+                        },
+                        "upper_value": {
+                            "value": 21.158211172220017
+                        },
+                        "value": {
+                            "value": 19.234737429290924
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 19.234737429290924,
+                        "lower_value": 17.31126368636183,
+                        "upper_value": 21.158211172220017
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "48439503-0803-47ab-be0f-713ee13b5704",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:36Z",
+                    "end_time": "2023-07-02T12:53:36Z",
+                    "version": {
+                        "number": 1,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 12.4983965705781
+                        },
+                        "upper_value": {
+                            "value": 15.275818030706564
+                        },
+                        "value": {
+                            "value": 13.887107300642333
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 13.887107300642333,
+                        "lower_value": 12.4983965705781,
+                        "upper_value": 15.275818030706564
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "a0dc813c-1eec-4062-919e-822562aeb1d6",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:38Z",
+                    "end_time": "2023-07-02T12:53:38Z",
+                    "version": {
+                        "number": 2,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 10.90794931075032
+                        },
+                        "upper_value": {
+                            "value": 13.331938046472612
+                        },
+                        "value": {
+                            "value": 12.119943678611468
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 12.119943678611468,
+                        "lower_value": 10.90794931075032,
+                        "upper_value": 13.331938046472612
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "cdcf7763-2776-4536-acc1-fa317833ee39",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:39Z",
+                    "end_time": "2023-07-02T12:53:39Z",
+                    "version": {
+                        "number": 3,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 10.190975988578607
+                        },
+                        "upper_value": {
+                            "value": 12.455637319373857
+                        },
+                        "value": {
+                            "value": 11.323306653976232
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 11.323306653976232,
+                        "lower_value": 10.190975988578607,
+                        "upper_value": 12.455637319373857
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "2d57774e-594d-4b1e-8335-8950b9389547",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:40Z",
+                    "end_time": "2023-07-02T12:53:40Z",
+                    "version": {
+                        "number": 4,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 17.28471459721883
+                        },
+                        "upper_value": {
+                            "value": 21.12576228548968
+                        },
+                        "value": {
+                            "value": 19.205238441354258
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 19.205238441354258,
+                        "lower_value": 17.28471459721883,
+                        "upper_value": 21.12576228548968
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                },
+                {
+                    "report": "c3677a74-a4cc-4fd7-bff2-1a57ba5d28bb",
+                    "iteration": 0,
+                    "start_time": "2023-07-02T12:53:41Z",
+                    "end_time": "2023-07-02T12:53:41Z",
+                    "version": {
+                        "number": 5,
+                        "hash": null
+                    },
+                    "threshold": null,
+                    "metrics": {
+                        "lower_value": {
+                            "value": 13.312406796163527
+                        },
+                        "upper_value": {
+                            "value": 16.2707194175332
+                        },
+                        "value": {
+                            "value": 14.791563106848365
+                        }
+                    },
+                    "metric": {
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                        "value": 14.791563106848365,
+                        "lower_value": 13.312406796163527,
+                        "upper_value": 16.2707194175332
+                    },
+                    "boundary": {
+                        "baseline": null,
+                        "lower_limit": null,
+                        "upper_limit": null
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/lib/bencher_plot/src/line.rs
+++ b/lib/bencher_plot/src/line.rs
@@ -664,10 +664,17 @@ impl Extent {
         let mut right_min_y = None;
         let mut right_max_y = None;
 
-        let lines = json_perf
+        // Only the lines that are drawn decide what the labels say. A variant past
+        // the line limit is not in the image, so it does not change how the lines
+        // that are in the image are told apart.
+        let results = json_perf
             .results
             .iter()
             .take(MAX_LINES)
+            .collect::<Vec<&JsonPerfLine>>();
+
+        let lines = results
+            .iter()
             .enumerate()
             .map(|(index, result)| {
                 let anchor = find_anchor(&result.measure).unwrap_or_default();
@@ -707,7 +714,7 @@ impl Extent {
                     })
                     .collect();
                 let color = LineData::color(index);
-                let dimensions = LineData::dimensions(result);
+                let dimensions = LineData::dimensions(result, &results);
                 LineData {
                     data,
                     anchor,
@@ -803,11 +810,36 @@ impl LineData {
         TABLEAU_10_RGB[index % 10]
     }
 
-    fn dimensions(result: &JsonPerfLine) -> String {
+    /// The benchmark row carries the variant's canonical parameter set when the
+    /// benchmark plots more than the empty set. The set follows the name on the
+    /// same row, so the key text shrinking drops the set's tail and never the
+    /// benchmark name.
+    fn dimensions(result: &JsonPerfLine, results: &[&JsonPerfLine]) -> String {
+        let benchmark = if Self::spells_parameters(result, results) {
+            format!(
+                "{} {}",
+                result.benchmark.name,
+                result.parameter.set.canonical()
+            )
+        } else {
+            result.benchmark.name.to_string()
+        };
         format!(
-            "- {}\n- {}\n- {}\n- {}",
-            result.branch.name, result.testbed.name, result.benchmark.name, result.measure.name,
+            "- {}\n- {}\n- {benchmark}\n- {}",
+            result.branch.name, result.testbed.name, result.measure.name,
         )
+    }
+
+    /// Whether this line's benchmark names the parameter set each of its lines plots.
+    ///
+    /// A benchmark whose every line in the image plots the empty parameter set keeps
+    /// the bare benchmark name it has always had. One non-empty set is enough to
+    /// name them all, whether it stands alone or beside the empty set, because a set
+    /// is what tells two lines of one benchmark apart.
+    fn spells_parameters(result: &JsonPerfLine, results: &[&JsonPerfLine]) -> bool {
+        results.iter().any(|line| {
+            line.benchmark.uuid == result.benchmark.uuid && !line.parameter.set.is_empty()
+        })
     }
 }
 
@@ -815,8 +847,9 @@ impl LineData {
 mod tests {
     use std::{fs::File, io::Write as _, sync::LazyLock};
 
-    use bencher_json::JsonPerf;
+    use bencher_json::{JsonPerf, project::perf::JsonPerfLine};
 
+    use super::Extent;
     use crate::LinePlot;
 
     pub const PERF_DOT_JSON: &str = include_str!("../perf.json");
@@ -838,6 +871,18 @@ mod tests {
     pub const DECIMAL_DOT_JSON: &str = include_str!("../decimal.json");
     static JSON_PERF_DECIMAL: LazyLock<JsonPerf> = LazyLock::new(|| {
         serde_json::from_str(DECIMAL_DOT_JSON).expect("Failed to serialize decimal JSON")
+    });
+
+    pub const PERF_VARIANTS_DOT_JSON: &str = include_str!("../perf_variants.json");
+    static JSON_PERF_VARIANTS: LazyLock<JsonPerf> = LazyLock::new(|| {
+        serde_json::from_str(PERF_VARIANTS_DOT_JSON)
+            .expect("Failed to serialize perf variants JSON")
+    });
+
+    pub const PERF_MISSING_VALUE_DOT_JSON: &str = include_str!("../perf_missing_value.json");
+    static JSON_PERF_MISSING_VALUE: LazyLock<JsonPerf> = LazyLock::new(|| {
+        serde_json::from_str(PERF_MISSING_VALUE_DOT_JSON)
+            .expect("Failed to serialize perf missing value JSON")
     });
 
     fn save_jpeg(jpeg: &[u8], name: &str) {
@@ -888,5 +933,119 @@ mod tests {
         json_perf.results.clear();
         let plot_buffer = plot.draw(None, &json_perf).unwrap();
         save_jpeg(&plot_buffer, "empty");
+    }
+
+    #[test]
+    fn plot_variants() {
+        let plot = LinePlot::new();
+        let plot_buffer = plot
+            .draw(Some("Benchmark Adapter Comparison"), &JSON_PERF_VARIANTS)
+            .unwrap();
+        save_jpeg(&plot_buffer, "perf_variants");
+    }
+
+    #[test]
+    fn plot_missing_value() {
+        let plot = LinePlot::new();
+        let plot_buffer = plot
+            .draw(
+                Some("Benchmark Adapter Comparison"),
+                &JSON_PERF_MISSING_VALUE,
+            )
+            .unwrap();
+        save_jpeg(&plot_buffer, "perf_missing_value");
+    }
+
+    /// The key text of every line the plot draws, in the order it draws them.
+    fn line_labels(json_perf: &JsonPerf) -> Vec<String> {
+        Extent::new(json_perf)
+            .unwrap()
+            .lines
+            .into_iter()
+            .map(|line| line.dimensions)
+            .collect()
+    }
+
+    /// The key text a line had before a benchmark had variants.
+    fn bare_label(result: &JsonPerfLine) -> String {
+        format!(
+            "- {}\n- {}\n- {}\n- {}",
+            result.branch.name, result.testbed.name, result.benchmark.name, result.measure.name,
+        )
+    }
+
+    // A project that only ever reported the empty parameter set draws exactly what it
+    // has always drawn: every line is labeled with the bare benchmark name, so the
+    // plot is handed the same inputs it was handed before.
+    #[test]
+    fn labels_stay_bare_without_variants() {
+        for json_perf in [
+            &*JSON_PERF,
+            &*JSON_PERF_LOG,
+            &*JSON_PERF_DUAL_AXES,
+            &*JSON_PERF_DECIMAL,
+        ] {
+            let bare = json_perf
+                .results
+                .iter()
+                .take(super::MAX_LINES)
+                .map(bare_label)
+                .collect::<Vec<_>>();
+            assert_eq!(
+                line_labels(json_perf),
+                bare,
+                "a project with no variants is labeled the way it always was"
+            );
+        }
+    }
+
+    // Two variants of one benchmark are two lines, so each line names the set it
+    // plots, and the empty set among them reads `{}`. A benchmark with nothing but
+    // its empty set in the same image keeps its bare label.
+    #[test]
+    fn labels_name_each_variant() {
+        assert_eq!(
+            line_labels(&JSON_PERF_VARIANTS),
+            vec![
+                "- master\n- base\n- bencher::mock_0 {}\n- Latency".to_owned(),
+                "- master\n- base\n- bencher::mock_0 {\"size_mb\":16}\n- Latency".to_owned(),
+                "- master\n- base\n- bencher::mock_0 {\"size_mb\":32}\n- Latency".to_owned(),
+                "- master\n- base\n- bencher::mock_1\n- Latency".to_owned(),
+            ],
+            "each variant of a benchmark names the set it plots"
+        );
+    }
+
+    // A lone variant that is not the empty set names itself too: the benchmark
+    // name alone would not say which of its variants the line plots.
+    #[test]
+    fn labels_name_a_lone_variant() {
+        let mut json_perf = JSON_PERF_VARIANTS.clone();
+        json_perf
+            .results
+            .retain(|result| result.parameter.set.canonical() == r#"{"size_mb":16}"#);
+        assert_eq!(
+            line_labels(&json_perf),
+            vec!["- master\n- base\n- bencher::mock_0 {\"size_mb\":16}\n- Latency".to_owned()],
+            "a lone variant that is not the empty set names itself"
+        );
+    }
+
+    // A point whose measure named no `value` has no point estimate to place on the
+    // axis, so it is left out of the line rather than drawn.
+    #[test]
+    fn point_without_a_value_is_left_out() {
+        let extent = Extent::new(&JSON_PERF_MISSING_VALUE).unwrap();
+        let line = extent.lines.first().unwrap();
+        let points = JSON_PERF_MISSING_VALUE.results[0].metrics.len();
+        assert_eq!(
+            line.data.len(),
+            points - 1,
+            "the value-less point is not on the line"
+        );
+        assert!(
+            !line.data.iter().any(|(_, y)| *y == 1024.0),
+            "the metric of the value-less point is not plotted"
+        );
     }
 }

--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -6604,7 +6604,7 @@
           "perf"
         ],
         "summary": "Generate a dynamic image of project performance metrics",
-        "description": "Generate a dynamic image of performance metrics for a project. The query results are every permutation of each branch, testbed, benchmark, and measure. There is a limit of 8 permutations for a single image. Therefore, only the first 8 permutations are plotted. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project.",
+        "description": "Generate a dynamic image of performance metrics for a project. The query results are every permutation of each branch, testbed, benchmark, and measure. There is a limit of 8 permutations for a single image. Therefore, only the first 8 permutations are plotted. Each permutation plots one line per variant of its benchmark, narrowed by the `parameters` filter when one is given. If the project is public, then the user does not need to be authenticated. If the project is private, then the user must be authenticated and have `view` permissions for the project, or provide a valid project key for the project.",
         "operationId": "proj_perf_img_get",
         "parameters": [
           {
@@ -6657,6 +6657,15 @@
             "description": "A comma separated list of measure UUIDs to query. Only the first 64 measures are queried.",
             "required": true,
             "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "parameters",
+            "description": "An optional comma separated list of URL encoded parameter sets to filter on. A variant is queried when at least one of them is a subset of its parameter set: every key the filter names, with the same value. Leaving this off queries every variant. Only the first 64 parameter sets are queried.",
+            "schema": {
+              "nullable": true,
               "type": "string"
             }
           },


### PR DESCRIPTION
The perf image catches up with the perf query.

## The parameter

The image endpoint takes `parameters`, the same comma separated list of URL encoded parameter sets the query endpoint takes, spelled the same way and read by the same code path. The image query struct mirrors the query struct field for field, doc comment included, so the image is the plot of the query it mirrors. An endpoint test pins that: the image of a filtered query is byte for byte the plot of that query's own response.

## The label rules

A line plots one variant, so the key names the variant when the benchmark name no longer says which line is which.

- A benchmark whose every line in the image plots the empty parameter set keeps the bare benchmark name it has always had.
- One non empty set among a benchmark's lines names them all. Each line's benchmark row becomes the benchmark name, a space, and the set in its canonical form, so the empty set among them reads `{}`.
- The set follows the benchmark name on the same row, so the wrapping and font shrinking the key text already does for a long benchmark name loses the tail of the set spelling first and the benchmark name never.

## What older projects see

A project that never reported a parameter set is drawn from the inputs it was always drawn from. Every line of every such benchmark is labeled exactly as before, which the existing fixtures pin line by line, and nothing else on the draw path moved.

## Points with no value

A point whose measure named no `value` has no point estimate to place on the axis, so the plot leaves it out of the line rather than drawing it at zero. That already held; a fixture now pins it.

