### PR TITLE
Fetch crates from the static download endpoint in the Nix build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770197578,
-        "narHash": "sha256-AYqlWrX09+HvGs8zM6ebZ1pwUqjkfpnv8mewYwAo+iM=",
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The Nix package build job in CI fails while vendoring crates. One crate, `aligned` 0.4.3 (pulled in by `av-scenechange`), fails its download every single time, while hundreds of other crates in the same vendor step succeed. The failure is a hard 403 from crates.io, not a timeout or a flake, and it reproduces on every rerun.

## Cause

`rustPlatform.buildRustPackage` vendors each crate with a fixed-output `fetchurl` against the crates.io API download endpoint:

```
https://crates.io/api/v1/crates/aligned/0.4.3/download
```

That endpoint now refuses requests whose user agent looks like curl, and the nixpkgs `fetchurl` builder sends exactly that: `curl/<version> Nixpkgs/<version>`. So every crate download in the job is refused at the API. Popular crates still land because the response is already sitting in the CDN in front of the endpoint, which makes the refusal invisible for almost everything. A cold object like `aligned` 0.4.3 has nothing cached to fall back on, so it fails deterministically. This is the same rate limiting and intermittent 403 behavior tracked in [rust-lang/crates.io#13482](https://github.com/rust-lang/crates.io/issues/13482).

## Fix

nixpkgs fixed this upstream in May 2026 by pointing `importCargoLock` at the static CDN download endpoint that the Rust tooling documents:

```
https://static.crates.io/crates/aligned/0.4.3/download
```

The pinned nixpkgs predates that change, so this bumps the `nixpkgs` input to pick it up. That is the whole diff: one input in `flake.lock`, no change to `flake.nix`.

Doing it any other way is worse. `importCargoLock` does take an `extraRegistries` argument that can redirect the crates.io download URL, but it also emits a `[source."<index url>"]` block into the generated `.cargo/config.toml` for every entry, which collides with the `[source.crates-io]` block it always writes, and cargo refuses to start: `source ... defines source registry crates-io, but that source is already defined by crates-io`. There is no other seam in the flake that reaches the fetcher.

## Hashes are unchanged

The static endpoint serves the identical tarball, so nothing in `Cargo.lock` or any fixed-output hash has to change. Verified against the reproduce case: both endpoints return the same 10452 byte tarball with sha256 `ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685`, which is exactly the `aligned` 0.4.3 checksum already in `Cargo.lock`. The derivation for the crate keeps its name (`crate-aligned-0.4.3.tar.gz`) and its `outputHash`; only the URL it reads from moves.

## Verification

- With the bumped pin, the `crate-aligned-0.4.3.tar.gz` derivation resolves to the static URL, with its `outputHash` unchanged from the lockfile checksum.
- The static URL returns 200 and the expected sha256 under the exact user agent the nixpkgs fetcher sends, while the API URL returns 403 under that same agent.
- An earlier push on this branch reached the static endpoint through `extraRegistries` and vendored every crate, `aligned` included, with no 403. That run is what proves the endpoint switch is the right fix, and it only failed later on the duplicate cargo source described above.
- `alejandra --check`, `statix check`, and `deadnix` all pass with the tools from the new pin.

Note that the pin moves about six months, so the Nix build job rebuilds the workspace against a newer stdenv. CI is the verifier for that part.